### PR TITLE
spatial subset before reprojection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## Changes in 0.3.0 (in development)
 
 ### New
-
+* xcube now may first make a spatial subset input file according to the area of 
+  interest and then does the reprojection, if implementation is given in input processors.
 * Added new parameter in `xcube gen` called `--no_sort`. Using `--no_sort`, 
   the input file list wont be sorted before creating the xcube dataset. 
   If `--no_sort` parameter is passed, order the input list will be kept. 

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -238,6 +238,8 @@ def _process_input(input_processor: InputProcessor,
 
     # noinspection PyShadowingNames
     def step4(input_slice):
+        if output_region:
+            input_slice = input_processor.get_spatial_subest(input_slice, output_region)
         return input_processor.process(input_slice,
                                        dst_size=output_size,
                                        dst_region=output_region,

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -239,7 +239,7 @@ def _process_input(input_processor: InputProcessor,
     # noinspection PyShadowingNames
     def step4(input_slice):
         if output_region:
-            input_slice = input_processor.get_spatial_subest(input_slice, output_region)
+            input_slice = input_processor.get_spatial_subset(input_slice, output_region)
         return input_processor.process(input_slice,
                                        dst_size=output_size,
                                        dst_region=output_region,

--- a/xcube/core/gen/iproc.py
+++ b/xcube/core/gen/iproc.py
@@ -120,6 +120,17 @@ class InputProcessor(ExtensionComponent, metaclass=ABCMeta):
         """
         return None
 
+    def get_spatial_subest(self, dataset: xr.Dataset, dst_region: Tuple[float, float, float, float]) -> xr.Dataset:
+        """
+        Get spatial subset based on dst_region.
+
+        Returns ``dataset`` by default.
+        :param dataset: The dataset.
+        :param dst_region: The region taken for the spatial subset
+        :return: A spatial subset of the dataset.
+        """
+        return dataset
+
     def pre_process(self, dataset: xr.Dataset) -> xr.Dataset:
         """
         Do any pre-processing before reprojection.


### PR DESCRIPTION
This PR relates to #206 . It allows xcube to make a spatial subset according to the output region before performing the reprojection of the dataset. 