### PR TITLE
Dzelge 94 warnings 3rd party

### DIFF
--- a/test/api/gen/default/test_gen.py
+++ b/test/api/gen/default/test_gen.py
@@ -44,7 +44,8 @@ class DefaultProcessTest(unittest.TestCase):
             self.assertTrue('\nstep 8 of 8: creating input slice in l2c.nc...\n' in output)
             self.assertTrue('\nstep 8 of 8: appending input slice to l2c.nc...\n' in output)
 
-            # Ignoring warning Variable 'time' has datetime type and a bounds variable but time.encoding does not have units specified...
+            # Ignoring warning Variable 'time' has datetime type and a bounds variable but time.encoding
+            # does not have units specified...
             # TODO: Find out why this happens
             for w in warning.warnings:
                 self.assertTrue("has datetime type and a bounds variable but time.encoding does" in str(w.message))

--- a/test/api/gen/default/test_gen.py
+++ b/test/api/gen/default/test_gen.py
@@ -34,13 +34,20 @@ class DefaultProcessTest(unittest.TestCase):
         self.assertEqual(True, status)
         self.assertTrue('\nstep 8 of 8: creating input slice in l2c-single.nc...\n' in output)
 
+    # noinspection PyUnresolvedReferences
     def test_process_inputs_append_multiple_nc(self):
