### PR TITLE
Fix Colour Maps for Category Ocean not Working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ ENV/
 
 # Test data
 *.nc/
+
+config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -107,5 +107,3 @@ ENV/
 
 # Test data
 *.nc/
-
-config.yml

--- a/test/webapi/im/test_cmaps.py
+++ b/test/webapi/im/test_cmaps.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
+from matplotlib.colors import LinearSegmentedColormap, ListedColormap
+import matplotlib.cm as cm
 
-from xcube.webapi.im.cmaps import get_cmaps
+from xcube.webapi.im.cmaps import get_cmaps, ensure_cmaps_loaded
 
 
 class CmapsTest(TestCase):
@@ -9,6 +11,11 @@ class CmapsTest(TestCase):
         cmaps = get_cmaps()
         self.assertIs(cmaps, get_cmaps())
         self.assertIs(cmaps, get_cmaps())
+
+    def test_get_cmaps_registers_ocean_colour(self):
+        ensure_cmaps_loaded()
+        cmap = cm.get_cmap('deep', 256)
+        self.assertTrue((type(cmap) is LinearSegmentedColormap) or (type(cmap) is ListedColormap))
 
     def test_get_cmaps_retruns_equal_size_recs(self):
         cmaps = get_cmaps()

--- a/xcube/webapi/im/cmaps.py
+++ b/xcube/webapi/im/cmaps.py
@@ -125,6 +125,7 @@ def ensure_cmaps_loaded():
                     try:
                         if cmap_category == 'Ocean':
                             cmap = getattr(ocm, cmap_name)
+                            cm.register_cmap(cmap=cmap)
                         else:
                             cmap = cm.get_cmap(cmap_name)
                     except ValueError:

--- a/xcube/webapi/im/cmaps.py
+++ b/xcube/webapi/im/cmaps.py
@@ -125,6 +125,7 @@ def ensure_cmaps_loaded():
                     try:
                         if cmap_category == 'Ocean':
                             cmap = getattr(ocm, cmap_name)
+                            cm.register_cmap(cmap=new_cmap)
                         else:
                             cmap = cm.get_cmap(cmap_name)
                     except ValueError:

--- a/xcube/webapi/im/cmaps.py
+++ b/xcube/webapi/im/cmaps.py
@@ -125,7 +125,6 @@ def ensure_cmaps_loaded():
                     try:
                         if cmap_category == 'Ocean':
                             cmap = getattr(ocm, cmap_name)
-                            cm.register_cmap(cmap=new_cmap)
                         else:
                             cmap = cm.get_cmap(cmap_name)
                     except ValueError:

--- a/xcube/webapi/im/tiledimage.py
+++ b/xcube/webapi/im/tiledimage.py
@@ -35,6 +35,11 @@ from .utils import downsample_ndarray, aggregate_ndarray_first
 from ..cache import Cache
 from ...util.perf import measure_time_cm
 
+try:
+    import cmocean.cm as ocm
+except ImportError:
+    ocm = None
+
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
 _LOG = logging.getLogger('xcube')
@@ -448,7 +453,12 @@ class ColorMappedRgbaImage(DecoratorImage):
         self._value_range = value_range
         self._cmap_name = cmap_name if cmap_name else 'jet'
         ensure_cmaps_loaded()
-        self._cmap = cm.get_cmap(self._cmap_name, num_colors)
+
+        try:
+            self._cmap = cm.get_cmap(self._cmap_name, num_colors)
+        except ValueError:
+            self._cmap = getattr(ocm, self._cmap_name)
+
         self._cmap.set_bad('k', 0)
         self._no_data_value = no_data_value
         self._encode = encode

--- a/xcube/webapi/im/tiledimage.py
+++ b/xcube/webapi/im/tiledimage.py
@@ -456,8 +456,11 @@ class ColorMappedRgbaImage(DecoratorImage):
 
         try:
             self._cmap = cm.get_cmap(self._cmap_name, num_colors)
-        except ValueError:
-            self._cmap = getattr(ocm, self._cmap_name)
+        except ValueError as e:
+            _LOG.warning(str(e))
+            _LOG.warning('reverting to colour map "jet"')
+            self._cmap_name = 'jet'
+            self._cmap = cm.get_cmap(self._cmap_name, num_colors)
 
         self._cmap.set_bad('k', 0)
         self._no_data_value = no_data_value

--- a/xcube/webapi/res/demo/config.yml
+++ b/xcube/webapi/res/demo/config.yml
@@ -1,85 +1,96 @@
 Datasets:
-  - Identifier: local
-    Title: "Local OLCI L2C cube for region SNS"
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: local
-    Path: cube-1-250-250.zarr
-    Style: default
-    TimeSeriesDataset: local_ts
-    PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
-
-  - Identifier: local_ts
-    Title: "'local' optimized for time-series"
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: local
-    Path: cube-5-100-200.zarr
-    Hidden: true
-    Style: default
-
-  - Identifier: remote
-    Title: Remote OLCI L2C cube for region SNS
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: obs
+  - Identifier: cyanoalert-olci-lswe-l2c-v1
+    Title: "Sverige Sj\u00f6ar 2018"
     Endpoint: "http://obs.eu-de.otc.t-systems.com"
-    Path: "dcs4cop-obs-01/OLCI-SNS-RAW-CUBE-2.zarr"
+    Path: "cyanoalert/cyanoalert-olci-lswe-l2c-v1.zarr"
+    FileSystem: "obs"
     Region: "eu-de"
     Style: default
     PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
-
-  - Identifier: local_1w
-    Title: OLCI weekly L3 cube for region SNS computed from local L2C cube
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: memory
-    Path: "resample_in_time.py"
-    Function: "compute_dataset"
-    InputDatasets: ["local"]
-    InputParameters:
-      period: "1W"
-      incl_stdev: True
-    Style: default
-    PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
-
-  - Identifier: remote_1w
-    Title: OLCI weekly L3 cube for region SNS computed from remote L2C cube
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: memory
-    Path: "resample_in_time.py"
-    Function: "compute_dataset"
-    InputDatasets: ["remote"]
-    InputParameters:
-      period: "1W"
-      incl_stdev: True
-    Style: default
-    PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
+      - PlaceGroupRef: Sweden_SE_Lakes
+      - PlaceGroupRef: Sweden_SE_Bathing_Sites
 
 PlaceGroups:
-  - Identifier: inside-cube
-    Title: Points inside the cube
-    Path: "places/inside-cube.geojson"
-  - Identifier: outside-cube
-    Title: Points outside the cube
-    Path: "places/outside-cube.geojson"
+  - Identifier: Sweden_SE_Lakes
+    Title: "Svenska Sj\u00f6arna"
+    Path: "C:\\Users/Helge/IdeaProjects/xcube/data/places/Selected_Monitoring_Lakes_wgs84_reprojected.shp"
+    CharacterEncoding: utf-8
+    PropertyMapping:
+      label: "SJONAMN"
+      infoUrl: "URL_VISS"
+  - Identifier: Sweden_SE_Bathing_Sites
+    Title: "Sverige selected bathing sites"
+    Path: "C:\\Users/Helge/IdeaProjects/xcube/data/places/Selected_Bathing_Sites_reprojected.shp"
+    CharacterEncoding: utf-8
+    PropertyMapping:
+      label: "BADPLATS"
+      eu_id: "EU_ID"
 
 Styles:
   - Identifier: default
     ColorMappings:
-      conc_chl:
-        ColorBar: "plasma"
-        ValueRange: [0., 24.]
-      conc_tsm:
-        ColorBar: "PuBuGn"
+      chl_c2rcc:
+        ColorBar: "YlGn"
+        ValueRange: [0., 20.]
+      chl_mph:
+        ColorBar: "YlGn"
+        ValueRange: [0., 20.]
+      iop_adg:
+        ColorBar: "RdBu"
+        ValueRange: [0., 2.]
+      iop_agelb:
+        ColorBar: "RdPu"
+        ValueRange: [0., 2.]
+      kd_z90max:
+        ColorBar: "YlGn"
+        ValueRange: [0., 1.]
+      tsm_c2rcc:
+        ColorBar: "viridis"
         ValueRange: [0., 100.]
-      kd489:
-        ColorBar: "jet"
-        ValueRange: [0., 6.]
+      tur_nechad_665:
+        ColorBar: "inferno"
+        ValueRange: [0., 100.]
+      tur_nechad_865:
+        ColorBar: "plasma"
+        ValueRange: [0., 100.]
+      # min and max for the parameter below need to be adjusted! just placeholder values at the moment
+      c2rcc_secchi_depth_1:
+        ColorBar: "deep"
+        ValueRange: [0., 20.]
+      c2rcc_secchi_depth_2:
+        ColorBar: "deep"
+        ValueRange: [0, 20.]
+      c2rcc_secchi_depth_3:
+        ColorBar: "deep"
+        ValueRange: [0, 20.]
+      c2rcc_secchi_depth_4:
+        ColorBar: "deep"
+        ValueRange: [0, 20.]
+      immersed_cyanobacteria:
+        ColorBar: "Reds"
+        ValueRange: [0, 1.]
+      floating_cyanobacteria:
+        ColorBar: "Blues_alpha"
+        ValueRange: [0, 1.]
+      floating_vegetation:
+        ColorBar: "Greens_alpha"
+        ValueRange: [0, 1.]
+      chl_pitarch:
+        ColorBar: "gnuplot"
+        ValueRange: [0, 10.]
+
+#Styles:
+#  - Identifier: default
+#    ColorMappings:
+#      conc_chl:
+#        ColorBar: "plasma"
+#        ValueRange: [0., 24.]
+#      conc_tsm:
+#        ColorBar: "PuBuGn"
+#        ValueRange: [0., 100.]
+#      kd489:
+#        ColorBar: "jet"
+#        ValueRange: [0., 6.]
 
 ServiceProvider:
   ProviderName: "Brockmann Consult GmbH"

