### PR TITLE
Forman add maskset to api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 
+* `xcube.api` now exports the `MaskSet` class which is useful for decoding flag values encoding following the
+  [CF conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#flags).
 * Added new CLI tool `xcube optimize` and API function `xcube.api.optimize_dataset` 
   optimizes data cubes for cloud object storage deployment. (#141)
 * Added two new spatial dataset operations to Python API `xcube.api` (#148):

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -3,13 +3,13 @@ import unittest
 import xarray as xr
 
 from test.sampledata import new_test_dataset
-from xcube.api.api import XCubeAPI
+from xcube.api.api import XCubeDatasetAccessor
 
 
-class XCubeAPITest(unittest.TestCase):
+class XCubeDatasetAccessorTest(unittest.TestCase):
     # noinspection PyMethodMayBeStatic
     def test_init(self):
-        XCubeAPI(xr.Dataset())
+        XCubeDatasetAccessor(xr.Dataset())
 
     def test_installed(self):
         self.assertTrue(hasattr(xr.Dataset, "xcube"))

--- a/xcube/api/__init__.py
+++ b/xcube/api/__init__.py
@@ -1,7 +1,6 @@
 # Force loading of xarray
 # noinspection PyUnresolvedReferences
 import xcube.api.api
-
 from .dump import dump_dataset
 from .extract import DEFAULT_INDEX_NAME_PATTERN, DEFAULT_INTERP_POINT_METHOD, DEFAULT_REF_NAME_PATTERN, \
     get_cube_point_indexes, get_cube_values_for_indexes, get_cube_values_for_points, get_dataset_indexes
@@ -18,6 +17,8 @@ from .verify import assert_cube, verify_cube
 from ..util.chunk import chunk_dataset
 # noinspection PyUnresolvedReferences
 from ..util.geom import clip_dataset_by_geometry, mask_dataset_by_geometry, convert_geometry
+# noinspection PyUnresolvedReferences
+from ..util.maskset import MaskSet
 # noinspection PyUnresolvedReferences
 from ..util.optimize import optimize_dataset
 # noinspection PyUnresolvedReferences

--- a/xcube/api/__init__.py
+++ b/xcube/api/__init__.py
@@ -1,4 +1,7 @@
-from .api import XCubeAPI
+# Force loading of xarray
+# noinspection PyUnresolvedReferences
+import xcube.api.api
+
 from .dump import dump_dataset
 from .extract import DEFAULT_INDEX_NAME_PATTERN, DEFAULT_INTERP_POINT_METHOD, DEFAULT_REF_NAME_PATTERN, \
     get_cube_point_indexes, get_cube_values_for_indexes, get_cube_values_for_points, get_dataset_indexes

--- a/xcube/api/api.py
+++ b/xcube/api/api.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from xcube.util.chunk import chunk_dataset
 # noinspection PyUnresolvedReferences
 from .compute import compute_dataset
 from .dump import dump_dataset
@@ -18,10 +17,13 @@ from .readwrite import read_cube, open_cube, write_cube
 from .select import select_vars
 from .vars_to_dim import vars_to_dim
 from .verify import verify_cube
+from ..util.chunk import chunk_dataset
+# noinspection PyUnresolvedReferences
+from ..util.maskset import MaskSet
 
 
 @xr.register_dataset_accessor('xcube')
-class XCubeAPI:
+class XCubeDatasetAccessor:
     """
     The XCube API.
 
@@ -293,19 +295,3 @@ class XCubeAPI:
         :return: A list of dataset instances representing the multi-level pyramid.
         """
         return compute_levels(self._dataset, **kwargs)
-
-    def resample_in_time(self):
-        """
-        Resample a data cube in the time dimension.
-
-        :param frequency: Resampling frequency.
-        :param method: Resampling method or sequence of resampling methods.
-        :param offset: Offset used to adjust the resampled time labels. Some pandas date offset strings are supported.
-        :param base: Resampling method.
-        :param var_names: Variable names to include.
-        :param tolerance: Time tolerance for selective upsampling methods. Defaults to *frequency*.
-        :param interp_kind: Kind of interpolation if *method* is 'interpolation'.
-        :param metadata: Output metadata.
-        :return: A new data cube resampled in time.
-        """
-        return resample_in_time()

--- a/xcube/api/api.py
+++ b/xcube/api/api.py
@@ -18,8 +18,6 @@ from .select import select_vars
 from .vars_to_dim import vars_to_dim
 from .verify import verify_cube
 from ..util.chunk import chunk_dataset
-# noinspection PyUnresolvedReferences
-from ..util.maskset import MaskSet
 
 
 @xr.register_dataset_accessor('xcube')

--- a/xcube/util/maskset.py
+++ b/xcube/util/maskset.py
@@ -19,7 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, Any
+from typing import Dict, Any, Iterable
 
 import numpy as np
 import xarray as xr
@@ -91,6 +91,9 @@ class MaskSet:
 
     def __str__(self):
         return "%s(%s)" % (self._flag_var.name, ', '.join(["%s=%s" % (n, v) for n, v in self._flags.items()]))
+
+    def __dir__(self) -> Iterable[str]:
+        return self._flag_names
 
     def __getattr__(self, name: str) -> Any:
         if name not in self._flags:


### PR DESCRIPTION
This PR lets `xcube.api` export `xcube.util.maskset.MaskSet` so we can use it in NBs.
Added tests for Sentinel-2 L2A SCL flags.