-        status, output = gen_cube_wrapper(
-            [get_inputdata_path('201701??-IFR-L4_GHRSST-SSTfnd-ODYSSEA-NWE_002-v2.0-fv1.0.nc')], 'l2c.nc',
-            sort_mode=True)
-        self.assertEqual(True, status)
-        self.assertTrue('\nstep 8 of 8: creating input slice in l2c.nc...\n' in output)
-        self.assertTrue('\nstep 8 of 8: appending input slice to l2c.nc...\n' in output)
+        with self.assertWarns(UserWarning) as warning:
+            status, output = gen_cube_wrapper(
+                [get_inputdata_path('201701??-IFR-L4_GHRSST-SSTfnd-ODYSSEA-NWE_002-v2.0-fv1.0.nc')], 'l2c.nc',
+                sort_mode=True)
+            self.assertEqual(True, status)
+            self.assertTrue('\nstep 8 of 8: creating input slice in l2c.nc...\n' in output)
+            self.assertTrue('\nstep 8 of 8: appending input slice to l2c.nc...\n' in output)
+
+            # Ignoring warning Variable 'time' has datetime type and a bounds variable but time.encoding does not have units specified...
+            # TODO: Find out why this happens
+            for w in warning.warnings:
+                self.assertTrue("has datetime type and a bounds variable but time.encoding does" in str(w.message))
 
     def test_process_inputs_append_multiple_zarr(self):
         status, output = gen_cube_wrapper(
@@ -96,7 +103,7 @@ class DefaultProcessTest(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             gen_cube_wrapper(
                 [get_inputdata_path('20170101120000-UKMO-L4_GHRSST-SSTfnd-OSTIAanom-GLOB-v02.0-fv02.0.nc')],
-                'l2c-single.zarr', sort_mode=True, input_processor_name=None)
+                'l2c-single.zarr', sort_mode=True, input_processor_name="")
         self.assertEqual('Missing input_processor_name', f'{e.exception}')
 
         with self.assertRaises(ValueError) as e:

--- a/test/api/gen/default/test_gen.py
+++ b/test/api/gen/default/test_gen.py
@@ -27,28 +27,19 @@ class DefaultProcessTest(unittest.TestCase):
     def tearDown(self):
         clean_up()
 
-    # noinspection PyMethodMayBeStatic
     def test_process_inputs_single(self):
         status, output = gen_cube_wrapper(
             [get_inputdata_path('20170101-IFR-L4_GHRSST-SSTfnd-ODYSSEA-NWE_002-v2.0-fv1.0.nc')], 'l2c-single.nc')
         self.assertEqual(True, status)
         self.assertTrue('\nstep 8 of 8: creating input slice in l2c-single.nc...\n' in output)
 
-    # noinspection PyUnresolvedReferences
     def test_process_inputs_append_multiple_nc(self):
-        with self.assertWarns(UserWarning) as warning:
-            status, output = gen_cube_wrapper(
-                [get_inputdata_path('201701??-IFR-L4_GHRSST-SSTfnd-ODYSSEA-NWE_002-v2.0-fv1.0.nc')], 'l2c.nc',
-                sort_mode=True)
-            self.assertEqual(True, status)
-            self.assertTrue('\nstep 8 of 8: creating input slice in l2c.nc...\n' in output)
-            self.assertTrue('\nstep 8 of 8: appending input slice to l2c.nc...\n' in output)
-
-            # Ignoring warning Variable 'time' has datetime type and a bounds variable but time.encoding
-            # does not have units specified...
-            # TODO: Find out why this happens
-            for w in warning.warnings:
-                self.assertTrue("has datetime type and a bounds variable but time.encoding does" in str(w.message))
+        status, output = gen_cube_wrapper(
+            [get_inputdata_path('201701??-IFR-L4_GHRSST-SSTfnd-ODYSSEA-NWE_002-v2.0-fv1.0.nc')], 'l2c.nc',
+            sort_mode=True)
+        self.assertEqual(True, status)
+        self.assertTrue('\nstep 8 of 8: creating input slice in l2c.nc...\n' in output)
+        self.assertTrue('\nstep 8 of 8: appending input slice to l2c.nc...\n' in output)
 
     def test_process_inputs_append_multiple_zarr(self):
         status, output = gen_cube_wrapper(

--- a/test/api/gen/default/test_iproc.py
+++ b/test/api/gen/default/test_iproc.py
@@ -74,8 +74,9 @@ def create_default_dataset(time_mode: str = "time_bnds"):
     res = 180. / h
     lon = np.linspace(-180 + 0.5 * res, 180 - 0.5 * res, w)
     lat = np.linspace(-90 + 0.5 * res, 90 - 0.5 * res, h)
-    time = np.array([pd.to_datetime("20100301T120000Z")])
-    time_bnds = np.array([[pd.to_datetime("20100301T000000Z"), pd.to_datetime("20100301T235959Z")]])
+    time = np.array([pd.to_datetime("20100301T120000")], dtype="datetime64[ns]")
+    time_bnds = np.array([[pd.to_datetime("20100301T000000"), pd.to_datetime("20100301T235959")]],
+                         dtype="datetime64[ns]")
 
     coords = dict(
         lon=(("lon",), lon, dict(long_name="longitude", units="degrees_east")),

--- a/test/cli/test_timeit.py
+++ b/test/cli/test_timeit.py
@@ -3,7 +3,6 @@ import os
 from test.cli.helpers import CliDataTest
 
 
-# noinspection PyUnresolvedReferences
 class TimeitCliTest(CliDataTest):
 
     def test_help_option(self):
@@ -21,18 +20,12 @@ class TimeitCliTest(CliDataTest):
         self.assertTrue('\n1;test.nc;' in result.stdout, msg=msg)
 
     def test_simple_with_repetitions(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            config_path = os.path.join(os.path.dirname(__file__), 'timeit-configs', 'simple.yml')
-            result = self.invoke_cli(['timeit', '--repeats', 3, config_path])
-            msg = f'actual output:\n{result.stdout}'
+        config_path = os.path.join(os.path.dirname(__file__), 'timeit-configs', 'simple.yml')
+        result = self.invoke_cli(['timeit', '--repeats', 3, config_path])
+        msg = f'actual output:\n{result.stdout}'
 
-            allowed = ("Mean of empty slice", "All-NaN slice encountered", "Degrees of freedom <= 0 for slice.")
-            for w in warning.warnings:
-                can_ignore = str(w.message) in allowed
-                self.assertTrue(can_ignore)
-
-            self.assertTrue('# command template: xcube dump ${input}\n' in result.stdout, msg=msg)
-            self.assertTrue('\n# repetition count: 3\n' in result.stdout, msg=msg)
-            self.assertTrue('\nid;input;time-mean;time-median;time-stdev;time-min;time-max\n' in result.stdout, msg=msg)
-            self.assertTrue('\n0;test.zarr;' in result.stdout, msg=msg)
-            self.assertTrue('\n1;test.nc;' in result.stdout, msg=msg)
+        self.assertTrue('# command template: xcube dump ${input}\n' in result.stdout, msg=msg)
+        self.assertTrue('\n# repetition count: 3\n' in result.stdout, msg=msg)
+        self.assertTrue('\nid;input;time-mean;time-median;time-stdev;time-min;time-max\n' in result.stdout, msg=msg)
+        self.assertTrue('\n0;test.zarr;' in result.stdout, msg=msg)
+        self.assertTrue('\n1;test.nc;' in result.stdout, msg=msg)

--- a/test/cli/test_timeit.py
+++ b/test/cli/test_timeit.py
@@ -3,6 +3,7 @@ import os
 from test.cli.helpers import CliDataTest
 
 
+# noinspection PyUnresolvedReferences
 class TimeitCliTest(CliDataTest):
 
     def test_help_option(self):
@@ -20,11 +21,18 @@ class TimeitCliTest(CliDataTest):
         self.assertTrue('\n1;test.nc;' in result.stdout, msg=msg)
 
     def test_simple_with_repetitions(self):
-        config_path = os.path.join(os.path.dirname(__file__), 'timeit-configs', 'simple.yml')
-        result = self.invoke_cli(['timeit', '--repeats', 3, config_path])
-        msg = f'actual output:\n{result.stdout}'
-        self.assertTrue('# command template: xcube dump ${input}\n' in result.stdout, msg=msg)
-        self.assertTrue('\n# repetition count: 3\n' in result.stdout, msg=msg)
-        self.assertTrue('\nid;input;time-mean;time-median;time-stdev;time-min;time-max\n' in result.stdout, msg=msg)
-        self.assertTrue('\n0;test.zarr;' in result.stdout, msg=msg)
-        self.assertTrue('\n1;test.nc;' in result.stdout, msg=msg)
+        with self.assertWarns(RuntimeWarning) as warning:
+            config_path = os.path.join(os.path.dirname(__file__), 'timeit-configs', 'simple.yml')
+            result = self.invoke_cli(['timeit', '--repeats', 3, config_path])
+            msg = f'actual output:\n{result.stdout}'
+
+            allowed = ("Mean of empty slice", "All-NaN slice encountered", "Degrees of freedom <= 0 for slice.")
+            for w in warning.warnings:
+                can_ignore = str(w.message) in allowed
+                self.assertTrue(can_ignore)
+
+            self.assertTrue('# command template: xcube dump ${input}\n' in result.stdout, msg=msg)
+            self.assertTrue('\n# repetition count: 3\n' in result.stdout, msg=msg)
+            self.assertTrue('\nid;input;time-mean;time-median;time-stdev;time-min;time-max\n' in result.stdout, msg=msg)
+            self.assertTrue('\n0;test.zarr;' in result.stdout, msg=msg)
+            self.assertTrue('\n1;test.nc;' in result.stdout, msg=msg)

--- a/test/util/test_config.py
+++ b/test/util/test_config.py
@@ -190,7 +190,7 @@ class FlattenDictTest(unittest.TestCase):
 
     def test_from_yaml(self):
         stream = StringIO(TEST_JSON)
-        d = yaml.load(stream)
+        d = yaml.full_load(stream)
         d = flatten_dict(d['output_metadata'])
         self.assertEqual(17, len(d))
         self.assertEqual('DCS4COP Sentinel-3 OLCI L2C Data Cube',
@@ -352,7 +352,7 @@ def _create_temp_yaml(temp_path_for_yaml, config_file_name, config_yaml):
             print("Successfully created the directory %s " % temp_path_for_yaml)
             yaml_path = os.path.join(temp_path_for_yaml, config_file_name)
             with open(yaml_path, 'w') as outfile:
-                yaml.dump(yaml.load(config_yaml), outfile)
+                yaml.dump(yaml.full_load(config_yaml), outfile)
             return yaml_path
 
     else:

--- a/test/util/test_plugin.py
+++ b/test/util/test_plugin.py
@@ -43,27 +43,25 @@ class PluginTest(unittest.TestCase):
         self.assertEqual(True, PLUGIN_INIT)
 
     def test_load_plugins_fail_load(self):
-        with warnings.catch_warnings(record=True) as warning:
-            warnings.simplefilter("always")
-
+        with self.assertWarns(Warning) as warning:
             plugins = load_plugins([BadEntryPoint('test', init_plugin_and_succeed)])
 
-            self.assertEqual(len(warning), 1)
+            self.assertEqual(len(warning.warnings), 1)
             self.assertEqual({}, plugins)
 
     def test_load_plugins_fail_call(self):
-        with warnings.catch_warnings(record=True) as warning:
-            warnings.simplefilter("always")
+        with self.assertWarns(Warning) as warning:
             plugins = load_plugins([EntryPoint('test', init_plugin_but_fail)])
 
-            self.assertEqual(len(warning), 1)
+            self.assertEqual(len(warning.warnings), 1)
             self.assertEqual({}, plugins)
 
     def test_load_plugins_not_callable(self):
-        with warnings.catch_warnings(record=True) as warning:
-            warnings.simplefilter("always")
+        with self.assertWarns(Warning) as warning:
             expected = "xcube plugin with entry point 'test' must be a callable but got a <class 'str'>"
+
             plugins = load_plugins([EntryPoint('test', "init_plugin_and_succeed")])
-            self.assertEqual(len(warning), 1)
-            self.assertEqual(expected, str(warning[0].message))
+
+            self.assertEqual(len(warning.warnings), 1)
+            self.assertEqual(expected, str(warning.warnings[0].message))
             self.assertEqual({}, plugins)

--- a/test/util/test_plugin.py
+++ b/test/util/test_plugin.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 from xcube.util.plugin import get_plugins, load_plugins
 
@@ -30,6 +29,7 @@ class BadEntryPoint(EntryPoint):
         raise RuntimeError()
 
 
+# noinspection PyUnresolvedReferences
 class PluginTest(unittest.TestCase):
 
     def test_get_plugins(self):

--- a/test/util/test_plugin.py
+++ b/test/util/test_plugin.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from xcube.util.plugin import get_plugins, load_plugins
 
@@ -42,13 +43,27 @@ class PluginTest(unittest.TestCase):
         self.assertEqual(True, PLUGIN_INIT)
 
     def test_load_plugins_fail_load(self):
-        plugins = load_plugins([BadEntryPoint('test', init_plugin_and_succeed)])
-        self.assertEqual({}, plugins)
+        with warnings.catch_warnings(record=True) as warning:
+            warnings.simplefilter("always")
+
+            plugins = load_plugins([BadEntryPoint('test', init_plugin_and_succeed)])
+
+            self.assertEqual(len(warning), 1)
+            self.assertEqual({}, plugins)
 
     def test_load_plugins_fail_call(self):
-        plugins = load_plugins([EntryPoint('test', init_plugin_but_fail)])
-        self.assertEqual({}, plugins)
+        with warnings.catch_warnings(record=True) as warning:
+            warnings.simplefilter("always")
+            plugins = load_plugins([EntryPoint('test', init_plugin_but_fail)])
+
+            self.assertEqual(len(warning), 1)
+            self.assertEqual({}, plugins)
 
     def test_load_plugins_not_callable(self):
-        plugins = load_plugins([EntryPoint('test', "init_plugin_and_succeed")])
-        self.assertEqual({}, plugins)
+        with warnings.catch_warnings(record=True) as warning:
+            warnings.simplefilter("always")
+            expected = "xcube plugin with entry point 'test' must be a callable but got a <class 'str'>"
+            plugins = load_plugins([EntryPoint('test', "init_plugin_and_succeed")])
+            self.assertEqual(len(warning), 1)
+            self.assertEqual(expected, str(warning[0].message))
+            self.assertEqual({}, plugins)

--- a/test/util/test_plugin.py
+++ b/test/util/test_plugin.py
@@ -29,7 +29,6 @@ class BadEntryPoint(EntryPoint):
         raise RuntimeError()
 
 
-# noinspection PyUnresolvedReferences
 class PluginTest(unittest.TestCase):
 
     def test_get_plugins(self):
@@ -43,25 +42,16 @@ class PluginTest(unittest.TestCase):
         self.assertEqual(True, PLUGIN_INIT)
 
     def test_load_plugins_fail_load(self):
-        with self.assertWarns(Warning) as warning:
-            plugins = load_plugins([BadEntryPoint('test', init_plugin_and_succeed)])
+        plugins = load_plugins([BadEntryPoint('test', init_plugin_and_succeed)])
 
-            self.assertEqual(len(warning.warnings), 1)
-            self.assertEqual({}, plugins)
+        self.assertEqual({}, plugins)
 
     def test_load_plugins_fail_call(self):
-        with self.assertWarns(Warning) as warning:
-            plugins = load_plugins([EntryPoint('test', init_plugin_but_fail)])
+        plugins = load_plugins([EntryPoint('test', init_plugin_but_fail)])
 
-            self.assertEqual(len(warning.warnings), 1)
-            self.assertEqual({}, plugins)
+        self.assertEqual({}, plugins)
 
     def test_load_plugins_not_callable(self):
-        with self.assertWarns(Warning) as warning:
-            expected = "xcube plugin with entry point 'test' must be a callable but got a <class 'str'>"
+        plugins = load_plugins([EntryPoint('test', "init_plugin_and_succeed")])
 
-            plugins = load_plugins([EntryPoint('test', "init_plugin_and_succeed")])
-
-            self.assertEqual(len(warning.warnings), 1)
-            self.assertEqual(expected, str(warning.warnings[0].message))
-            self.assertEqual({}, plugins)
+        self.assertEqual({}, plugins)

--- a/test/webapi/controllers/test_tiles.py
+++ b/test/webapi/controllers/test_tiles.py
@@ -84,28 +84,22 @@ class TilesControllerTest(unittest.TestCase):
         self.assertEqual(400, cm.exception.status_code)
         self.assertEqual('Unknown tile client "ol2.json"', cm.exception.reason)
 
-    # noinspection PyUnresolvedReferences
     def test_get_legend(self):
-        with self.assertWarns(Warning) as warning:
-            ctx = new_test_service_context()
-            image = get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock())
-            self.assertEqual("<class 'bytes'>", str(type(image)))
+        ctx = new_test_service_context()
+        image = get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock())
+        self.assertEqual("<class 'bytes'>", str(type(image)))
 
-            with self.assertRaises(ServiceResourceNotFoundError) as cm:
-                get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(cbar='sun-shine'))
-            self.assertEqual('color bar sun-shine not found', cm.exception.reason)
+        with self.assertRaises(ServiceResourceNotFoundError) as cm:
+            get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(cbar='sun-shine'))
+        self.assertEqual('color bar sun-shine not found', cm.exception.reason)
 
-            with self.assertRaises(ServiceBadRequestError) as cm:
-                get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(vmin='sun-shine'))
-            self.assertEqual("""Parameter "vmin" must be a number, but was 'sun-shine'""", cm.exception.reason)
+        with self.assertRaises(ServiceBadRequestError) as cm:
+            get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(vmin='sun-shine'))
+        self.assertEqual("""Parameter "vmin" must be a number, but was 'sun-shine'""", cm.exception.reason)
 