--- a/xcube/webapi/res/demo/config.yml
+++ b/xcube/webapi/res/demo/config.yml
@@ -1,85 +1,96 @@
 Datasets:
-  - Identifier: local
-    Title: "Local OLCI L2C cube for region SNS"
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: local
-    Path: cube-1-250-250.zarr
-    Style: default
-    TimeSeriesDataset: local_ts
-    PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
-
-  - Identifier: local_ts
-    Title: "'local' optimized for time-series"
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: local
-    Path: cube-5-100-200.zarr
-    Hidden: true
-    Style: default
-
-  - Identifier: remote
-    Title: Remote OLCI L2C cube for region SNS
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: obs
+  - Identifier: cyanoalert-olci-lswe-l2c-v1
+    Title: "Sverige Sj\u00f6ar 2018"
     Endpoint: "http://obs.eu-de.otc.t-systems.com"
-    Path: "dcs4cop-obs-01/OLCI-SNS-RAW-CUBE-2.zarr"
+    Path: "cyanoalert/cyanoalert-olci-lswe-l2c-v1.zarr"
+    FileSystem: "obs"
     Region: "eu-de"
     Style: default
     PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
-
-  - Identifier: local_1w
-    Title: OLCI weekly L3 cube for region SNS computed from local L2C cube
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: memory
-    Path: "resample_in_time.py"
-    Function: "compute_dataset"
-    InputDatasets: ["local"]
-    InputParameters:
-      period: "1W"
-      incl_stdev: True
-    Style: default
-    PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
-
-  - Identifier: remote_1w
-    Title: OLCI weekly L3 cube for region SNS computed from remote L2C cube
-    BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: memory
-    Path: "resample_in_time.py"
-    Function: "compute_dataset"
-    InputDatasets: ["remote"]
-    InputParameters:
-      period: "1W"
-      incl_stdev: True
-    Style: default
-    PlaceGroups:
-      - PlaceGroupRef: inside-cube
-      - PlaceGroupRef: outside-cube
+      - PlaceGroupRef: Sweden_SE_Lakes
+      - PlaceGroupRef: Sweden_SE_Bathing_Sites
 
 PlaceGroups:
-  - Identifier: inside-cube
-    Title: Points inside the cube
-    Path: "places/inside-cube.geojson"
-  - Identifier: outside-cube
-    Title: Points outside the cube
-    Path: "places/outside-cube.geojson"
+  - Identifier: Sweden_SE_Lakes
+    Title: "Svenska Sj\u00f6arna"
+    Path: "C:\\Users/Helge/IdeaProjects/xcube/data/places/Selected_Monitoring_Lakes_wgs84_reprojected.shp"
+    CharacterEncoding: utf-8
+    PropertyMapping:
+      label: "SJONAMN"
+      infoUrl: "URL_VISS"
+  - Identifier: Sweden_SE_Bathing_Sites
+    Title: "Sverige selected bathing sites"
+    Path: "C:\\Users/Helge/IdeaProjects/xcube/data/places/Selected_Bathing_Sites_reprojected.shp"
+    CharacterEncoding: utf-8
+    PropertyMapping:
+      label: "BADPLATS"
+      eu_id: "EU_ID"
 
 Styles:
   - Identifier: default
     ColorMappings:
-      conc_chl:
-        ColorBar: "plasma"
-        ValueRange: [0., 24.]
-      conc_tsm:
-        ColorBar: "PuBuGn"
+      chl_c2rcc:
+        ColorBar: "YlGn"
+        ValueRange: [0., 20.]
+      chl_mph:
+        ColorBar: "YlGn"
+        ValueRange: [0., 20.]
+      iop_adg:
+        ColorBar: "RdBu"
+        ValueRange: [0., 2.]
+      iop_agelb:
+        ColorBar: "RdPu"
+        ValueRange: [0., 2.]
+      kd_z90max:
+        ColorBar: "YlGn"
+        ValueRange: [0., 1.]
+      tsm_c2rcc:
+        ColorBar: "viridis"
         ValueRange: [0., 100.]
