### PR TITLE
Support xarray and numpy functions in expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Changes in 0.4.0 (in development)
 
+### New
+
+* Now supporting xarray and numpy functions in expressions. You can now use 
+  `xr` and `np` contexts, e.g. `xr.where(CHL >= 0.0, CHL)`. (#257)
+
 ### Other
 
 * Renamed default log file for `xcube serve` command to `xcube-serve.log`.

--- a/test/util/test_expression.py
+++ b/test/util/test_expression.py
@@ -171,6 +171,9 @@ class TranspileExprTest(unittest.TestCase):
                          'xr.where(a >= 0.0, a, NaN)')
         self.assertEqual(transpile_expr('np.where(a >= 0.0, a, NaN)'),
                          'np.where(a >= 0.0, a, NaN)')
+        # xarray.DataArray.where() method:
+        self.assertEqual(transpile_expr('a.where(a.x >= 0.0)'),
+                         'a.where(a.x >= 0.0)')
 
     def test_mixed(self):
         self.assertEqual(transpile_expr('a+sin(x + 2.8)'),

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -206,7 +206,7 @@ def _process_input(input_processor: InputProcessor,
         return False
 
     if output_variables:
-        output_variables = to_resolved_name_dict_pairs(output_variables, input_dataset)
+        output_variables = to_resolved_name_dict_pairs(output_variables, input_dataset, keep=True)
     else:
         output_variables = [(var_name, None) for var_name in input_dataset.data_vars]
 


### PR DESCRIPTION
Now supporting xarray and numpy functions in expressions. You can now use 
`xr` and `np` contexts, e.g. `xr.where(CHL >= 0.0, CHL)` or `CHL.where(CHL >= 0.0)`.

Closes  #257