### PR TITLE
Forman 48 incl ts uncert

### DIFF
--- a/test/webapi/controllers/test_time_series.py
+++ b/test/webapi/controllers/test_time_series.py
@@ -119,6 +119,8 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_dict, time_series)
 
     def test_get_time_series_info(self):
+        self.maxDiff = None
+
         ctx = new_test_service_context()
         info = get_time_series_info(ctx)
 
@@ -138,5 +140,8 @@ class TimeSeriesControllerTest(unittest.TestCase):
         demo1w_times = ['2017-01-22T00:00:00Z', '2017-01-29T00:00:00Z', '2017-02-05T00:00:00Z']
         for demo_variable in demo_variables:
             dict_variable = {'name': f'demo-1w.{demo_variable}', 'dates': demo1w_times, 'bounds': bounds}
+            expected_dict['layers'].append(dict_variable)
+        for demo_variable in demo_variables:
+            dict_variable = {'name': f'demo-1w.{demo_variable}_stdev', 'dates': demo1w_times, 'bounds': bounds}
             expected_dict['layers'].append(dict_variable)
         return expected_dict

--- a/test/webapi/controllers/test_time_series.py
+++ b/test/webapi/controllers/test_time_series.py
@@ -36,6 +36,26 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                  'validCount': 1}}]}
         self.assertEqual(expected_dict, time_series)
 
+    def test_get_time_series_for_point_with_stdev(self):
+        ctx = new_test_service_context()
+        time_series = get_time_series_for_point(ctx, 'demo-1w', 'conc_tsm',
+                                                lon=2.1, lat=51.4,
+                                                start_date=np.datetime64('2017-01-15'),
+                                                end_date=np.datetime64('2017-01-29'))
+        expected_dict = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                      'result': {'average': 3.534773588180542,
+                                                 'totalCount': 1,
+                                                 'validCount': 1}},
+                                     {'date': '2017-01-25T09:35:51Z',
+                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                     {'date': '2017-01-26T10:50:17Z',
+                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                     {'date': '2017-01-28T09:58:11Z',
+                                      'result': {'average': 20.12085723876953,
+                                                 'totalCount': 1,
+                                                 'validCount': 1}}]}
+        self.assertEqual(expected_dict, time_series)
+
     def test_get_time_series_for_geometry(self):
         ctx = new_test_service_context()
         time_series = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
@@ -57,6 +77,44 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_dict, time_series)
 
         time_series = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                   dict(type="Polygon", coordinates=[[
+                                                       [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                   ]]))
+        expected_dict = {'results': [
+            {'result': {'totalCount': 160801, 'validCount': 123540, 'average': 56.04547741839104},
+             'date': '2017-01-16T10:09:22Z'},
+            {'result': {'totalCount': 160801, 'validCount': 0, 'average': None},
+             'date': '2017-01-25T09:35:51Z'},
+            {'result': {'totalCount': 160801, 'validCount': 0, 'average': None},
+             'date': '2017-01-26T10:50:17Z'},
+            {'result': {'totalCount': 160801, 'validCount': 133267, 'average': 49.59349042604672},
+             'date': '2017-01-28T09:58:11Z'},
+            {'result': {'totalCount': 160801, 'validCount': 0, 'average': None},
+             'date': '2017-01-30T10:46:34Z'}]}
+
+        self.assertEqual(expected_dict, time_series)
+
+    def test_get_time_series_for_geometry_with_stdev(self):
+        ctx = new_test_service_context()
+        time_series = get_time_series_for_geometry(ctx, 'demo-1w', 'conc_tsm',
+                                                   dict(type="Point", coordinates=[2.1, 51.4]),
+                                                   start_date=np.datetime64('2017-01-15'),
+                                                   end_date=np.datetime64('2017-01-29'))
+        expected_dict = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                      'result': {'average': 3.534773588180542,
+                                                 'totalCount': 1,
+                                                 'validCount': 1}},
+                                     {'date': '2017-01-25T09:35:51Z',
+                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                     {'date': '2017-01-26T10:50:17Z',
+                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                     {'date': '2017-01-28T09:58:11Z',
+                                      'result': {'average': 20.12085723876953,
+                                                 'totalCount': 1,
+                                                 'validCount': 1}}]}
+        self.assertEqual(expected_dict, time_series)
+
+        time_series = get_time_series_for_geometry(ctx, 'demo-1w', 'conc_tsm',
                                                    dict(type="Polygon", coordinates=[[
                                                        [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
                                                    ]]))

--- a/test/webapi/controllers/test_time_series.py
+++ b/test/webapi/controllers/test_time_series.py
@@ -42,16 +42,14 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                 lon=2.1, lat=51.4,
                                                 start_date=np.datetime64('2017-01-15'),
                                                 end_date=np.datetime64('2017-01-29'))