-      kd489:
-        ColorBar: "jet"
-        ValueRange: [0., 6.]
+      tur_nechad_665:
+        ColorBar: "inferno"
+        ValueRange: [0., 100.]
+      tur_nechad_865:
+        ColorBar: "plasma"
+        ValueRange: [0., 100.]
+      # min and max for the parameter below need to be adjusted! just placeholder values at the moment
+      c2rcc_secchi_depth_1:
+        ColorBar: "deep"
+        ValueRange: [0., 20.]
+      c2rcc_secchi_depth_2:
+        ColorBar: "deep"
+        ValueRange: [0, 20.]
+      c2rcc_secchi_depth_3:
+        ColorBar: "deep"
+        ValueRange: [0, 20.]
+      c2rcc_secchi_depth_4:
+        ColorBar: "deep"
+        ValueRange: [0, 20.]
+      immersed_cyanobacteria:
+        ColorBar: "Reds"
+        ValueRange: [0, 1.]
+      floating_cyanobacteria:
+        ColorBar: "Blues_alpha"
+        ValueRange: [0, 1.]
+      floating_vegetation:
+        ColorBar: "Greens_alpha"
+        ValueRange: [0, 1.]
+      chl_pitarch:
+        ColorBar: "gnuplot"
+        ValueRange: [0, 10.]
+
+#Styles:
+#  - Identifier: default
+#    ColorMappings:
+#      conc_chl:
+#        ColorBar: "plasma"
+#        ValueRange: [0., 24.]
+#      conc_tsm:
+#        ColorBar: "PuBuGn"
+#        ValueRange: [0., 100.]
+#      kd489:
+#        ColorBar: "jet"
+#        ValueRange: [0., 6.]
 
 ServiceProvider:
   ProviderName: "Brockmann Consult GmbH"
@@ -98,3 +109,4 @@ ServiceProvider:
         PostalCode: "21502"
         Country: "Germany"
         ElectronicMailAddress: "norman.fomferra@brockmann-consult.de"
+

--- a/xcube/webapi/res/demo/config.yml
+++ b/xcube/webapi/res/demo/config.yml
@@ -1,96 +1,85 @@
 Datasets:
-  - Identifier: cyanoalert-olci-lswe-l2c-v1
-    Title: "Sverige Sj\u00f6ar 2018"
+  - Identifier: local
+    Title: "Local OLCI L2C cube for region SNS"
+    BoundingBox: [0.0, 50, 5.0, 52.5]
+    FileSystem: local
+    Path: cube-1-250-250.zarr
+    Style: default
+    TimeSeriesDataset: local_ts
+    PlaceGroups:
+      - PlaceGroupRef: inside-cube
+      - PlaceGroupRef: outside-cube
+
+  - Identifier: local_ts
+    Title: "'local' optimized for time-series"
+    BoundingBox: [0.0, 50, 5.0, 52.5]
+    FileSystem: local
+    Path: cube-5-100-200.zarr
+    Hidden: true
+    Style: default
+
+  - Identifier: remote
+    Title: Remote OLCI L2C cube for region SNS
+    BoundingBox: [0.0, 50, 5.0, 52.5]
+    FileSystem: obs
     Endpoint: "http://obs.eu-de.otc.t-systems.com"
-    Path: "cyanoalert/cyanoalert-olci-lswe-l2c-v1.zarr"
-    FileSystem: "obs"
+    Path: "dcs4cop-obs-01/OLCI-SNS-RAW-CUBE-2.zarr"
     Region: "eu-de"
     Style: default
     PlaceGroups:
-      - PlaceGroupRef: Sweden_SE_Lakes
-      - PlaceGroupRef: Sweden_SE_Bathing_Sites
+      - PlaceGroupRef: inside-cube
+      - PlaceGroupRef: outside-cube
+
+  - Identifier: local_1w
+    Title: OLCI weekly L3 cube for region SNS computed from local L2C cube
+    BoundingBox: [0.0, 50, 5.0, 52.5]
+    FileSystem: memory
+    Path: "resample_in_time.py"
+    Function: "compute_dataset"
+    InputDatasets: ["local"]
+    InputParameters:
+      period: "1W"
+      incl_stdev: True
+    Style: default
+    PlaceGroups:
+      - PlaceGroupRef: inside-cube
+      - PlaceGroupRef: outside-cube
+
+  - Identifier: remote_1w
+    Title: OLCI weekly L3 cube for region SNS computed from remote L2C cube
+    BoundingBox: [0.0, 50, 5.0, 52.5]
+    FileSystem: memory
+    Path: "resample_in_time.py"
+    Function: "compute_dataset"
+    InputDatasets: ["remote"]
+    InputParameters:
+      period: "1W"
+      incl_stdev: True
+    Style: default
+    PlaceGroups:
+      - PlaceGroupRef: inside-cube
+      - PlaceGroupRef: outside-cube
 
 PlaceGroups:
