### PR TITLE
fixing colormap_alpha not showing up in legend of xcube-viewer relate…

### DIFF
--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -60,7 +60,7 @@ class Vars2DimTest(CliDataTest):
         var_names = ds["var"]
         self.assertEqual(("var",), var_names.dims)
         self.assertTrue(hasattr(var_names, "encoding"))
-        self.assertEqual("object", str(var_names.dtype))
+        self.assertEqual("<U13", str(var_names.dtype))
         self.assertEqual(3, len(var_names))
         self.assertIn("precipitation", str(var_names[0]))
         self.assertIn("soil_moisture", str(var_names[1]))

--- a/test/webapi/im/test_cmaps.py
+++ b/test/webapi/im/test_cmaps.py
@@ -37,26 +37,26 @@ class CmapsTest(TestCase):
     def test_get_cmaps_category_tuples(self):
         cmaps = get_cmaps()
         category_tuple = cmaps[0][2]
-        self.assertEqual(len(category_tuple), 4)
+        self.assertEqual(len(category_tuple), 8)
         self.assertEqual(category_tuple[0][0], 'viridis')
         self.assertEqual(category_tuple[0][1],
                          'iVBORw0KGgoAAAANSUhEUgAAAQAAAAACCAYAAAC3zQLZAAAAzklEQVR4nO2TQZLFIAhEX7dXmyPM/Y8SZwEqMcnU3/9QZTU8GszC6Ee/HQlk5FAsJIENqVGv/piZ3uqf3nX6Vtd+l8D8UwNOLhZL3+BLh796OXvMdWaqtrrqnZ/tjvuZT/0XxnN/5f25z9X7tIMTKzV7/5yrME3NHoPlUzvplgOevOcz6ZO5eCqzOmark1nHDQveHuuYaazZkTcdmE110HJu6doR3tgfPHyL51zNc0fd2xjf0vPukUPL36YBTcpcWArFyY0RTca88cYbXxt/gUOJC8yRF1kAAAAASUVORK5CYII=')
 
-        self.assertEqual(category_tuple[1][0], 'inferno')
-        self.assertEqual(category_tuple[2][0], 'plasma')
-        self.assertEqual(category_tuple[3][0], 'magma')
+        self.assertEqual(category_tuple[1][0], 'viridis_alpha')
+        self.assertEqual(category_tuple[2][0], 'inferno')
+        self.assertEqual(category_tuple[3][0], 'inferno_alpha')
 
     def test_cmocean_category(self):
         cmaps = get_cmaps()
         category_tuple = cmaps[5][2]
-        self.assertEqual(len(category_tuple), 18)
+        self.assertEqual(len(category_tuple), 36)
         self.assertEqual(category_tuple[0][0], 'thermal')
         self.assertEqual(category_tuple[0][1],
                          'iVBORw0KGgoAAAANSUhEUgAAAQAAAAACCAYAAAC3zQLZAAAA2klEQVR4nO2S6xHDMAiDP+FROkL3Xy30RwBju52g8V0OIcnyKxqvtwsD5SfAUPZNE6M4VR2hJTdQeBX6UhlY8xgDY8V24A15pMuIXcQHJo4qwOQYIHlojpT6zWnzqDxRo+/+zFZbR7H2Tx3WvMPf1qDvq+17zz/m7TV97YxHbefEW27ve+7Oe9xZZu3cdXCdr17XokurfvYOcmTXxHJkE2P32ei8eVxww1WJecRlBxZr/cndj+T5MKULbzqm5pnY56MFjnkmPH7cb7xXzvR49RRO3njGM57xt+MDC391Pt11tkYAAAAASUVORK5CYII=')
 
-        self.assertEqual(category_tuple[1][0], 'haline')
-        self.assertEqual(category_tuple[2][0], 'solar')
-        self.assertEqual(category_tuple[3][0], 'ice')
+        self.assertEqual(category_tuple[1][0], 'thermal_alpha')
+        self.assertEqual(category_tuple[2][0], 'haline')
+        self.assertEqual(category_tuple[3][0], 'haline_alpha')
 
 
 def main():

--- a/xcube/webapi/im/cmaps.py
+++ b/xcube/webapi/im/cmaps.py
@@ -165,27 +165,34 @@ def ensure_cmaps_loaded():
                         _LOG.warning('could not create colormap "{}" because "{}" is of unknown type {}'
                                      .format(new_name, cmap.name, type(cmap)))
 
-                    gradient = np.linspace(0, 1, 256)
-                    gradient = np.vstack((gradient, gradient))
-                    image_data = cmap(gradient, bytes=True)
-                    image = Image.fromarray(image_data, 'RGBA')
+                    cbar_list.append((cmap_name, _get_cbar_png_bytes(cmap)))
+                    cbar_list.append((new_name, _get_cbar_png_bytes(new_cmap)))
 
-                    # ostream = io.FileIO('../cmaps/' + cmap_name + '.png', 'wb')
-                    # image.save(ostream, format='PNG')
-                    # ostream.close()
-
-                    ostream = io.BytesIO()
-                    image.save(ostream, format='PNG')
-                    cbar_png_bytes = ostream.getvalue()
-                    ostream.close()
-
-                    cbar_png_data = base64.b64encode(cbar_png_bytes)
-                    cbar_png_bytes = cbar_png_data.decode('unicode_escape')
-
-                    cbar_list.append((cmap_name, cbar_png_bytes))
                 new_cmaps.append((cmap_category, cmap_description, tuple(cbar_list)))
             _CMAPS = tuple(new_cmaps)
             _CBARS_LOADED = True
             # import pprint
             # pprint.pprint(_CMAPS)
         _LOCK.release()
+
+
+def _get_cbar_png_bytes(cmap):
+
+    gradient = np.linspace(0, 1, 256)
+    gradient = np.vstack((gradient, gradient))
+    image_data = cmap(gradient, bytes=True)
+    image = Image.fromarray(image_data, 'RGBA')
+
+    # ostream = io.FileIO('../cmaps/' + cmap_name + '.png', 'wb')
+    # image.save(ostream, format='PNG')
+    # ostream.close()
+
+    ostream = io.BytesIO()
+    image.save(ostream, format='PNG')
+    cbar_png_bytes = ostream.getvalue()
+    ostream.close()
+
+    cbar_png_data = base64.b64encode(cbar_png_bytes)
+    cbar_png_bytes = cbar_png_data.decode('unicode_escape')
+
+    return cbar_png_bytes


### PR DESCRIPTION
When using the suffix _alpha with colorbars, they were not displayed in the xcube-viewer legend. This is related to xcube-viewer issue https://github.com/dcs4cop/xcube-viewer/issues/49.