-            with self.assertRaises(ServiceBadRequestError) as cm:
-                get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(width='sun-shine'))
-            self.assertEqual("""Parameter "width" must be an integer, but was 'sun-shine'""", cm.exception.reason)
-
-            # Accepting this warning for the moment.Recipe to circumvent does not work: fig.set_tight_layout(True)
-            # instead of fig.tight_layout()
-            self.assertEqual("tight_layout : falling back to Agg renderer", str(warning.warnings[0].message))
+        with self.assertRaises(ServiceBadRequestError) as cm:
+            get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(width='sun-shine'))
+        self.assertEqual("""Parameter "width" must be an integer, but was 'sun-shine'""", cm.exception.reason)
 
     def test_get_ne2_tile_grid(self):
         ctx = ServiceContext()

--- a/test/webapi/controllers/test_tiles.py
+++ b/test/webapi/controllers/test_tiles.py
@@ -84,22 +84,28 @@ class TilesControllerTest(unittest.TestCase):
         self.assertEqual(400, cm.exception.status_code)
         self.assertEqual('Unknown tile client "ol2.json"', cm.exception.reason)
 
+    # noinspection PyUnresolvedReferences
     def test_get_legend(self):
-        ctx = new_test_service_context()
-        image = get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock())
-        self.assertEqual("<class 'bytes'>", str(type(image)))
+        with self.assertWarns(Warning) as warning:
+            ctx = new_test_service_context()
+            image = get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock())
+            self.assertEqual("<class 'bytes'>", str(type(image)))
 
-        with self.assertRaises(ServiceResourceNotFoundError) as cm:
-            get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(cbar='sun-shine'))
-        self.assertEqual('color bar sun-shine not found', cm.exception.reason)
+            with self.assertRaises(ServiceResourceNotFoundError) as cm:
+                get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(cbar='sun-shine'))
+            self.assertEqual('color bar sun-shine not found', cm.exception.reason)
 
-        with self.assertRaises(ServiceBadRequestError) as cm:
-            get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(vmin='sun-shine'))
-        self.assertEqual("""Parameter "vmin" must be a number, but was 'sun-shine'""", cm.exception.reason)
+            with self.assertRaises(ServiceBadRequestError) as cm:
+                get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(vmin='sun-shine'))
+            self.assertEqual("""Parameter "vmin" must be a number, but was 'sun-shine'""", cm.exception.reason)
 
