### PR TITLE
Forman ts web api fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,10 @@
   in the cube. Useful for testing.
 
 ### Fixes
-
+* `totalCount` attribute of time series returned by Web API `ts/{dataset}/{variable}/{geom-type}` now
+   contains the correct number of possible observations. Was always `1` before.
+* Renamed Web API function `ts/{dataset}/{variable}/places` into
+  `ts/{dataset}/{variable}/features`.
 * `xcube gen` is now taking care that when new time slices are added to an existing
    cube, this is done by maintaining the chronological order. New time slices are
    either appended, inserted, or replaced. (#64) (#139)

--- a/test/webapi/controllers/test_time_series.py
+++ b/test/webapi/controllers/test_time_series.py
@@ -115,18 +115,24 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    ]]))
         expected_dict = {'results': [{'date': '2017-01-16T10:09:22Z',
                                       'result': {'average': 56.12519223634024,
-                                                 'totalCount': 1,
+                                                 'totalCount': 159600,
                                                  'validCount': 122392}},
                                      {'date': '2017-01-25T09:35:51Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                      'result': {'average': None,
+                                                 'totalCount': 159600,
+                                                 'validCount': 0}},
                                      {'date': '2017-01-26T10:50:17Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                      'result': {'average': None,
+                                                 'totalCount': 159600,
+                                                 'validCount': 0}},
                                      {'date': '2017-01-28T09:58:11Z',
                                       'result': {'average': 49.70755256053988,
-                                                 'totalCount': 1,
+                                                 'totalCount': 159600,
                                                  'validCount': 132066}},
                                      {'date': '2017-01-30T10:46:34Z',
-                                      'result': {'average': None, 'totalCount': 1, 'validCount': 0}}]}
+                                      'result': {'average': None,
+                                                 'totalCount': 159600,
+                                                 'validCount': 0}}]}
 
         self.assertEqual(expected_dict, time_series)
 
@@ -138,7 +144,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    ]]), max_valids=1)
         expected_dict = {'results': [{'date': '2017-01-28T09:58:11Z',
                                       'result': {'average': 49.70755256053988,
-                                                 'totalCount': 1,
+                                                 'totalCount': 159600,
                                                  'validCount': 132066}}]}
 
         self.assertEqual(expected_dict, time_series)
@@ -151,11 +157,11 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    ]]), max_valids=-1)
         expected_dict = {'results': [{'date': '2017-01-16T10:09:22Z',
                                       'result': {'average': 56.12519223634024,
-                                                 'totalCount': 1,
+                                                 'totalCount': 159600,
                                                  'validCount': 122392}},
                                      {'date': '2017-01-28T09:58:11Z',
                                       'result': {'average': 49.70755256053988,
-                                                 'totalCount': 1,
+                                                 'totalCount': 159600,
                                                  'validCount': 132066}}]}
 
         self.assertEqual(expected_dict, time_series)
@@ -194,18 +200,24 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                                    ]])]))
         expected_dict = {'results': [[{'date': '2017-01-16T10:09:22Z',
                                        'result': {'average': 56.12519223634024,
-                                                  'totalCount': 1,
+                                                  'totalCount': 159600,
                                                   'validCount': 122392}},
                                       {'date': '2017-01-25T09:35:51Z',
-                                       'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                       'result': {'average': None,
+                                                  'totalCount': 159600,
+                                                  'validCount': 0}},
                                       {'date': '2017-01-26T10:50:17Z',
-                                       'result': {'average': None, 'totalCount': 1, 'validCount': 0}},
+                                       'result': {'average': None,
+                                                  'totalCount': 159600,
+                                                  'validCount': 0}},
                                       {'date': '2017-01-28T09:58:11Z',
                                        'result': {'average': 49.70755256053988,
-                                                  'totalCount': 1,
+                                                  'totalCount': 159600,
                                                   'validCount': 132066}},
                                       {'date': '2017-01-30T10:46:34Z',
-                                       'result': {'average': None, 'totalCount': 1, 'validCount': 0}}]]}
+                                       'result': {'average': None,
+                                                  'totalCount': 159600,
+                                                  'validCount': 0}}]]}
 
         self.assertEqual(expected_dict, time_series)
 

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -348,7 +348,7 @@ class HandlersTest(AsyncHTTPTestCase):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='')
         self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON feature collection in request body')
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/places', method="POST",
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='{"type":"Point"}')
         self.assertBadRequestResponse(response, 'Invalid GeoJSON feature collection')
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -345,19 +345,19 @@ class HandlersTest(AsyncHTTPTestCase):
         self.assertResponseOK(response)
 
     def test_fetch_time_series_features(self):
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/places', method="POST",
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='')
         self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON feature collection in request body')
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/places', method="POST",
                               body='{"type":"Point"}')
         self.assertBadRequestResponse(response, 'Invalid GeoJSON feature collection')
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/places', method="POST",
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='{"type": "FeatureCollection", "features": null}')
         self.assertResponseOK(response)
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/places', method="POST",
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='{"type": "FeatureCollection", "features": []}')
         self.assertResponseOK(response)
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/places', method="POST",
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='{"type": "FeatureCollection", "features": ['
                                    '  {"type": "Feature", "properties": {}, '
                                    '   "geometry": {"type": "Point", "coordinates": [1, 51]}}'

--- a/xcube/webapi/app.py
+++ b/xcube/webapi/app.py
@@ -111,7 +111,7 @@ def new_application(prefix: str = None):
          GetTimeSeriesForGeometryHandler),
         (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/geometries'),
          GetTimeSeriesForGeometriesHandler),
-        (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/places'),
+        (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/features'),
          GetTimeSeriesForFeaturesHandler),
     ])
     return application

--- a/xcube/webapi/controllers/time_series.py
+++ b/xcube/webapi/controllers/time_series.py
@@ -282,7 +282,7 @@ def _collect_ts_result(ts_ds: xr.Dataset,
     uncert_var = ts_ds[uncert_var_name] if uncert_var_name else None
     count_var = ts_ds[count_var_name] if count_var_name else None
 
-    total_count = ts_ds.get('max_number_of_observations', 1)
+    total_count = ts_ds.attrs.get('max_number_of_observations', 1)
 
     num_times = var.time.size
     time_series = []

--- a/xcube/webapi/res/demo/places/inside-cube.geojson
+++ b/xcube/webapi/res/demo/places/inside-cube.geojson
@@ -48,6 +48,25 @@
         "Sub_Region_Name": "Inside",
         "Region_Name": "Belgium"
       }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [2.088774, 51.275067],
+          [2.876289, 51.275067],
+          [2.876289, 51.703104],
+          [2.088774, 51.703104],
+          [2.088774, 51.275067]
+        ]]
+      },
+      "properties": {
+        "Name": "Area 1",
+        "ID": "0",
+        "Sub_Region_Name": "Inside",
+        "Region_Name": "Belgium"
+      }
     }
   ]
 }


### PR DESCRIPTION
* `totalCount` attribute of time series returned by Web API `ts/{dataset}/{variable}/{geom-type}` now contains the correct number of possible observations. Was always `1` before.
* Renamed Web API function `ts/{dataset}/{variable}/places` into `ts/{dataset}/{variable}/features`.
* Added polygon to demo config for testing.