### PR TITLE
closes #233

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,13 @@
   - `xcube.core.geom`
   - `xcube.core.schema`
   - `xcube.core.verify`
-   
+* Sometimes the cell bounds coordinate variables of a given coordinate variables are not in a proper, 
+  [CF compliant](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#cell-boundaries) 
+  order, e.g. for decreasing latitudes `lat` the respective bounds coordinate
+  `lat_bnds` is decreasing for `lat_bnds[:, 0]` and `lat_bnds[:, 1]`, but `lat_bnds[i, 0] < lat_bnds[i, 1]`
+  for all `i`. xcube is now more tolerant w.r.t. to such wrong ordering of cell boundaries and will 
+  compute the correct spatial extent. (#233)
+ 
 ### Fixes
 
 * `xcube resample` now correctly re-chunks its output. By default, chunking of the 

--- a/xcube/webapi/controllers/tiles.py
+++ b/xcube/webapi/controllers/tiles.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import warnings
 from typing import Dict, Any
 
 import matplotlib
@@ -257,9 +258,20 @@ def _tile_grid_to_ol4x_xyz_source_options(tile_grid: TileGrid, url: str):
     :return:
     """
     west, south, east, north = tile_grid.geo_extent
-    res0 = (north - south) / tile_grid.height(0)
-    #   https://openlayers.org/en/latest/examples/xyz.html
-    #   https://openlayers.org/en/latest/apidoc/ol.source.XYZ.html
+
+    delta_x = east - west + (0 if east >= west else 360)
+    delta_y = north - south
+    width = tile_grid.width(0)
+    height = tile_grid.height(0)
+    res0_x = delta_x / width
+    res0_y = delta_y / height
+    res0 = max(res0_x, res0_y)
+    if abs(res0_y - res0_x) >= 1.e-5:
+        warnings.warn(f'spatial resolutions in x and y direction differ significantly:'
+                      f' {res0_x} and {res0_y} degrees, using maximum {res0}')
+
+    # https://openlayers.org/en/latest/examples/xyz.html
+    # https://openlayers.org/en/latest/apidoc/ol.source.XYZ.html
     return dict(url=url,
                 projection='EPSG:4326',
                 minZoom=0,


### PR DESCRIPTION
closes #233
closes https://github.com/dcs4cop/xcube-viewer/issues/90

* `xcube.core.geom.get_dataset_bounds()` is now more tolerant
* Getting tile grids definitions for OpenLayers will now issue a warning if x and y resolutions differ significantly
