### PR TITLE
Update verify.py

### DIFF
--- a/xcube/core/verify.py
+++ b/xcube/core/verify.py
@@ -204,6 +204,14 @@ def _check_lon_or_lat(dataset, var_name, min_value, max_value, report):
     if np.min(var) < min_value or np.max(var) > max_value:
         report.append(f"values of coordinate variable {var_name!r}"
                       f" must be in the range {min_value} to {max_value}")
+        
+    if max_value > 92. and var[0] > var[-1]:
+        report.append(f"values of coordinate variable {var_name!r}"
+                      f" must be in ascending order")
+
+    if max_value < 92. and var[0] < var[-1]:
+        report.append(f"values of coordinate variable {var_name!r}"
+                      f" must be in descending order")
 
 
 def _check_time(dataset, name, report):


### PR DESCRIPTION
Coordinate values must have a descending order for latitude, and ascending order for longitude. A datacube could have different coordinate values order and still be a correct input or datacube. However, if that is the case, the xcube viewer will not plot the data on the map (even when the time graph works properly). There are two ways of solving this, adapting the viewer to be able of plotting the data whatever is the coordinate values order, or add this few line to xcube verify.