-  - Identifier: Sweden_SE_Lakes
-    Title: "Svenska Sj\u00f6arna"
-    Path: "C:\\Users/Helge/IdeaProjects/xcube/data/places/Selected_Monitoring_Lakes_wgs84_reprojected.shp"
-    CharacterEncoding: utf-8
-    PropertyMapping:
-      label: "SJONAMN"
-      infoUrl: "URL_VISS"
-  - Identifier: Sweden_SE_Bathing_Sites
-    Title: "Sverige selected bathing sites"
-    Path: "C:\\Users/Helge/IdeaProjects/xcube/data/places/Selected_Bathing_Sites_reprojected.shp"
-    CharacterEncoding: utf-8
-    PropertyMapping:
-      label: "BADPLATS"
-      eu_id: "EU_ID"
+  - Identifier: inside-cube
+    Title: Points inside the cube
+    Path: "places/inside-cube.geojson"
+  - Identifier: outside-cube
+    Title: Points outside the cube
+    Path: "places/outside-cube.geojson"
 
 Styles:
   - Identifier: default
     ColorMappings:
-      chl_c2rcc:
-        ColorBar: "YlGn"
-        ValueRange: [0., 20.]
-      chl_mph:
-        ColorBar: "YlGn"
-        ValueRange: [0., 20.]
-      iop_adg:
-        ColorBar: "RdBu"
-        ValueRange: [0., 2.]
-      iop_agelb:
-        ColorBar: "RdPu"
-        ValueRange: [0., 2.]
-      kd_z90max:
-        ColorBar: "YlGn"
-        ValueRange: [0., 1.]
-      tsm_c2rcc:
-        ColorBar: "viridis"
-        ValueRange: [0., 100.]
-      tur_nechad_665:
-        ColorBar: "inferno"
-        ValueRange: [0., 100.]
-      tur_nechad_865:
+      conc_chl:
         ColorBar: "plasma"
+        ValueRange: [0., 24.]
+      conc_tsm:
+        ColorBar: "PuBuGn"
         ValueRange: [0., 100.]
-      # min and max for the parameter below need to be adjusted! just placeholder values at the moment
-      c2rcc_secchi_depth_1:
-        ColorBar: "deep"
-        ValueRange: [0., 20.]
-      c2rcc_secchi_depth_2:
-        ColorBar: "deep"
-        ValueRange: [0, 20.]
-      c2rcc_secchi_depth_3:
-        ColorBar: "deep"
-        ValueRange: [0, 20.]
-      c2rcc_secchi_depth_4:
-        ColorBar: "deep"
-        ValueRange: [0, 20.]
-      immersed_cyanobacteria:
-        ColorBar: "Reds"
-        ValueRange: [0, 1.]
-      floating_cyanobacteria:
-        ColorBar: "Blues_alpha"
-        ValueRange: [0, 1.]
-      floating_vegetation:
-        ColorBar: "Greens_alpha"
-        ValueRange: [0, 1.]
-      chl_pitarch:
-        ColorBar: "gnuplot"
-        ValueRange: [0, 10.]
-
-#Styles:
-#  - Identifier: default
-#    ColorMappings:
-#      conc_chl:
-#        ColorBar: "plasma"
-#        ValueRange: [0., 24.]
-#      conc_tsm:
-#        ColorBar: "PuBuGn"
-#        ValueRange: [0., 100.]
-#      kd489:
-#        ColorBar: "jet"
-#        ValueRange: [0., 6.]
+      kd489:
+        ColorBar: "jet"
+        ValueRange: [0., 6.]
 
 ServiceProvider:
   ProviderName: "Brockmann Consult GmbH"
@@ -109,4 +98,3 @@ ServiceProvider:
         PostalCode: "21502"
         Country: "Germany"
         ElectronicMailAddress: "norman.fomferra@brockmann-consult.de"
-


### PR DESCRIPTION
Fixes part of https://github.com/dcs4cop/xcube-viewer/issues/49. Colours from
category Ocean would not show in the colour bar legend. The issue was that
these colours were not registered to the matplotlib colour map register.