-        with self.assertRaises(ServiceBadRequestError) as cm:
-            get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(width='sun-shine'))
-        self.assertEqual("""Parameter "width" must be an integer, but was 'sun-shine'""", cm.exception.reason)
+            with self.assertRaises(ServiceBadRequestError) as cm:
+                get_legend(ctx, 'demo', 'conc_chl', RequestParamsMock(width='sun-shine'))
+            self.assertEqual("""Parameter "width" must be an integer, but was 'sun-shine'""", cm.exception.reason)
+
+            # Accepting this warning for the moment.Recipe to circumvent does not work: fig.set_tight_layout(True)
+            # instead of fig.tight_layout()
+            self.assertEqual("tight_layout : falling back to Agg renderer", str(warning.warnings[0].message))
 
     def test_get_ne2_tile_grid(self):
         ctx = ServiceContext()

--- a/test/webapi/controllers/test_time_series.py
+++ b/test/webapi/controllers/test_time_series.py
@@ -7,6 +7,7 @@ from xcube.webapi.controllers.time_series import get_time_series_info, get_time_
 from ..helpers import new_test_service_context
 
 
+# noinspection PyUnresolvedReferences
 class TimeSeriesControllerTest(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -70,22 +71,25 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_point_with_uncertainty(self):
-        ctx = new_test_service_context()
-        actual_result = get_time_series_for_point(ctx, 'demo-1w', 'conc_tsm',
-                                                  lon=2.1, lat=51.4,
-                                                  start_date=np.datetime64('2017-01-15'),
-                                                  end_date=np.datetime64('2017-01-29'))
-        expected_result = {'results': [{'date': '2017-01-22T00:00:00Z',
-                                        'result': {'average': 3.534773588180542,
-                                                   'uncertainty': 0.0,
-                                                   'totalCount': 1,
-                                                   'validCount': 1}},
-                                       {'date': '2017-01-29T00:00:00Z',
-                                        'result': {'average': 20.12085723876953,
-                                                   'uncertainty': 0.0,
-                                                   'totalCount': 1,
-                                                   'validCount': 1}}]}
-        self.assertEqual(expected_result, actual_result)
+        with self.assertWarns(RuntimeWarning) as warning:
+            ctx = new_test_service_context()
+            actual_result = get_time_series_for_point(ctx, 'demo-1w', 'conc_tsm',
+                                                      lon=2.1, lat=51.4,
+                                                      start_date=np.datetime64('2017-01-15'),
+                                                      end_date=np.datetime64('2017-01-29'))
+            expected_result = {'results': [{'date': '2017-01-22T00:00:00Z',
+                                            'result': {'average': 3.534773588180542,
+                                                       'uncertainty': 0.0,
+                                                       'totalCount': 1,
+                                                       'validCount': 1}},
+                                           {'date': '2017-01-29T00:00:00Z',
+                                            'result': {'average': 20.12085723876953,
+                                                       'uncertainty': 0.0,
+                                                       'totalCount': 1,
+                                                       'validCount': 1}}]}
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_point(self):
         ctx = new_test_service_context()
@@ -109,104 +113,116 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon(self):
-        ctx = new_test_service_context()
-        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                     dict(type="Polygon", coordinates=[[
-                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                     ]]),
-                                                     include_count=True)
-        expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
-                                        'result': {'average': 56.12519223634024,
-                                                   'totalCount': 159600,
-                                                   'validCount': 122392}},
-                                       {'date': '2017-01-25T09:35:51Z',
-                                        'result': {'average': None,
-                                                   'totalCount': 159600,
-                                                   'validCount': 0}},
-                                       {'date': '2017-01-26T10:50:17Z',
-                                        'result': {'average': None,
-                                                   'totalCount': 159600,
-                                                   'validCount': 0}},
-                                       {'date': '2017-01-28T09:58:11Z',
-                                        'result': {'average': 49.70755256053988,
-                                                   'totalCount': 159600,
-                                                   'validCount': 132066}},
-                                       {'date': '2017-01-30T10:46:34Z',
-                                        'result': {'average': None,
-                                                   'totalCount': 159600,
-                                                   'validCount': 0}}]}
-        self.assertEqual(expected_result, actual_result)
+        with self.assertWarns(RuntimeWarning) as warning:
+            ctx = new_test_service_context()
+            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                         dict(type="Polygon", coordinates=[[
+                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                         ]]),
+                                                         include_count=True)
+            expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                            'result': {'average': 56.12519223634024,
+                                                       'totalCount': 159600,
+                                                       'validCount': 122392}},
+                                           {'date': '2017-01-25T09:35:51Z',
+                                            'result': {'average': None,
+                                                       'totalCount': 159600,
+                                                       'validCount': 0}},
+                                           {'date': '2017-01-26T10:50:17Z',
+                                            'result': {'average': None,
+                                                       'totalCount': 159600,
+                                                       'validCount': 0}},
+                                           {'date': '2017-01-28T09:58:11Z',
+                                            'result': {'average': 49.70755256053988,
+                                                       'totalCount': 159600,
+                                                       'validCount': 132066}},
+                                           {'date': '2017-01-30T10:46:34Z',
+                                            'result': {'average': None,
+                                                       'totalCount': 159600,
+                                                       'validCount': 0}}]}
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_with_stdev(self):
-        ctx = new_test_service_context()
-        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                     dict(type="Polygon", coordinates=[[
-                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                     ]]),
-                                                     include_count=True,
-                                                     include_stdev=True)
+        with self.assertWarns(RuntimeWarning) as warning:
+            ctx = new_test_service_context()
+            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                         dict(type="Polygon", coordinates=[[
+                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                         ]]),
+                                                         include_count=True,
+                                                         include_stdev=True)
 
-        expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
-                                        'result': {'average': 56.12519223634024,
-                                                   'totalCount': 159600,
-                                                   'uncertainty': 40.78859862094861,
-                                                   'validCount': 122392}},
-                                       {'date': '2017-01-25T09:35:51Z',
-                                        'result': {'average': None,
-                                                   'totalCount': 159600,
-                                                   'uncertainty': None,
-                                                   'validCount': 0}},
-                                       {'date': '2017-01-26T10:50:17Z',
-                                        'result': {'average': None,
-                                                   'totalCount': 159600,
-                                                   'uncertainty': None,
-                                                   'validCount': 0}},
-                                       {'date': '2017-01-28T09:58:11Z',
-                                        'result': {'average': 49.70755256053988,
-                                                   'totalCount': 159600,
-                                                   'uncertainty': 34.98868194514786,
-                                                   'validCount': 132066}},
-                                       {'date': '2017-01-30T10:46:34Z',
-                                        'result': {'average': None,
-                                                   'totalCount': 159600,
-                                                   'uncertainty': None,
-                                                   'validCount': 0}}]}
+            expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                            'result': {'average': 56.12519223634024,
+                                                       'totalCount': 159600,
+                                                       'uncertainty': 40.78859862094861,
+                                                       'validCount': 122392}},
+                                           {'date': '2017-01-25T09:35:51Z',
+                                            'result': {'average': None,
+                                                       'totalCount': 159600,
+                                                       'uncertainty': None,
+                                                       'validCount': 0}},
+                                           {'date': '2017-01-26T10:50:17Z',
+                                            'result': {'average': None,
+                                                       'totalCount': 159600,
+                                                       'uncertainty': None,
+                                                       'validCount': 0}},
+                                           {'date': '2017-01-28T09:58:11Z',
+                                            'result': {'average': 49.70755256053988,
+                                                       'totalCount': 159600,
+                                                       'uncertainty': 34.98868194514786,
+                                                       'validCount': 132066}},
+                                           {'date': '2017-01-30T10:46:34Z',
+                                            'result': {'average': None,
+                                                       'totalCount': 159600,
+                                                       'uncertainty': None,
+                                                       'validCount': 0}}]}
 