-        expected_dict = {'results': [{'date': '2017-01-16T10:09:22Z',
+        expected_dict = {'results': [{'date': '2017-01-22T00:00:00Z',
                                       'result': {'average': 3.534773588180542,
+                                                 'stdev': 0.0,
                                                  'totalCount': 1,
                                                  'validCount': 1}},
-                                     {'date': '2017-01-25T09:35:51Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
-                                     {'date': '2017-01-26T10:50:17Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
-                                     {'date': '2017-01-28T09:58:11Z',
+                                     {'date': '2017-01-29T00:00:00Z',
                                       'result': {'average': 20.12085723876953,
+                                                 'stdev': 0.0,
                                                  'totalCount': 1,
                                                  'validCount': 1}}]}
         self.assertEqual(expected_dict, time_series)
@@ -100,16 +98,14 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    dict(type="Point", coordinates=[2.1, 51.4]),
                                                    start_date=np.datetime64('2017-01-15'),
                                                    end_date=np.datetime64('2017-01-29'))
-        expected_dict = {'results': [{'date': '2017-01-16T10:09:22Z',
+        expected_dict = {'results': [{'date': '2017-01-22T00:00:00Z',
                                       'result': {'average': 3.534773588180542,
+                                                 'stdev': 0.0,
                                                  'totalCount': 1,
                                                  'validCount': 1}},
-                                     {'date': '2017-01-25T09:35:51Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
-                                     {'date': '2017-01-26T10:50:17Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
-                                     {'date': '2017-01-28T09:58:11Z',
+                                     {'date': '2017-01-29T00:00:00Z',
                                       'result': {'average': 20.12085723876953,
+                                                 'stdev': 0.0,
                                                  'totalCount': 1,
                                                  'validCount': 1}}]}
         self.assertEqual(expected_dict, time_series)
@@ -118,17 +114,21 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    dict(type="Polygon", coordinates=[[
                                                        [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
                                                    ]]))
-        expected_dict = {'results': [
-            {'result': {'totalCount': 160801, 'validCount': 123540, 'average': 56.04547741839104},
-             'date': '2017-01-16T10:09:22Z'},
-            {'result': {'totalCount': 160801, 'validCount': 0, 'average': None},
-             'date': '2017-01-25T09:35:51Z'},
-            {'result': {'totalCount': 160801, 'validCount': 0, 'average': None},
-             'date': '2017-01-26T10:50:17Z'},
-            {'result': {'totalCount': 160801, 'validCount': 133267, 'average': 49.59349042604672},
-             'date': '2017-01-28T09:58:11Z'},
-            {'result': {'totalCount': 160801, 'validCount': 0, 'average': None},
-             'date': '2017-01-30T10:46:34Z'}]}
+        expected_dict = {'results': [{'date': '2017-01-22T00:00:00Z',
+                                      'result': {'average': 56.04547741839104,
+                                                 'stdev': 0.0,
+                                                 'totalCount': 160801,
+                                                 'validCount': 123540}},
+                                     {'date': '2017-01-29T00:00:00Z',
+                                      'result': {'average': 49.59349042604672,
+                                                 'stdev': 0.0,
+                                                 'totalCount': 160801,
+                                                 'validCount': 133267}},
+                                     {'date': '2017-02-05T00:00:00Z',
+                                      'result': {'average': None,
+                                                 'stdev': None,
+                                                 'totalCount': 160801,
+                                                 'validCount': 0}}]}
 
         self.assertEqual(expected_dict, time_series)
 

--- a/test/webapi/helpers.py
+++ b/test/webapi/helpers.py
@@ -1,24 +1,24 @@
 import os
-from typing import Optional
+from typing import Optional, Dict
 
 import yaml
 
-from xcube.webapi.context import ServiceContext
+from xcube.util.undefined import UNDEFINED
+from xcube.webapi.context import ServiceContext, MultiLevelDatasetOpener
 from xcube.webapi.errors import ServiceBadRequestError
 from xcube.webapi.reqparams import RequestParams
-from xcube.util.undefined import UNDEFINED
 
 
-def new_test_service_context() -> ServiceContext:
-    ctx = ServiceContext(base_dir=get_res_test_dir())
+def new_test_service_context(ml_dataset_openers: Dict[str, MultiLevelDatasetOpener] = None) -> ServiceContext:
+    ctx = ServiceContext(base_dir=get_res_test_dir(), ml_dataset_openers=ml_dataset_openers)
     config_file = os.path.join(ctx.base_dir, 'config.yml')
     with open(config_file) as fp:
         ctx.config = yaml.safe_load(fp)
     return ctx
 
 
-def new_demo_service_context() -> ServiceContext:
-    ctx = ServiceContext(base_dir=get_res_demo_dir())
+def new_demo_service_context(ml_dataset_openers: Dict[str, MultiLevelDatasetOpener] = None) -> ServiceContext:
+    ctx = ServiceContext(base_dir=get_res_demo_dir(), ml_dataset_openers=ml_dataset_openers)
     config_file = os.path.join(ctx.base_dir, 'config.yml')
     with open(config_file) as fp:
         ctx.config = yaml.safe_load(fp)

--- a/test/webapi/res/test/WMTSCapabilities.xml
+++ b/test/webapi/res/test/WMTSCapabilities.xml
@@ -364,6 +364,121 @@
                 <Value>2017-02-05T00:00:00.000000000</Value>
             </Dimension>
         </Layer>
+        <Layer>
+            <ows:Identifier>demo-1w.quality_flags_stdev</ows:Identifier>
+            <ows:Title>demo-1w/quality_flags_stdev</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+            <ows:LowerCorner>050</ows:LowerCorner>
+            <ows:UpperCorner>552.5</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <Style isDefault="true"><ows:Identifier>Default</ows:Identifier></Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink><TileMatrixSet>TileGrid_0</TileMatrixSet></TileMatrixSetLink>
+            <ResourceURL format="image/png"resourceType="tile"template="http://bibo/xcube/api/0.1.0.dev6/wmts/1.0.0/tile/demo-1w/quality_flags_stdev/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+            <Dimension>
+                <ows:Identifier>time</ows:Identifier>
+                <ows:Title>time</ows:Title>
+                <ows:UOM>ISO8601</ows:UOM>
+                <Default>current</Default>
+                <Current>true</Current>
+                <Value>2017-01-22T00:00:00.000000000</Value>
+                <Value>2017-01-29T00:00:00.000000000</Value>
+                <Value>2017-02-05T00:00:00.000000000</Value>
+            </Dimension>
+        </Layer>
+        <Layer>
+            <ows:Identifier>demo-1w.kd489_stdev</ows:Identifier>
+            <ows:Title>demo-1w/kd489_stdev</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+            <ows:LowerCorner>050</ows:LowerCorner>
+            <ows:UpperCorner>552.5</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <Style isDefault="true"><ows:Identifier>Default</ows:Identifier></Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink><TileMatrixSet>TileGrid_0</TileMatrixSet></TileMatrixSetLink>
+            <ResourceURL format="image/png"resourceType="tile"template="http://bibo/xcube/api/0.1.0.dev6/wmts/1.0.0/tile/demo-1w/kd489_stdev/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+            <Dimension>
+                <ows:Identifier>time</ows:Identifier>
+                <ows:Title>time</ows:Title>
+                <ows:UOM>ISO8601</ows:UOM>
+                <Default>current</Default>
+                <Current>true</Current>
+                <Value>2017-01-22T00:00:00.000000000</Value>
+                <Value>2017-01-29T00:00:00.000000000</Value>
+                <Value>2017-02-05T00:00:00.000000000</Value>
+            </Dimension>
+        </Layer>
+        <Layer>
+            <ows:Identifier>demo-1w.conc_tsm_stdev</ows:Identifier>
+            <ows:Title>demo-1w/conc_tsm_stdev</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+            <ows:LowerCorner>050</ows:LowerCorner>
+            <ows:UpperCorner>552.5</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <Style isDefault="true"><ows:Identifier>Default</ows:Identifier></Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink><TileMatrixSet>TileGrid_0</TileMatrixSet></TileMatrixSetLink>
+            <ResourceURL format="image/png"resourceType="tile"template="http://bibo/xcube/api/0.1.0.dev6/wmts/1.0.0/tile/demo-1w/conc_tsm_stdev/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+            <Dimension>
+                <ows:Identifier>time</ows:Identifier>
+                <ows:Title>time</ows:Title>
+                <ows:UOM>ISO8601</ows:UOM>
+                <Default>current</Default>
+                <Current>true</Current>
+                <Value>2017-01-22T00:00:00.000000000</Value>
+                <Value>2017-01-29T00:00:00.000000000</Value>
+                <Value>2017-02-05T00:00:00.000000000</Value>
+            </Dimension>
+        </Layer>
+        <Layer>
+            <ows:Identifier>demo-1w.conc_chl_stdev</ows:Identifier>
+            <ows:Title>demo-1w/conc_chl_stdev</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+            <ows:LowerCorner>050</ows:LowerCorner>
+            <ows:UpperCorner>552.5</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <Style isDefault="true"><ows:Identifier>Default</ows:Identifier></Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink><TileMatrixSet>TileGrid_0</TileMatrixSet></TileMatrixSetLink>
+            <ResourceURL format="image/png"resourceType="tile"template="http://bibo/xcube/api/0.1.0.dev6/wmts/1.0.0/tile/demo-1w/conc_chl_stdev/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+            <Dimension>
+                <ows:Identifier>time</ows:Identifier>
+                <ows:Title>time</ows:Title>
+                <ows:UOM>ISO8601</ows:UOM>
+                <Default>current</Default>
+                <Current>true</Current>
+                <Value>2017-01-22T00:00:00.000000000</Value>
+                <Value>2017-01-29T00:00:00.000000000</Value>
+                <Value>2017-02-05T00:00:00.000000000</Value>
+            </Dimension>
+        </Layer>
+        <Layer>
+            <ows:Identifier>demo-1w.c2rcc_flags_stdev</ows:Identifier>
+            <ows:Title>demo-1w/c2rcc_flags_stdev</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:WGS84BoundingBox>
+            <ows:LowerCorner>050</ows:LowerCorner>
+            <ows:UpperCorner>552.5</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <Style isDefault="true"><ows:Identifier>Default</ows:Identifier></Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink><TileMatrixSet>TileGrid_0</TileMatrixSet></TileMatrixSetLink>
+            <ResourceURL format="image/png"resourceType="tile"template="http://bibo/xcube/api/0.1.0.dev6/wmts/1.0.0/tile/demo-1w/c2rcc_flags_stdev/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+            <Dimension>
+                <ows:Identifier>time</ows:Identifier>
+                <ows:Title>time</ows:Title>
+                <ows:UOM>ISO8601</ows:UOM>
+                <Default>current</Default>
+                <Current>true</Current>
+                <Value>2017-01-22T00:00:00.000000000</Value>
+                <Value>2017-01-29T00:00:00.000000000</Value>
+                <Value>2017-02-05T00:00:00.000000000</Value>
+            </Dimension>
+        </Layer>
     </Contents>
     <Themes>
         <Theme>
@@ -424,6 +539,31 @@
                 <ows:Title>c2rcc_flags</ows:Title>
                 <ows:Identifier>demo-1w.c2rcc_flags</ows:Identifier>
                 <LayerRef>demo-1w.c2rcc_flags</LayerRef>
+            </Theme>
+            <Theme>
+                <ows:Title>quality_flags_stdev</ows:Title>
+                <ows:Identifier>demo-1w.quality_flags_stdev</ows:Identifier>
+                <LayerRef>demo-1w.quality_flags_stdev</LayerRef>
+            </Theme>
+            <Theme>
+                <ows:Title>kd489_stdev</ows:Title>
+                <ows:Identifier>demo-1w.kd489_stdev</ows:Identifier>
+                <LayerRef>demo-1w.kd489_stdev</LayerRef>
+            </Theme>
+            <Theme>
+                <ows:Title>conc_tsm_stdev</ows:Title>
+                <ows:Identifier>demo-1w.conc_tsm_stdev</ows:Identifier>
+                <LayerRef>demo-1w.conc_tsm_stdev</LayerRef>
+            </Theme>
+            <Theme>
+                <ows:Title>conc_chl_stdev</ows:Title>
+                <ows:Identifier>demo-1w.conc_chl_stdev</ows:Identifier>
+                <LayerRef>demo-1w.conc_chl_stdev</LayerRef>
+            </Theme>
+            <Theme>
+                <ows:Title>c2rcc_flags_stdev</ows:Title>
+                <ows:Identifier>demo-1w.c2rcc_flags_stdev</ows:Identifier>
+                <LayerRef>demo-1w.c2rcc_flags_stdev</LayerRef>
             </Theme>
         </Theme>
     </Themes>

--- a/test/webapi/res/test/config.yml
+++ b/test/webapi/res/test/config.yml
@@ -11,6 +11,7 @@ Datasets:
     InputDatasets: ["demo"]
     InputParameters:
       period: "1W"
+      incl_stdev: True
     Style: default
 
 PlaceGroups:

--- a/test/webapi/res/test/script.py
+++ b/test/webapi/res/test/script.py
@@ -1,3 +1,13 @@
+import xarray as xr
 
-def compute_dataset(ds, period='1W'):
-    return ds.resample(time=period).mean(dim='time')
+
+def compute_dataset(ds, period='1W', incl_stdev=False):
+    if incl_stdev:
+        resample_obj = ds.resample(time=period)
+        ds_mean = resample_obj.mean(dim='time')
+        ds_std = resample_obj.std(dim='time').rename(name_dict={name: f"{name}_stdev" for name in ds.data_vars})
+        ds_merged = xr.merge([ds_mean, ds_std])
+        ds_merged.attrs.update(ds.attrs)
+        return ds_merged
+    else:
+        return ds.resample(time=period).mean(dim='time')

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -5,12 +5,24 @@ from xcube.webapi.app import new_application
 from xcube.webapi.defaults import API_PREFIX, DEFAULT_NAME
 from .helpers import new_test_service_context
 
+CTX = new_test_service_context()
+
+# Preload datasets, so we don't run into timeout during testing
+
+_ds = CTX.get_dataset("demo")
+for name, var in _ds.coords.items():
+    values = var.values
+
+_ds = CTX.get_dataset("demo-1w")
+for name, var in _ds.coords.items():
+    values = var.values
+
 
 class HandlersTest(AsyncHTTPTestCase):
 
     def get_app(self):
         application = new_application()
-        application.service_context = new_test_service_context()
+        application.service_context = CTX
         return application
 
     def assertResponseOK(self, response):

--- a/xcube/webapi/controllers/time_series.py
+++ b/xcube/webapi/controllers/time_series.py
@@ -152,7 +152,7 @@ def _get_time_series_for_point(dataset: xr.Dataset,
             for index, entry in zip(range(num_time_steps), ancillary_time_subset):
                 ancillary_value = entry.values.item()
                 statistics = time_series[index]['result']
-                statistics[ancillary_field_name] = None if np.isnan(ancillary_value) else float(ancillary_value)
+                statistics[ancillary_field_name] = None if np.isnan(ancillary_value) else ancillary_value
 
     return {'results': time_series}
 
@@ -219,10 +219,10 @@ def _get_time_series_for_geometry(dataset: xr.Dataset,
         for time_index in range(num_times):
             ancillary_slice = ancillary_variable.isel(time=time_index)
             ancillary_masked = ancillary_slice.where(mask)
-            ancillary_mean = ancillary_masked.mean(["lat", "lon"]).values.item()
+            ancillary_mean = ancillary_masked.mean(["lat", "lon"])
             ancillary_value = ancillary_mean.values.item()
             statistics = time_series[time_index]["result"]
-            statistics[ancillary_field_name] = None if np.isnan(ancillary_value) else float(ancillary_value)
+            statistics[ancillary_field_name] = None if np.isnan(ancillary_value) else ancillary_value
 
     return {'results': time_series}
 

--- a/xcube/webapi/res/demo/config.yml
+++ b/xcube/webapi/res/demo/config.yml
@@ -30,6 +30,7 @@ Datasets:
     InputDatasets: ["local"]
     InputParameters:
       period: "1W"
+      incl_stdev: True
     Style: default
     PlaceGroups:
       - PlaceGroupRef: inside-cube
@@ -44,6 +45,7 @@ Datasets:
     InputDatasets: ["remote"]
     InputParameters:
       period: "1W"
+      incl_stdev: True
     Style: default
     PlaceGroups:
       - PlaceGroupRef: inside-cube

--- a/xcube/webapi/res/demo/resample_in_time.py
+++ b/xcube/webapi/res/demo/resample_in_time.py
@@ -1,3 +1,13 @@
+import xarray as xr
 
-def compute_dataset(ds, period='1W'):
-    return ds.resample(time=period).mean(dim='time')
+
+def compute_dataset(ds, period='1W', incl_stdev=False):
+    if incl_stdev:
+        resample_obj = ds.resample(time=period)
+        ds_mean = resample_obj.mean(dim='time')
+        ds_std = resample_obj.std(dim='time').rename(name_dict={name: f"{name}_stdev" for name in ds.data_vars})
+        ds_merged = xr.merge([ds_mean, ds_std])
+        ds_merged.attrs.update(ds.attrs)
+        return ds_merged
+    else:
+        return ds.resample(time=period).mean(dim='time')


### PR DESCRIPTION
If accepted, all '/ts/*' API calls may also return either `error`, `error`, or `uncertainty` in time-series if auxiliary variables are available in the source datasets.

Closes #48