### PR TITLE
Forman 212 resample bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 
 * CLI commands execute much faster now when invoked with the `--help` and `--info` options.
 
+### Fixes
+
+* `xcube resample` now correctly re-chunks its output. By default, chunking of the 
+  `time` dimension is set to one. (#212)
 
 ### Incompatible changes
 

--- a/test/core/test_chunk.py
+++ b/test/core/test_chunk.py
@@ -29,6 +29,26 @@ class ChunkDatasetTest(unittest.TestCase):
         self.assertEqual({}, chunked_dataset.precipitation.encoding)
         self.assertEqual({}, chunked_dataset.temperature.encoding)
 
+        dataset = dataset.chunk(dict(time=2, lat=10, lon=20))
+
+        chunked_dataset = chunk_dataset(dataset,
+                                        chunk_sizes=None,
+                                        format_name="zarr")
+        self.assertEqual({}, chunked_dataset.precipitation.encoding)
+        self.assertEqual({}, chunked_dataset.temperature.encoding)
+
+        chunked_dataset = chunk_dataset(dataset,
+                                        chunk_sizes={},
+                                        format_name="zarr")
+        self.assertEqual({'chunks': (2, 10, 20)}, chunked_dataset.precipitation.encoding)
+        self.assertEqual({'chunks': (2, 10, 20)}, chunked_dataset.temperature.encoding)
+
+        chunked_dataset = chunk_dataset(dataset,
+                                        chunk_sizes=dict(time=1),
+                                        format_name="zarr")
+        self.assertEqual({'chunks': (1, 10, 20)}, chunked_dataset.precipitation.encoding)
+        self.assertEqual({'chunks': (1, 10, 20)}, chunked_dataset.temperature.encoding)
+
     def test_unchunk_dataset(self):
         dataset = new_test_dataset(["2010-01-01", "2010-01-02", "2010-01-03", "2010-01-04", "2010-01-05"],
                                    precipitation=0.4, temperature=275.2)

--- a/test/sampledata.py
+++ b/test/sampledata.py
@@ -29,8 +29,10 @@ def new_test_dataset(time, height=180, **indexers):
             raise ValueError()
         data_vars[name] = (['time', 'lat', 'lon'],
                            np.concatenate(tuple(np.full(shape, values[i]) for i in range(num_times))))
+    time = np.array(pd.to_datetime(time), dtype=np.datetime64)
     return xr.Dataset(data_vars,
-                      coords=dict(time=(['time'], pd.to_datetime(time)),
+                      coords=dict(time=(
+                      ['time'], time, dict(units='nanoseconds since 1970-01-01', calendar='proleptic_gregorian')),
                                   lat=(['lat'], np.linspace(-90 + res, +90 - res, height)),
                                   lon=(['lon'], np.linspace(-180 + res, +180 - res, width))))
 

--- a/xcube/cli/resample.py
+++ b/xcube/cli/resample.py
@@ -167,7 +167,7 @@ def _resample_in_time(input_path: str = None,
                       methods: Sequence[str] = (DEFAULT_RESAMPLING_METHOD,),
                       frequency: str = DEFAULT_RESAMPLING_FREQUENCY,
                       offset: str = None,
-                      base: str = DEFAULT_RESAMPLING_BASE,
+                      base: int = DEFAULT_RESAMPLING_BASE,
                       interp_kind: str = DEFAULT_INTERPOLATION_KIND,
                       tolerance: str = None,
                       dry_run: bool = False,
@@ -176,6 +176,7 @@ def _resample_in_time(input_path: str = None,
     from xcube.core.dsio import open_cube
     from xcube.core.dsio import write_cube
     from xcube.core.resample import resample_in_time
+    from xcube.core.update import update_dataset_chunk_encoding
 
     if not output_format:
         output_format = guess_dataset_format(output_path)
@@ -191,8 +192,14 @@ def _resample_in_time(input_path: str = None,
                                   base=base,
                                   interp_kind=interp_kind,
                                   tolerance=tolerance,
+                                  time_chunk_size=1,
                                   var_names=variables,
                                   metadata=metadata)
+
+        agg_ds = update_dataset_chunk_encoding(agg_ds,
+                                               chunk_sizes={},
+                                               format_name=output_format,
+                                               in_place=True)
 
         monitor(f'Writing resampled cube to {output_path!r}...')
         if not dry_run:

--- a/xcube/core/chunk.py
+++ b/xcube/core/chunk.py
@@ -4,41 +4,24 @@ from typing import Dict, Tuple, Iterable
 import numpy as np
 import xarray as xr
 
-from xcube.constants import FORMAT_NAME_ZARR, FORMAT_NAME_NETCDF4
+from xcube.core.update import update_dataset_chunk_encoding
 
 
 def chunk_dataset(dataset: xr.Dataset,
                   chunk_sizes: Dict[str, int] = None,
                   format_name: str = None) -> xr.Dataset:
     """
-    Chunk dataset and update encodings for given format.
+    Chunk *dataset* using *chunk_sizes* and optionally update encodings for given *format_name*.
 
     :param dataset: input dataset
     :param chunk_sizes: mapping from dimension name to new chunk size
-    :param format_name: format, e.g. "zarr" or "netcdf4"
-    :return: the re-chunked dataset
+    :param format_name: optional format, e.g. "zarr" or "netcdf4"
+    :return: the (re)chunked dataset
     """
-    chunked_ds = dataset.chunk(chunks=chunk_sizes)
-
-    # Update encoding so writing of chunked_ds recognizes new chunks
-    chunk_sizes_attr_name = None
-    if format_name == FORMAT_NAME_ZARR:
-        chunk_sizes_attr_name = "chunks"
-    if format_name == FORMAT_NAME_NETCDF4:
-        chunk_sizes_attr_name = "chunksizes"
-    if chunk_sizes_attr_name:
-        for var_name in chunked_ds.variables:
-            var = chunked_ds[var_name]
-            if chunk_sizes:
-                sizes = tuple(chunk_sizes[dim_name] if dim_name in chunk_sizes
-                              else var.shape[var.dims.index(dim_name)]
-                              for dim_name in var.dims)
-                var.encoding.update({chunk_sizes_attr_name: sizes})
-            elif chunk_sizes_attr_name in var.encoding:
-                # Remove any explicit and wrong specification so writing will use Dask chunks (TBC!)
-                del var.encoding[chunk_sizes_attr_name]
-
-    return chunked_ds
+    dataset = dataset.chunk(chunks=chunk_sizes)
+    if format_name:
+        dataset = update_dataset_chunk_encoding(dataset, chunk_sizes=chunk_sizes, format_name=format_name)
+    return dataset
 
 
 def get_empty_dataset_chunks(dataset: xr.Dataset) -> Dict[str, Tuple[Tuple[int, ...]]]:

--- a/xcube/core/resample.py
+++ b/xcube/core/resample.py
@@ -43,10 +43,11 @@ def resample_in_time(cube: xr.Dataset,
     Resample a xcube dataset in the time dimension.
 
     :param cube: The xcube dataset.
-    :param frequency: Resampling frequency.
+    :param frequency: Temporal aggregation frequency. Use format "<count><offset>"
+        "where <offset> is one of 'H', 'D', 'W', 'M', 'Q', 'Y'.
     :param method: Resampling method or sequence of resampling methods.
     :param offset: Offset used to adjust the resampled time labels.
-        Some pandas date offset strings are supported.
+        Uses same syntax as *frequency*.
     :param base: For frequencies that evenly subdivide 1 day, the "origin" of the
         aggregated intervals. For example, for '24H' frequency, base could range from 0 through 23.
     :param time_chunk_size: If not None, the chunk size to be used for the "time" dimension.

--- a/xcube/core/resample.py
+++ b/xcube/core/resample.py
@@ -23,32 +23,43 @@ from typing import Dict, Any, Sequence, Union
 
 import xarray as xr
 
+from xcube.core.schema import CubeSchema
 from xcube.core.select import select_vars
+from xcube.core.verify import assert_cube
 
 
 def resample_in_time(cube: xr.Dataset,
                      frequency: str,
                      method: Union[str, Sequence[str]],
                      offset=None,
-                     base: str = 0,
+                     base: int = 0,
                      tolerance=None,
                      interp_kind=None,
+                     time_chunk_size=None,
                      var_names: Sequence[str] = None,
-                     metadata: Dict[str, Any] = None):
+                     metadata: Dict[str, Any] = None,
+                     cube_asserted: bool = False) -> xr.Dataset:
     """
     Resample a xcube dataset in the time dimension.
 
     :param cube: The xcube dataset.
     :param frequency: Resampling frequency.
     :param method: Resampling method or sequence of resampling methods.
-    :param offset: Offset used to adjust the resampled time labels. Some pandas date offset strings are supported.
-    :param base: Resampling method.
+    :param offset: Offset used to adjust the resampled time labels.
+        Some pandas date offset strings are supported.
+    :param base: For frequencies that evenly subdivide 1 day, the "origin" of the
+        aggregated intervals. For example, for '24H' frequency, base could range from 0 through 23.
+    :param time_chunk_size: If not None, the chunk size to be used for the "time" dimension.
     :param var_names: Variable names to include.
     :param tolerance: Time tolerance for selective upsampling methods. Defaults to *frequency*.
     :param interp_kind: Kind of interpolation if *method* is 'interpolation'.
     :param metadata: Output metadata.
+    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
     :return: A new xcube dataset resampled in time.
     """
+    if not cube_asserted:
+        assert_cube(cube)
+
     if var_names:
         cube = select_vars(cube, var_names)
 
@@ -70,7 +81,8 @@ def resample_in_time(cube: xr.Dataset,
         resampling_method = getattr(resampler, method)
         kwargs = get_method_kwargs(method, frequency, interp_kind, tolerance)
         resampled_cube = resampling_method(**kwargs)
-        resampled_cube = resampled_cube.rename({var_name: f'{var_name}_{method}' for var_name in resampled_cube.data_vars})
+        resampled_cube = resampled_cube.rename(
+            {var_name: f'{var_name}_{method}' for var_name in resampled_cube.data_vars})
         resampled_cubes.append(resampled_cube)
 
     if len(resampled_cubes) == 1:
@@ -86,7 +98,14 @@ def resample_in_time(cube: xr.Dataset,
     # TODO: add other time_coverage_ attributes
     resampled_cube.attrs.update(time_coverage_start=time_coverage_start,
                                 time_coverage_end=time_coverage_end)
-    return resampled_cube
+
+    schema = CubeSchema.new(cube)
+    chunk_sizes = {schema.dims[i]: schema.chunks[i] for i in range(schema.ndim)}
+
+    if isinstance(time_chunk_size, int) and time_chunk_size >= 0:
+        chunk_sizes['time'] = time_chunk_size
+
+    return resampled_cube.chunk(chunk_sizes)
 
 
 def get_method_kwargs(method, frequency, interp_kind, tolerance):


### PR DESCRIPTION
* `xcube resample` now correctly re-chunks its output. By default, chunking of the 
  `time` dimension is set to one. (#212)
* refactored out new function `xcube.core.update.update_dataset_chunk_encoding()`

Closes #212