-        self.assertEqual(expected_result, actual_result)
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_one_valid(self):
-        ctx = new_test_service_context()
-        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                     dict(type="Polygon", coordinates=[[
-                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                     ]]),
-                                                     include_count=True,
-                                                     max_valids=1)
-        expected_result = {'results': [{'date': '2017-01-28T09:58:11Z',
-                                        'result': {'average': 49.70755256053988,
-                                                   'totalCount': 159600,
-                                                   'validCount': 132066}}]}
+        with self.assertWarns(RuntimeWarning) as warning:
+            ctx = new_test_service_context()
+            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                         dict(type="Polygon", coordinates=[[
+                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                         ]]),
+                                                         include_count=True,
+                                                         max_valids=1)
+            expected_result = {'results': [{'date': '2017-01-28T09:58:11Z',
+                                            'result': {'average': 49.70755256053988,
+                                                       'totalCount': 159600,
+                                                       'validCount': 132066}}]}
 
-        self.assertEqual(expected_result, actual_result)
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_only_valids(self):
-        ctx = new_test_service_context()
-        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                     dict(type="Polygon", coordinates=[[
-                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                     ]]),
-                                                     include_count=True,
-                                                     max_valids=-1)
-        expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
-                                        'result': {'average': 56.12519223634024,
-                                                   'totalCount': 159600,
-                                                   'validCount': 122392}},
-                                       {'date': '2017-01-28T09:58:11Z',
-                                        'result': {'average': 49.70755256053988,
-                                                   'totalCount': 159600,
-                                                   'validCount': 132066}}]}
+        with self.assertWarns(RuntimeWarning) as warning:
+            ctx = new_test_service_context()
+            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                         dict(type="Polygon", coordinates=[[
+                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                         ]]),
+                                                         include_count=True,
+                                                         max_valids=-1)
+            expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                            'result': {'average': 56.12519223634024,
+                                                       'totalCount': 159600,
+                                                       'validCount': 122392}},
+                                           {'date': '2017-01-28T09:58:11Z',
+                                            'result': {'average': 49.70755256053988,
+                                                       'totalCount': 159600,
+                                                       'validCount': 132066}}]}
 
-        self.assertEqual(expected_result, actual_result)
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometries_incl_point(self):
         ctx = new_test_service_context()
@@ -233,37 +249,40 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometries_incl_polygon(self):
-        ctx = new_test_service_context()
-        actual_result = get_time_series_for_geometry_collection(ctx,
-                                                                'demo', 'conc_tsm',
-                                                                dict(type="GeometryCollection",
-                                                                     geometries=[dict(type="Polygon", coordinates=[[
-                                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.],
-                                                                         [1., 51.]
-                                                                     ]])]),
-                                                                include_count=True)
-        expected_result = {'results': [[{'date': '2017-01-16T10:09:22Z',
-                                         'result': {'average': 56.12519223634024,
-                                                    'totalCount': 159600,
-                                                    'validCount': 122392}},
-                                        {'date': '2017-01-25T09:35:51Z',
-                                         'result': {'average': None,
-                                                    'totalCount': 159600,
-                                                    'validCount': 0}},
-                                        {'date': '2017-01-26T10:50:17Z',
-                                         'result': {'average': None,
-                                                    'totalCount': 159600,
-                                                    'validCount': 0}},
-                                        {'date': '2017-01-28T09:58:11Z',
-                                         'result': {'average': 49.70755256053988,
-                                                    'totalCount': 159600,
-                                                    'validCount': 132066}},
-                                        {'date': '2017-01-30T10:46:34Z',
-                                         'result': {'average': None,
-                                                    'totalCount': 159600,
-                                                    'validCount': 0}}]]}
+        with self.assertWarns(RuntimeWarning) as warning:
+            ctx = new_test_service_context()
+            actual_result = get_time_series_for_geometry_collection(ctx,
+                                                                    'demo', 'conc_tsm',
+                                                                    dict(type="GeometryCollection",
+                                                                         geometries=[dict(type="Polygon", coordinates=[[
+                                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.],
+                                                                             [1., 51.]
+                                                                         ]])]),
+                                                                    include_count=True)
+            expected_result = {'results': [[{'date': '2017-01-16T10:09:22Z',
+                                             'result': {'average': 56.12519223634024,
+                                                        'totalCount': 159600,
+                                                        'validCount': 122392}},
+                                            {'date': '2017-01-25T09:35:51Z',
+                                             'result': {'average': None,
+                                                        'totalCount': 159600,
+                                                        'validCount': 0}},
+                                            {'date': '2017-01-26T10:50:17Z',
+                                             'result': {'average': None,
+                                                        'totalCount': 159600,
+                                                        'validCount': 0}},
+                                            {'date': '2017-01-28T09:58:11Z',
+                                             'result': {'average': 49.70755256053988,
+                                                        'totalCount': 159600,
+                                                        'validCount': 132066}},
+                                            {'date': '2017-01-30T10:46:34Z',
+                                             'result': {'average': None,
+                                                        'totalCount': 159600,
+                                                        'validCount': 0}}]]}
 
-        self.assertEqual(expected_result, actual_result)
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_info(self):
         self.maxDiff = None

--- a/test/webapi/controllers/test_time_series.py
+++ b/test/webapi/controllers/test_time_series.py
@@ -7,7 +7,6 @@ from xcube.webapi.controllers.time_series import get_time_series_info, get_time_
 from ..helpers import new_test_service_context
 
 
