### PR TITLE
Forman 132 wmts parsing error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,8 @@ xcube's organisation. (#49)
 
 ### Fixes
 
+* Fixed `xcube serve` issue with WMTS KVP method `GetTile` with query parameter `time` 
+  whose value can now also have the two forms `<start-date>/<end-date>` and just `<date>`. (#132) 
 * Fixed `xcube extract` regression that stopped working after Pandas update (#95) 
 * Fixed problem where CTRL+C didn't function anymore with `xcube serve`. (#87)
 * Fixed error `indexes along dimension 'y' are not equal` occurred when using 

--- a/test/webapi/controllers/test_tiles.py
+++ b/test/webapi/controllers/test_tiles.py
@@ -29,6 +29,10 @@ class TilesControllerTest(unittest.TestCase):
         self.assertIsInstance(tile, bytes)
 
         ctx = new_test_service_context()
+        tile = get_dataset_tile(ctx, 'demo', 'conc_tsm', '0', '0', '0', RequestParamsMock(time='2017-01-26/2017-01-27'))
+        self.assertIsInstance(tile, bytes)
+
+        ctx = new_test_service_context()
         tile = get_dataset_tile(ctx, 'demo', 'conc_tsm', '0', '0', '0', RequestParamsMock(time='current'))
         self.assertIsInstance(tile, bytes)
 

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -84,6 +84,36 @@ class HandlersTest(AsyncHTTPTestCase):
                                             '&TileCol=0')
         self.assertResponseOK(response)
 
+        # issue #132 by Dirk
+        response = self.fetch(self.prefix + '/wmts/kvp'
+                                            '?Service=WMTS'
+                                            '&Version=1.0.0'
+                                            '&Request=GetTile'
+                                            '&Format=image/png'
+                                            '&Style=Default'
+                                            '&Layer=demo.conc_chl'
+                                            '&TileMatrixSet=TileGrid_2000_1000'
+                                            '&TileMatrix=0'
+                                            '&TileRow=0'
+                                            '&TileCol=0'
+                                            '&Time=2017-01-25T09%3A35%3A50')
+        self.assertResponseOK(response)
+
+        # issue #132 by Dirk
+        response = self.fetch(self.prefix + '/wmts/kvp'
+                                            '?Service=WMTS'
+                                            '&Version=1.0.0'
+                                            '&Request=GetTile'
+                                            '&Format=image/png'
+                                            '&Style=Default'
+                                            '&Layer=demo.conc_chl'
+                                            '&TileMatrixSet=TileGrid_2000_1000'
+                                            '&TileMatrix=0'
+                                            '&TileRow=0'
+                                            '&TileCol=0'
+                                            '&Time=2017-01-25T09%3A35%3A50%2F2017-01-25T10%3A20%3A15')
+        self.assertResponseOK(response)
+
         response = self.fetch(self.prefix + '/wmts/kvp'
                                             '?Service=WMTS'
                                             '&Version=1.0.0'
@@ -122,6 +152,7 @@ class HandlersTest(AsyncHTTPTestCase):
                                             '&TileRow=0'
                                             '&TileCol=0')
         self.assertBadRequestResponse(response, 'Value for "layer" parameter must be "<dataset>.<variable>"')
+
 
     def test_fetch_wmts_capabilities(self):
         response = self.fetch(self.prefix + '/wmts/1.0.0/WMTSCapabilities.xml')

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -33,7 +33,6 @@ import s3fs
 import xarray as xr
 import zarr
 
-from xcube.api import assert_cube
 from .cache import MemoryCacheStore, Cache
 from .defaults import DEFAULT_CMAP_CBAR, DEFAULT_CMAP_VMIN, DEFAULT_CMAP_VMAX, DEFAULT_TRACE_PERF
 from .errors import ServiceConfigError, ServiceError, ServiceBadRequestError, ServiceResourceNotFoundError
@@ -41,6 +40,7 @@ from .im import TileGrid
 from .mldataset import FileStorageMultiLevelDataset, BaseMultiLevelDataset, MultiLevelDataset, \
     ComputedMultiLevelDataset, ObjectStorageMultiLevelDataset
 from .reqparams import RequestParams
+from ..api import assert_cube
 from ..util.dsio import guess_dataset_format, FORMAT_NAME_NETCDF4, FORMAT_NAME_ZARR
 from ..util.perf import measure_time
 from ..version import version
@@ -417,9 +417,16 @@ class ServiceContext:
                 elif np.issubdtype(coord_var.dtype, np.integer):
                     var_indexers[dim_name] = int(dim_value_str)
                 elif np.issubdtype(coord_var.dtype, np.datetime64):
-                    var_indexers[dim_name] = pd.to_datetime(dim_value_str)
+                    if '/' in dim_value_str:
+                        date_str_1, date_str_2 = dim_value_str.split('/', maxsplit=1)
+                        var_indexer_1 = pd.to_datetime(date_str_1)
+                        var_indexer_2 = pd.to_datetime(date_str_2)
+                        var_indexers[dim_name] = var_indexer_1 + (var_indexer_2 - var_indexer_1) / 2
+                    else:
+                        date_str = dim_value_str
+                        var_indexers[dim_name] = pd.to_datetime(date_str)
                 else:
-                    raise ValueError(f'unable to dimension value {dim_value_str!r} to {coord_var.dtype!r}')
+                    raise ValueError(f'unable to convert value {dim_value_str!r} to {coord_var.dtype!r}')
             except ValueError as e:
                 raise ServiceBadRequestError(
                     f'{dim_value_str!r} is not a valid value for dimension {dim_name!r} '


### PR DESCRIPTION
Fixed `xcube serve` issue with WMTS KVP method `GetTile` with query parameter `time` 
whose value can now also have the two forms `<start-date>/<end-date>` and just `<date>`. 

Closes #132