### PR TITLE
fixed memory problem with new mask_dataset_by_geometry()

### DIFF
--- a/xcube/util/geom.py
+++ b/xcube/util/geom.py
@@ -93,7 +93,7 @@ def mask_dataset_by_geometry(dataset: xr.Dataset,
         var = dataset[var_name]
         masked_vars[var_name] = var.where(mask)
 
-    masked_dataset = dataset.copy(data=masked_vars)
+    masked_dataset = xr.Dataset(masked_vars, coords=dataset.coords, attrs=dataset.attrs)
 
     _save_geometry_mask(masked_dataset, mask, save_geometry_mask)
     _save_geometry_wkt(masked_dataset, intersection_geometry, save_geometry_wkt)


### PR DESCRIPTION
Effectively only one line of code has changed, but that makes a big difference. 

Using method `dataset_copy = dataset.copy(data=<dict>)` will create a shallow `dataset` copy, but then it will literally *copy* all data from `data` into variables of `dataset_copy`, hence turning Dask arrays in `data` into numpy arrays in `dataset_copy`. Bang!   

**Last one to accept this PR should also merge immediately**