-# noinspection PyUnresolvedReferences
 class TimeSeriesControllerTest(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -71,25 +70,23 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_point_with_uncertainty(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            ctx = new_test_service_context()
-            actual_result = get_time_series_for_point(ctx, 'demo-1w', 'conc_tsm',
-                                                      lon=2.1, lat=51.4,
-                                                      start_date=np.datetime64('2017-01-15'),
-                                                      end_date=np.datetime64('2017-01-29'))
-            expected_result = {'results': [{'date': '2017-01-22T00:00:00Z',
-                                            'result': {'average': 3.534773588180542,
-                                                       'uncertainty': 0.0,
-                                                       'totalCount': 1,
-                                                       'validCount': 1}},
-                                           {'date': '2017-01-29T00:00:00Z',
-                                            'result': {'average': 20.12085723876953,
-                                                       'uncertainty': 0.0,
-                                                       'totalCount': 1,
-                                                       'validCount': 1}}]}
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertEqual(expected_result, actual_result)
+        ctx = new_test_service_context()
+        actual_result = get_time_series_for_point(ctx, 'demo-1w', 'conc_tsm',
+                                                  lon=2.1, lat=51.4,
+                                                  start_date=np.datetime64('2017-01-15'),
+                                                  end_date=np.datetime64('2017-01-29'))
+        expected_result = {'results': [{'date': '2017-01-22T00:00:00Z',
+                                        'result': {'average': 3.534773588180542,
+                                                   'uncertainty': 0.0,
+                                                   'totalCount': 1,
+                                                   'validCount': 1}},
+                                       {'date': '2017-01-29T00:00:00Z',
+                                        'result': {'average': 20.12085723876953,
+                                                   'uncertainty': 0.0,
+                                                   'totalCount': 1,
+                                                   'validCount': 1}}]}
+
+        self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_point(self):
         ctx = new_test_service_context()
@@ -113,116 +110,103 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            ctx = new_test_service_context()
-            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                         dict(type="Polygon", coordinates=[[
-                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                         ]]),
-                                                         include_count=True)
-            expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
-                                            'result': {'average': 56.12519223634024,
-                                                       'totalCount': 159600,
-                                                       'validCount': 122392}},
-                                           {'date': '2017-01-25T09:35:51Z',
-                                            'result': {'average': None,
-                                                       'totalCount': 159600,
-                                                       'validCount': 0}},
-                                           {'date': '2017-01-26T10:50:17Z',
-                                            'result': {'average': None,
-                                                       'totalCount': 159600,
-                                                       'validCount': 0}},
-                                           {'date': '2017-01-28T09:58:11Z',
-                                            'result': {'average': 49.70755256053988,
-                                                       'totalCount': 159600,
-                                                       'validCount': 132066}},
-                                           {'date': '2017-01-30T10:46:34Z',
-                                            'result': {'average': None,
-                                                       'totalCount': 159600,
-                                                       'validCount': 0}}]}
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertEqual(expected_result, actual_result)
+        ctx = new_test_service_context()
+        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                     dict(type="Polygon", coordinates=[[
+                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                     ]]),
+                                                     include_count=True)
+        expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                        'result': {'average': 56.12519223634024,
+                                                   'totalCount': 159600,
+                                                   'validCount': 122392}},
+                                       {'date': '2017-01-25T09:35:51Z',
+                                        'result': {'average': None,
+                                                   'totalCount': 159600,
+                                                   'validCount': 0}},
+                                       {'date': '2017-01-26T10:50:17Z',
+                                        'result': {'average': None,
+                                                   'totalCount': 159600,
+                                                   'validCount': 0}},
+                                       {'date': '2017-01-28T09:58:11Z',
+                                        'result': {'average': 49.70755256053988,
+                                                   'totalCount': 159600,
+                                                   'validCount': 132066}},
+                                       {'date': '2017-01-30T10:46:34Z',
+                                        'result': {'average': None,
+                                                   'totalCount': 159600,
+                                                   'validCount': 0}}]}
+        self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_with_stdev(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            ctx = new_test_service_context()
-            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                         dict(type="Polygon", coordinates=[[
-                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                         ]]),
-                                                         include_count=True,
-                                                         include_stdev=True)
+        ctx = new_test_service_context()
+        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                     dict(type="Polygon", coordinates=[[
+                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                     ]]),
+                                                     include_count=True,
+                                                     include_stdev=True)
 
-            expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
-                                            'result': {'average': 56.12519223634024,
-                                                       'totalCount': 159600,
-                                                       'uncertainty': 40.78859862094861,
-                                                       'validCount': 122392}},
-                                           {'date': '2017-01-25T09:35:51Z',
-                                            'result': {'average': None,
-                                                       'totalCount': 159600,
-                                                       'uncertainty': None,
-                                                       'validCount': 0}},
-                                           {'date': '2017-01-26T10:50:17Z',
-                                            'result': {'average': None,
-                                                       'totalCount': 159600,
-                                                       'uncertainty': None,
-                                                       'validCount': 0}},
-                                           {'date': '2017-01-28T09:58:11Z',
-                                            'result': {'average': 49.70755256053988,
-                                                       'totalCount': 159600,
-                                                       'uncertainty': 34.98868194514786,
-                                                       'validCount': 132066}},
-                                           {'date': '2017-01-30T10:46:34Z',
-                                            'result': {'average': None,
-                                                       'totalCount': 159600,
-                                                       'uncertainty': None,
-                                                       'validCount': 0}}]}
+        expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                        'result': {'average': 56.12519223634024,
+                                                   'totalCount': 159600,
+                                                   'uncertainty': 40.78859862094861,
+                                                   'validCount': 122392}},
+                                       {'date': '2017-01-25T09:35:51Z',
+                                        'result': {'average': None,
+                                                   'totalCount': 159600,
+                                                   'uncertainty': None,
+                                                   'validCount': 0}},
+                                       {'date': '2017-01-26T10:50:17Z',
+                                        'result': {'average': None,
+                                                   'totalCount': 159600,
+                                                   'uncertainty': None,
+                                                   'validCount': 0}},
+                                       {'date': '2017-01-28T09:58:11Z',
+                                        'result': {'average': 49.70755256053988,
+                                                   'totalCount': 159600,
+                                                   'uncertainty': 34.98868194514786,
+                                                   'validCount': 132066}},
+                                       {'date': '2017-01-30T10:46:34Z',
+                                        'result': {'average': None,
+                                                   'totalCount': 159600,
+                                                   'uncertainty': None,
+                                                   'validCount': 0}}]}
 
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertEqual(expected_result, actual_result)
+        self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_one_valid(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            ctx = new_test_service_context()
-            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                         dict(type="Polygon", coordinates=[[
-                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                         ]]),
-                                                         include_count=True,
-                                                         max_valids=1)
-            expected_result = {'results': [{'date': '2017-01-28T09:58:11Z',
-                                            'result': {'average': 49.70755256053988,
-                                                       'totalCount': 159600,
-                                                       'validCount': 132066}}]}
+        ctx = new_test_service_context()
+        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                     dict(type="Polygon", coordinates=[[
+                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                     ]]),
+                                                     include_count=True,
+                                                     max_valids=1)
+        expected_result = {'results': [{'date': '2017-01-28T09:58:11Z',
+                                        'result': {'average': 49.70755256053988,
+                                                   'totalCount': 159600,
+                                                   'validCount': 132066}}]}
 
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertEqual(expected_result, actual_result)
+        self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_only_valids(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            ctx = new_test_service_context()
-            actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
-                                                         dict(type="Polygon", coordinates=[[
-                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
-                                                         ]]),
-                                                         include_count=True,
-                                                         max_valids=-1)
-            expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
-                                            'result': {'average': 56.12519223634024,
-                                                       'totalCount': 159600,
-                                                       'validCount': 122392}},
-                                           {'date': '2017-01-28T09:58:11Z',
-                                            'result': {'average': 49.70755256053988,
-                                                       'totalCount': 159600,
-                                                       'validCount': 132066}}]}
-
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertEqual(expected_result, actual_result)
+        ctx = new_test_service_context()
+        actual_result = get_time_series_for_geometry(ctx, 'demo', 'conc_tsm',
+                                                     dict(type="Polygon", coordinates=[[
+                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                                     ]]),
+                                                     include_count=True,
+                                                     max_valids=-1)
+        expected_result = {'results': [{'date': '2017-01-16T10:09:22Z',
+                                        'result': {'average': 56.12519223634024,
+                                                   'totalCount': 159600,
+                                                   'validCount': 122392}},
+                                       {'date': '2017-01-28T09:58:11Z',
+                                        'result': {'average': 49.70755256053988,
+                                                   'totalCount': 159600,
+                                                   'validCount': 132066}}]}
+        self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometries_incl_point(self):
         ctx = new_test_service_context()
