### PR TITLE
Importing plugins on time for using xcube-gen-..

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Added `xcube vars2dim` command to make variables a cube dimension (#31)
 * Added `xcube serve` option `--traceperf` that allows switching on performance diagnostics.
 * Fixed error in plugins when importing `xcube.api.gen` (#62)
+* Fixed import of plugins only when executing `xcube.cli` (#66)
 
 
 ## Changes in 0.1.0

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ The SwaggerHub allows to choose the xcube-server project and therefore the datas
 
 To run the server on default port 8080:
 
-    $ xcube server -v -c xcube_server/res/demo/config.yml
+    $ xcube serve -v -c xcube/webapi/res/demo/config.yml
 
 
 Test it:

--- a/xcube/api/gen/gen.py
+++ b/xcube/api/gen/gen.py
@@ -75,6 +75,9 @@ def gen_cube(input_files: Sequence[str] = None, input_processor: str = None, inp
     :param monitor: A progress monitor.
     :return: A tuple (output_path, status). If status is True, output_path will be the path to the output.
     """
+    # Force loading of plugins
+    __import__('xcube.util.plugin')
+
     input_processor = get_input_processor(input_processor)
     if not input_processor:
         raise ValueError(f'unknown input_processor {input_processor!r}')


### PR DESCRIPTION
This PR  fixes issue #66. 
Before the only time plugins were loaded was when executing 'xcube.cli', but for xcube-gen-... it is also needed within 'xcube.api.gen.gen' in order not to receive an import error. 