### PR TITLE
Cleanup Xcube IO API

### DIFF
--- a/xcube/__init__.py
+++ b/xcube/__init__.py
@@ -20,5 +20,4 @@
 # SOFTWARE.
 
 from .version import version as __version__
-from xcube.util.dsio import open_from_obs, open_from_fs
 

--- a/xcube/api/__init__.py
+++ b/xcube/api/__init__.py
@@ -1,8 +1,10 @@
 from .api import XCubeAPI
 from .chunk import chunk_dataset
-from .vars_to_dim import vars_to_dim
 from .dump import dump_dataset
+from .extract import get_cube_point_indexes, get_cube_values_for_indexes, get_cube_values_for_points, \
+    get_dataset_indexes
 from .new import new_cube
-from .extract import get_cube_point_indexes, get_cube_values_for_indexes, get_cube_values_for_points, get_dataset_indexes
-from .readwrite import open_dataset, read_dataset, write_dataset
+from .readwrite import read_cube, open_cube, open_dataset, read_dataset, write_dataset
+from .ts import get_time_series
+from .vars_to_dim import vars_to_dim
 from .verify import assert_cube, verify_cube

--- a/xcube/api/compute.py
+++ b/xcube/api/compute.py
@@ -36,6 +36,18 @@ def compute_dataset(dataset: xr.Dataset,
     """
     Compute a dataset from another dataset and return it.
 
+    New variables are computed according to the value of an ``expression`` attribute which, if given,
+    must by a valid Python expression that can reference any other preceding variables by name.
+    The expression can also reference any flags defined by another variable according the their CF
+    attributes ``flag_meaning`` and ``flag_values``.
+
+    Invalid values may be masked out using the value of an
+    optional ``valid_pixel_expression`` attribute that forms a boolean Python expression.
+    The value of the ``_FillValue`` attribute or NaN will be used in the new variable where the
+    expression returns zero or false.
+
+    Other attributes will be stored as variable metadata as-is.
+
     :param dataset: A dataset.
     :param processed_variables: Optional list of variables that will be loaded or computed in the order given.
            Each variable is either identified by name or by a name to variable attributes mapping.

--- a/xcube/cli/apply.py
+++ b/xcube/cli/apply.py
@@ -97,7 +97,7 @@ def apply(output: str,
     if not callable(apply_function):
         raise click.ClickException(f"{apply_function!r} in {script} is not a callable")
 
-    from xcube.api import assert_cube, read_dataset
+    from xcube.api import read_cube
     from xcube.util.cliutil import parse_cli_kwargs
     from xcube.util.dsio import guess_dataset_format, find_dataset_io, open_from_obs
 
@@ -105,14 +105,7 @@ def apply(output: str,
     input_cube_0 = None
     input_cubes = []
     for input_path in input_paths:
-        # TODO (forman): move url code into read_dataset()
-        if input_path.startswith("http://") or input_path.startswith("https://"):
-            import urllib3
-            url = urllib3.util.parse_url(input_path)
-            input_cube = open_from_obs(path=url.path, endpoint_url=f"{url.scheme}://{url.host}")
-            assert_cube(input_cube)
-        else:
-            input_cube = read_dataset(input_path=input_path, is_cube=True)
+        input_cube = read_cube(input_path=input_path)
         if input_cube_0 is None:
             input_cube_0 = input_cube
         else:

--- a/xcube/cli/apply.py
+++ b/xcube/cli/apply.py
@@ -99,7 +99,7 @@ def apply(output: str,
 
     from xcube.api import read_cube
     from xcube.util.cliutil import parse_cli_kwargs
-    from xcube.util.dsio import guess_dataset_format, find_dataset_io, open_from_obs
+    from xcube.util.dsio import guess_dataset_format, find_dataset_io
 
     kwargs = parse_cli_kwargs(params, "<params>")
     input_cube_0 = None

--- a/xcube/util/dsio.py
+++ b/xcube/util/dsio.py
@@ -19,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import glob
 import os
 import shutil
 import warnings
@@ -30,56 +29,14 @@ import pandas as pd
 import s3fs
 import xarray as xr
 import zarr
-from xcube.util.objreg import get_obj_registry
+
+from ..util.objreg import get_obj_registry
 
 FORMAT_NAME_EXCEL = "excel"
 FORMAT_NAME_CSV = "csv"
 FORMAT_NAME_MEM = "mem"
 FORMAT_NAME_NETCDF4 = "netcdf4"
 FORMAT_NAME_ZARR = "zarr"
-
-
-def open_from_fs(paths: str, recursive: bool = False, **kwargs):
-    """
-    Open an xcube (xarray dataset) from local or any mounted file system.
-
-    :param paths: A path which may contain Unix-style wildcards or a sequence of paths.
-    :param recursive: Whether wildcards should be resolved recursively in sub-directories.
-    :type kwargs: keyword arguments passed to `xarray.open_mfdataset()`.
-    """
-    if isinstance(paths, str):
-        paths = [file for file in glob.glob(paths, recursive=recursive)]
-        if 'autoclose' not in kwargs:
-            kwargs['autoclose'] = True
-
-    if 'coords' not in kwargs:
-        kwargs['coords'] = 'minimum'
-    if 'data_vars' not in kwargs:
-        kwargs['data_vars'] = 'minimum'
-
-    ds = xr.open_mfdataset(paths, **kwargs)
-
-    if 'chunks' not in kwargs:
-        print("ds.encoding = ", ds.encoding)
-
-    return ds
-
-
-def open_from_obs(path: str, endpoint_url: str = None, max_cache_size: int = 2 ** 28) -> xr.Dataset:
-    """
-    Open an xcube (xarray dataset) from S3 compatible object storage (OBS).
-
-    :param path: Path having format "<bucket>/<my>/<sub>/<path>"
-    :param endpoint_url: Optional URL of the OBS service endpoint. If omitted, AWS S3 service URL is used.
-    :param max_cache_size: If > 0, size of a memory cache in bytes, e.g. 2**30 = one giga bytes.
-           If None or size <= 0, no memory cache will be used.
-    :return: an xarray dataset
-    """
-    s3 = s3fs.S3FileSystem(anon=True, client_kwargs=dict(endpoint_url=endpoint_url))
-    store = s3fs.S3Map(root=path, s3=s3, check=False)
-    if max_cache_size is not None and max_cache_size > 0:
-        store = zarr.LRUStoreCache(store, max_size=max_cache_size)
-    return xr.open_zarr(store)
 
 
 class DatasetIO(metaclass=ABCMeta):
@@ -384,7 +341,21 @@ class ZarrDatasetIO(DatasetIO):
         return (3 * ext_value + type_value) / 4
 
     def read(self, path: str, **kwargs) -> xr.Dataset:
-        return xr.open_zarr(path, **kwargs)
+        path_or_store = path
+        if isinstance(path, str) \
+                and (path.startswith("http://")
+                     or path.startswith("https://")):
+            import urllib3.util
+            url = urllib3.util.parse_url(path_or_store)
+            endpoint_url = f'{url.scheme}://{url.host}'
+            s3 = s3fs.S3FileSystem(anon=True, client_kwargs=dict(endpoint_url=endpoint_url))
+            path_or_store = s3fs.S3Map(root=path, s3=s3, check=False)
+            if 'max_cache_size' in kwargs:
+                max_cache_size = kwargs.pop('max_cache_size')
+                if max_cache_size > 0:
+                    path_or_store = zarr.LRUStoreCache(path_or_store, max_size=max_cache_size)
+
+        return xr.open_zarr(path_or_store, **kwargs)
 
     def write(self,
               dataset: xr.Dataset,
@@ -395,7 +366,8 @@ class ZarrDatasetIO(DatasetIO):
         encoding = self._get_write_encodings(dataset, compress, cname, clevel, shuffle, blocksize, chunksizes)
         dataset.to_zarr(output_path, mode="w", encoding=encoding)
 
-    def _get_write_encodings(self, dataset, compress, cname, clevel, shuffle, blocksize, chunksizes):
+    @classmethod
+    def _get_write_encodings(cls, dataset, compress, cname, clevel, shuffle, blocksize, chunksizes):
         encoding = None
         if chunksizes:
             encoding = {}
@@ -434,6 +406,7 @@ class ZarrDatasetIO(DatasetIO):
                 var_array.append(new_var, axis=axis)
 
 
+# noinspection PyAbstractClass
 class CsvDatasetIO(DatasetIO):
     """
     A dataset I/O that reads from / writes to CSV files.


### PR DESCRIPTION
The following functionshave been removed from API

* `open_from_obs()`
* `open_from_fs()`

Cubes and other datasets shall be read with the following API functions

* `read_cube()`
* `read_dataset()`

Both now also accepts URLs so we can open from Object Storage directly.

@AliceBalfanz this is important for the documentation and for any example notebooks we'll create for the API manuals