@@ -249,40 +233,37 @@ class TimeSeriesControllerTest(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_for_geometries_incl_polygon(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            ctx = new_test_service_context()
-            actual_result = get_time_series_for_geometry_collection(ctx,
-                                                                    'demo', 'conc_tsm',
-                                                                    dict(type="GeometryCollection",
-                                                                         geometries=[dict(type="Polygon", coordinates=[[
-                                                                             [1., 51.], [2., 51.], [2., 52.], [1., 52.],
-                                                                             [1., 51.]
-                                                                         ]])]),
-                                                                    include_count=True)
-            expected_result = {'results': [[{'date': '2017-01-16T10:09:22Z',
-                                             'result': {'average': 56.12519223634024,
-                                                        'totalCount': 159600,
-                                                        'validCount': 122392}},
-                                            {'date': '2017-01-25T09:35:51Z',
-                                             'result': {'average': None,
-                                                        'totalCount': 159600,
-                                                        'validCount': 0}},
-                                            {'date': '2017-01-26T10:50:17Z',
-                                             'result': {'average': None,
-                                                        'totalCount': 159600,
-                                                        'validCount': 0}},
-                                            {'date': '2017-01-28T09:58:11Z',
-                                             'result': {'average': 49.70755256053988,
-                                                        'totalCount': 159600,
-                                                        'validCount': 132066}},
-                                            {'date': '2017-01-30T10:46:34Z',
-                                             'result': {'average': None,
-                                                        'totalCount': 159600,
-                                                        'validCount': 0}}]]}
+        ctx = new_test_service_context()
+        actual_result = get_time_series_for_geometry_collection(ctx,
+                                                                'demo', 'conc_tsm',
+                                                                dict(type="GeometryCollection",
+                                                                     geometries=[dict(type="Polygon", coordinates=[[
+                                                                         [1., 51.], [2., 51.], [2., 52.], [1., 52.],
+                                                                         [1., 51.]
+                                                                     ]])]),
+                                                                include_count=True)
+        expected_result = {'results': [[{'date': '2017-01-16T10:09:22Z',
+                                         'result': {'average': 56.12519223634024,
+                                                    'totalCount': 159600,
+                                                    'validCount': 122392}},
+                                        {'date': '2017-01-25T09:35:51Z',
+                                         'result': {'average': None,
+                                                    'totalCount': 159600,
+                                                    'validCount': 0}},
+                                        {'date': '2017-01-26T10:50:17Z',
+                                         'result': {'average': None,
+                                                    'totalCount': 159600,
+                                                    'validCount': 0}},
+                                        {'date': '2017-01-28T09:58:11Z',
+                                         'result': {'average': 49.70755256053988,
+                                                    'totalCount': 159600,
+                                                    'validCount': 132066}},
+                                        {'date': '2017-01-30T10:46:34Z',
+                                         'result': {'average': None,
+                                                    'totalCount': 159600,
+                                                    'validCount': 0}}]]}
 
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertEqual(expected_result, actual_result)
+        self.assertEqual(expected_result, actual_result)
 
     def test_get_time_series_info(self):
         self.maxDiff = None

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -18,6 +18,7 @@ for name, var in _ds.coords.items():
 
 # For usage of the tornado.testing.AsyncHTTPTestCase see http://www.tornadoweb.org/en/stable/testing.html
 
+
 class HandlersTest(AsyncHTTPTestCase):
 
     def get_app(self):
@@ -310,19 +311,24 @@ class HandlersTest(AsyncHTTPTestCase):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/point?lon=2.1&lat=51.1')
         self.assertResponseOK(response)
 
+    # noinspection PyUnresolvedReferences
     def test_fetch_time_series_geometry(self):
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                              body='')
-        self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON geometry in request body')
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                              body='{"type":"Point"}')
-        self.assertBadRequestResponse(response, 'Invalid GeoJSON geometry')
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                              body='{"type": "Point", "coordinates": [1, 51]}')
-        self.assertResponseOK(response)
-        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                              body='{"type":"Polygon", "coordinates": [[[1, 51], [2, 51], [2, 52], [1, 51]]]}')
-        self.assertResponseOK(response)
+        with self.assertWarns(RuntimeWarning) as warning:
+            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                                  body='')
+            self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON geometry in request body')
+            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                                  body='{"type":"Point"}')
+            self.assertBadRequestResponse(response, 'Invalid GeoJSON geometry')
+            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                                  body='{"type": "Point", "coordinates": [1, 51]}')
+            self.assertResponseOK(response)
+            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                                  body='{"type":"Polygon", "coordinates": [[[1, 51], [2, 51], [2, 52], [1, 51]]]}')
+
+            for w in warning.warnings:
+                self.assertEqual("invalid value encountered in true_divide", str(w.message))
+            self.assertResponseOK(response)
 
     def test_fetch_time_series_geometries(self):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometries', method="POST",

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -311,24 +311,20 @@ class HandlersTest(AsyncHTTPTestCase):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/point?lon=2.1&lat=51.1')
         self.assertResponseOK(response)
 
-    # noinspection PyUnresolvedReferences
     def test_fetch_time_series_geometry(self):
-        with self.assertWarns(RuntimeWarning) as warning:
-            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                                  body='')
-            self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON geometry in request body')
-            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                                  body='{"type":"Point"}')
-            self.assertBadRequestResponse(response, 'Invalid GeoJSON geometry')
-            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                                  body='{"type": "Point", "coordinates": [1, 51]}')
-            self.assertResponseOK(response)
-            response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
-                                  body='{"type":"Polygon", "coordinates": [[[1, 51], [2, 51], [2, 52], [1, 51]]]}')
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                              body='')
+        self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON geometry in request body')
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                              body='{"type":"Point"}')
+        self.assertBadRequestResponse(response, 'Invalid GeoJSON geometry')
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                              body='{"type": "Point", "coordinates": [1, 51]}')
+        self.assertResponseOK(response)
+        response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
+                              body='{"type":"Polygon", "coordinates": [[[1, 51], [2, 51], [2, 52], [1, 51]]]}')
 
-            for w in warning.warnings:
-                self.assertEqual("invalid value encountered in true_divide", str(w.message))
-            self.assertResponseOK(response)
+        self.assertResponseOK(response)
 
     def test_fetch_time_series_geometries(self):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometries', method="POST",

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -344,7 +344,8 @@ class HandlersTest(AsyncHTTPTestCase):
                               body='{"type": "GeometryCollection", "geometries": []}')
         self.assertResponseOK(response)
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometries', method="POST",
-                              body='{"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": [1, 51]}]}')
+                              body='{"type": "GeometryCollection", "geometries": '
+                                   '[{"type": "Point", "coordinates": [1, 51]}]}')
         self.assertResponseOK(response)
 
     def test_fetch_time_series_features(self):

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -153,7 +153,6 @@ class HandlersTest(AsyncHTTPTestCase):
                                             '&TileCol=0')
         self.assertBadRequestResponse(response, 'Value for "layer" parameter must be "<dataset>.<variable>"')
 
-
     def test_fetch_wmts_capabilities(self):
         response = self.fetch(self.prefix + '/wmts/1.0.0/WMTSCapabilities.xml')
         self.assertResponseOK(response)
@@ -188,10 +187,6 @@ class HandlersTest(AsyncHTTPTestCase):
         response = self.fetch(self.prefix + '/datasets/demo?tiles=ol4')
         self.assertResponseOK(response)
         response = self.fetch(self.prefix + '/datasets/demo?tiles=cesium')
