### PR TITLE
Fixing false time stamp parsing in xcube gen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   metadata. (#141) 
 
 ### Fixes
-
+- time stamps are now parsed correcly into cube from input data(#207)
 - `.levels` can be stored in obs and are usable with `xcube serve` (#179)
 - `xcube optimize` now consolidates metadata only after consolidating
   coordinate variables. (#194)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   metadata. (#141) 
 
 ### Fixes
-- time stamps are now parsed correcly into cube from input data(#207)
+- `xcube gen` now parses time stamps correcly from input data. (#207)
 - `.levels` can be stored in obs and are usable with `xcube serve` (#179)
 - `xcube optimize` now consolidates metadata only after consolidating
   coordinate variables. (#194)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 - `xcube gen` now parses time stamps correcly from input data. (#207)
-- `.levels` can be stored in obs and are usable with `xcube serve` (#179)
+- Dataset multi-resolution pyramids (`*.levels` directories) can be stored in cloud object storage and are now usable with `xcube serve` (#179)
 - `xcube optimize` now consolidates metadata only after consolidating
   coordinate variables. (#194)
 - Removed broken links from `./README.md` (#197)

--- a/test/util/test_timecoord.py
+++ b/test/util/test_timecoord.py
@@ -1,10 +1,11 @@
 import unittest
 
 import numpy as np
+import pandas as pd
 
 from test.sampledata import create_highroc_dataset
-from xcube.util.timecoord import add_time_coords, to_time_in_days_since_1970, timestamp_to_iso_string, \
-    from_time_in_days_since_1970
+from xcube.util.timecoord import add_time_coords, from_time_in_days_since_1970, timestamp_to_iso_string, \
+    to_time_in_days_since_1970
 
 
 class AddTimeCoordsTest(unittest.TestCase):
@@ -35,6 +36,8 @@ class AddTimeCoordsTest(unittest.TestCase):
                          to_time_in_days_since_1970('2018-06-08 12:00'))
         self.assertEqual(17690.5,
                          to_time_in_days_since_1970('2018-06-08T12:00'))
+        self.assertEqual(18173.42625622898,
+                         to_time_in_days_since_1970('04-OCT-2019 10:13:48.538184'))
 
     def test_from_time_in_days_since_1970(self):
         self.assertEqual('2017-06-07T12:00:00.000000000',
@@ -45,6 +48,8 @@ class AddTimeCoordsTest(unittest.TestCase):
                          str(from_time_in_days_since_1970(to_time_in_days_since_1970('2018-06-08 12:00'))))
         self.assertEqual('2018-06-08T12:00:00.000000000',
                          str(from_time_in_days_since_1970(to_time_in_days_since_1970('2018-06-08T12:00'))))
+        self.assertEqual('2019-10-04T10:13:48.538000000',
+                         str(from_time_in_days_since_1970(to_time_in_days_since_1970('04-OCT-2019 10:13:48.538184'))))
 
 
 class TimestampToIsoStringTest(unittest.TestCase):
@@ -55,6 +60,8 @@ class TimestampToIsoStringTest(unittest.TestCase):
                          timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42")))
         self.assertEqual("2018-09-05T10:35:42Z",
                          timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42.164")))
+        self.assertEqual("2019-10-04T10:13:49Z",
+                         timestamp_to_iso_string(pd.to_datetime("04-OCT-2019 10:13:48.538184")))
 
     def test_it_with_h_res(self):
         self.assertEqual("2018-09-05T00:00:00Z",
@@ -63,3 +70,5 @@ class TimestampToIsoStringTest(unittest.TestCase):
                          timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42"), freq="H"))
         self.assertEqual("2018-09-05T11:00:00Z",
                          timestamp_to_iso_string(np.datetime64("2018-09-05 10:35:42.164"), freq="H"))
+        self.assertEqual("2019-10-04T10:00:00Z",
+                         timestamp_to_iso_string(pd.to_datetime("04-OCT-2019 10:13:48.538184"), freq="H"))

--- a/xcube/util/timecoord.py
+++ b/xcube/util/timecoord.py
@@ -73,7 +73,7 @@ def add_time_coords(dataset: xr.Dataset, time_range: Tuple[float, float]) -> xr.
 
 
 def to_time_in_days_since_1970(time_str: str, pattern=None) -> float:
-    datetime = pd.to_datetime(time_str, format=pattern, infer_datetime_format=True, utc=True)
+    datetime = pd.to_datetime(time_str, format=pattern, infer_datetime_format=False, utc=True)
     timedelta = datetime - REF_DATETIME
     return timedelta.days + timedelta.seconds / SECONDS_PER_DAY + timedelta.microseconds / MICROSECONDS_PER_DAY
 


### PR DESCRIPTION
This PR is fixing the issue #207 . Now the time stamps are parsed correcly and will not falsly generate time stamps which are not corresponding to the input data time stamps. 

The tests of the xcube-gen-input plugins are passing with the changes in this PR as well. 

Note: Commitmessage is wrong. Accidently clickt on ok to fast. 