### PR TITLE
changed xcube gen monitor to use flush

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Other
 
 * Renamed default log file for `xcube serve` command to `xcube-serve.log`.
-* Changed`xcube gen` monitor to use flush
+* `xcube gen` now immediately flushes logging output to standard out
   
 ## Changes in 0.3.1 (in development)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Other
 
 * Renamed default log file for `xcube serve` command to `xcube-serve.log`.
+* Changed`xcube gen` monitor to use flush
   
 ## Changes in 0.3.1 (in development)
 

--- a/xcube/cli/gen.py
+++ b/xcube/cli/gen.py
@@ -123,8 +123,11 @@ def gen(input: Sequence[str],
         no_sort_mode=no_sort,
     )
 
+    def flushing_monitor(*args, **kwargs):
+        print(*args, flush=True, **kwargs)
+
     gen_cube(dry_run=dry_run,
-             monitor=print,
+             monitor=flushing_monitor,
              **config)
 
     return 0


### PR DESCRIPTION
This PR is not related to an issue. 
xcube gen monitor is now using prints flush. 