-        self.assertResponseOK(response)
-
-    def test_fetch_dataset_places(self):
-        response = self.fetch(self.prefix + '/datasets/demo/places')
         self.assertResponseOK(response)
 
     def test_fetch_dataset_coords(self):
@@ -288,6 +283,8 @@ class HandlersTest(AsyncHTTPTestCase):
         self.assertResponseOK(response)
 
     def test_fetch_dataset_places(self):
+        response = self.fetch(self.prefix + '/datasets/demo/places')
+        self.assertResponseOK(response)
         response = self.fetch(self.prefix + '/places/all/demo')
         self.assertResponseOK(response)
         response = self.fetch(self.prefix + '/places/inside-cube/demo')

--- a/test/webapi/test_service.py
+++ b/test/webapi/test_service.py
@@ -101,13 +101,13 @@ class UrlPatternTest(unittest.TestCase):
     def test_url_pattern_ok(self):
         self.assertEqual('/version',
                          url_pattern('/version'))
-        self.assertEqual('(?P<num>[^\;\/\?\:\@\&\=\+\$\,]+)/get',
+        self.assertEqual(r'(?P<num>[^\;\/\?\:\@\&\=\+\$\,]+)/get',
                          url_pattern('{{num}}/get'))
-        self.assertEqual('/open/(?P<ws_name>[^\;\/\?\:\@\&\=\+\$\,]+)',
+        self.assertEqual(r'/open/(?P<ws_name>[^\;\/\?\:\@\&\=\+\$\,]+)',
                          url_pattern('/open/{{ws_name}}'))
-        self.assertEqual('/open/ws(?P<id1>[^\;\/\?\:\@\&\=\+\$\,]+)/wf(?P<id2>[^\;\/\?\:\@\&\=\+\$\,]+)',
+        self.assertEqual(r'/open/ws(?P<id1>[^\;\/\?\:\@\&\=\+\$\,]+)/wf(?P<id2>[^\;\/\?\:\@\&\=\+\$\,]+)',
                          url_pattern('/open/ws{{id1}}/wf{{id2}}'))
-        self.assertEqual('/datasets/(?P<ds_id>[^\;\/\?\:\@\&\=\+\$\,]+)/data.zip/(.*)',
+        self.assertEqual(r'/datasets/(?P<ds_id>[^\;\/\?\:\@\&\=\+\$\,]+)/data.zip/(.*)',
                          url_pattern('/datasets/{{ds_id}}/data.zip/(.*)'))
 
     def test_url_pattern_fail(self):

--- a/xcube/api/gen/default/iproc.py
+++ b/xcube/api/gen/default/iproc.py
@@ -180,7 +180,8 @@ def _normalize_lon_360(dataset: xr.Dataset) -> xr.Dataset:
     if not np.any(lon_values[lon_size_05:] > 180.):
         return dataset
 
-    dataset = dataset.roll(lon=lon_size_05)
+    # roll_coords will be set to False by default in the future
+    dataset = dataset.roll(lon=lon_size_05, roll_coords=True)
     dataset = dataset.assign_coords(lon=(((dataset.lon + 180) % 360) - 180))
 
     return dataset

--- a/xcube/api/ts.py
+++ b/xcube/api/ts.py
@@ -107,11 +107,11 @@ def get_time_series(cube: xr.Dataset,
     ds_stdev = None
     if use_groupby:
         time_group = dataset.groupby('time')
-        ds_mean = time_group.mean(skipna=True)
+        ds_mean = time_group.mean(skipna=True, dim=xr.ALL_DIMS)
         if include_count:
-            ds_count = time_group.count()
+            ds_count = time_group.count(dim=xr.ALL_DIMS)
         if include_stdev:
-            ds_stdev = time_group.std(skipna=True)
+            ds_stdev = time_group.std(skipna=True, dim=xr.ALL_DIMS)
     else:
         ds_mean = dataset.mean(dim=('lat', 'lon'), skipna=True)
         if include_count:

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -43,6 +43,7 @@ def load_plugins(entry_points, plugins=None):
                 _handle_error(entry_point, e)
                 continue
         else:
+            # We use warning and not raise to allow loading xcube despite a broken plugin. Raise would stop xcube.
             warnings.warn(f'xcube plugin with entry point {entry_point.name!r} '
                           f'must be a callable but got a {type(plugin_init_function)!r}')
             continue
@@ -60,6 +61,7 @@ def get_plugins():
 
 
 def _handle_error(entry_point, e):
+    # We use warning and not raise to allow loading xcube despite a broken plugin. Raise would stop xcube.
     warnings.warn('Unexpected exception while loading xcube plugin '
                   f'with entry point {entry_point.name!r}: {e}')
     traceback.print_exc()

--- a/xcube/util/reproject.py
+++ b/xcube/util/reproject.py
@@ -22,7 +22,7 @@
 import warnings
 from typing import Tuple, List, Union, Dict, Any
 
-import gdal
+from osgeo import gdal
 import numpy as np
 import xarray as xr
 from xcube.util.constants import CRS_WKT_EPSG_4326, EARTH_GEO_COORD_RANGE

--- a/xcube/webapi/im/cmaps.py
+++ b/xcube/webapi/im/cmaps.py
@@ -234,7 +234,7 @@ def _get_color(colortext):
     if any('color' in line for line in lines):
         for line in lines:
             if "color" in line:
-                r, g, b = (((re.split('\W+', line, 1)[1:])[0].strip()).split(','))
+                r, g, b = (((re.split(r'\W+', line, 1)[1:])[0].strip()).split(','))
                 hex_col = ('#%02x%02x%02x' % (int(r), int(g), int(b)))
                 c.append(hex_col)
     else:
@@ -251,7 +251,7 @@ def get_tick_val_col(colortext):
     if any('sample' in line for line in lines):
         for line in lines:
             if "sample" in line:
-                value = ((re.split('\W+', line, 1)[1:])[0].strip())
+                value = ((re.split(r'\W+', line, 1)[1:])[0].strip())
                 values.append(float(value))
     else:
         _LOG.warning('Keyword "sample" not found. SNAP .cpd file invalid.')

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -54,6 +54,7 @@ _LOG = logging.getLogger('xcube')
 
 SNAP_CPD_LIST = list()
 
+
 class Service:
     """
     A web service that provides a remote API to some application.
@@ -365,7 +366,7 @@ def url_pattern(pattern: str):
     :return: equivalent regex pattern
     :raise ValueError: if *pattern* is invalid
     """
-    name_pattern = '(?P<%s>[^\;\/\?\:\@\&\=\+\$\,]+)'
+    name_pattern = r'(?P<%s>[^\;\/\?\:\@\&\=\+\$\,]+)'
     reg_expr = ''
     pos = 0
     while True:


### PR DESCRIPTION
When accepting this PR the number of warnings during testing will be significantly reduced. Two
warnings remain that will disappear when we change to Python 3.8.

- Some warnings are supressed as they cannot be entirely avoided (e.g. numpy warnings for all NaN slices)
- Python warnings are now caught and checked by self.assertWarns (mainly in plugin.py)
- Some deprecation warnings due to default changes in xarray have been fixed

The foloowing warnings are safely suppressed but could/should get attention:
- matplotlib: tight_layout warning
- time unit warning when writing to netcdf 
