### PR TITLE
improved efficiency of unchunk()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,10 @@
 
 ### Other
 
+* The `unchunk_coords` keyword argument of Python API function 
+  `xcube.core.optimize.optimize_dataset()` can now be a name, or list of names  
+  of the coordinate variable(s) to be consolidated. If boolean ``True`` is used
+  all variables will be consolidated.
 * The `xcube serve` API operations `datasets/` and `datasets/{ds_id}` now also
   return the metadata attributes of a given dataset and it variables in a property
   named `attrs`. For variables we added a new metadata property `htmlRepr` that is

--- a/test/cli/test_optimize.py
+++ b/test/cli/test_optimize.py
@@ -1,55 +1,55 @@
 from test.cli.helpers import CliDataTest
-from test.core.test_optimize import TEST_CUBE, TEST_CUBE_ZARR, TEST_CUBE_FILE_SET, list_file_set
+from test.core.test_optimize import TEST_CUBE, INPUT_CUBE_PATH, INPUT_CUBE_FILE_SET, list_file_set
 from xcube.core.dsio import rimraf
 
-TEST_CUBE_ZARR_OPTIMIZED_DEFAULT = 'test-optimized.zarr'
-TEST_CUBE_ZARR_OPTIMIZED_USER = 'fast-test.zarr'
+OUTPUT_CUBE_OPTIMIZED_DEFAULT_PATH = 'test-optimized.zarr'
+OUTPUT_CUBE_OPTIMIZED_USER_PATH = 'fast-test.zarr'
 
 
 class OptimizeDataTest(CliDataTest):
     def _clear_outputs(self):
-        rimraf(TEST_CUBE_ZARR)
-        rimraf(TEST_CUBE_ZARR_OPTIMIZED_DEFAULT)
-        rimraf(TEST_CUBE_ZARR_OPTIMIZED_USER)
+        rimraf(INPUT_CUBE_PATH)
+        rimraf(OUTPUT_CUBE_OPTIMIZED_DEFAULT_PATH)
+        rimraf(OUTPUT_CUBE_OPTIMIZED_USER_PATH)
 
     def setUp(self):
         self._clear_outputs()
-        TEST_CUBE.to_zarr(TEST_CUBE_ZARR)
+        TEST_CUBE.to_zarr(INPUT_CUBE_PATH)
 
     def tearDown(self):
         self._clear_outputs()
 
     def test_defaults(self):
-        result = self.invoke_cli(['optimize', TEST_CUBE_ZARR])
+        result = self.invoke_cli(['optimize', INPUT_CUBE_PATH])
         self.assertEqual(0, result.exit_code)
 
-        expected_files = set(TEST_CUBE_FILE_SET)
+        expected_files = set(INPUT_CUBE_FILE_SET)
         expected_files.add('.zmetadata')
-        self.assertEqual(expected_files, list_file_set(TEST_CUBE_ZARR_OPTIMIZED_DEFAULT))
+        self.assertEqual(expected_files, list_file_set(OUTPUT_CUBE_OPTIMIZED_DEFAULT_PATH))
 
     def test_user_output(self):
-        result = self.invoke_cli(['optimize', '-o', TEST_CUBE_ZARR_OPTIMIZED_USER, '-C', TEST_CUBE_ZARR])
+        result = self.invoke_cli(['optimize', '-o', OUTPUT_CUBE_OPTIMIZED_USER_PATH, '-C', INPUT_CUBE_PATH])
         self.assertEqual(0, result.exit_code)
 
-        expected_files = set(TEST_CUBE_FILE_SET)
+        expected_files = set(INPUT_CUBE_FILE_SET)
         expected_files.add('.zmetadata')
         expected_files.remove('time/1')
         expected_files.remove('time/2')
         expected_files.remove('time_bnds/1.0')
         expected_files.remove('time_bnds/2.0')
-        self.assertEqual(expected_files, list_file_set(TEST_CUBE_ZARR_OPTIMIZED_USER))
+        self.assertEqual(expected_files, list_file_set(OUTPUT_CUBE_OPTIMIZED_USER_PATH))
 
     def test_in_place(self):
-        result = self.invoke_cli(['optimize', '-IC', TEST_CUBE_ZARR])
+        result = self.invoke_cli(['optimize', '-IC', INPUT_CUBE_PATH])
         self.assertEqual(0, result.exit_code)
 
-        expected_files = set(TEST_CUBE_FILE_SET)
+        expected_files = set(INPUT_CUBE_FILE_SET)
         expected_files.add('.zmetadata')
         expected_files.remove('time/1')
         expected_files.remove('time/2')
         expected_files.remove('time_bnds/1.0')
         expected_files.remove('time_bnds/2.0')
-        self.assertEqual(expected_files, list_file_set(TEST_CUBE_ZARR))
+        self.assertEqual(expected_files, list_file_set(INPUT_CUBE_PATH))
 
 
 class OptimizeTest(CliDataTest):

--- a/test/core/test_optimize.py
+++ b/test/core/test_optimize.py
@@ -1,20 +1,22 @@
 import os
 import os.path
 import unittest
-from typing import Set
+from typing import Set, Union, Sequence
 
-from xcube.core.new import new_cube
-from xcube.core.chunk import chunk_dataset
 from xcube.constants import FORMAT_NAME_ZARR
+from xcube.core.chunk import chunk_dataset
 from xcube.core.dsio import rimraf
+from xcube.core.new import new_cube
 from xcube.core.optimize import optimize_dataset
 
 TEST_CUBE = chunk_dataset(new_cube(time_periods=3, variables=dict(A=0.5, B=-1.5)),
                           chunk_sizes=dict(time=1, lat=180, lon=360), format_name=FORMAT_NAME_ZARR)
 
-TEST_CUBE_ZARR = 'test.zarr'
+INPUT_CUBE_PATH = 'test.zarr'
+OUTPUT_CUBE_PATH = 'test_opt.zarr'
+OUTPUT_CUBE_PATTERN = '{input}_opt.zarr'
 
-TEST_CUBE_FILE_SET = {
+INPUT_CUBE_FILE_SET = {
     '.zattrs', '.zgroup',
     'A/.zarray', 'A/.zattrs', 'A/0.0.0', 'A/1.0.0', 'A/2.0.0',
     'B/.zarray', 'B/.zattrs', 'B/0.0.0', 'B/1.0.0', 'B/2.0.0',
@@ -28,35 +30,103 @@ TEST_CUBE_FILE_SET = {
 
 
 class OptimizeDatasetTest(unittest.TestCase):
+    def _clear_outputs(self):
+        rimraf(INPUT_CUBE_PATH)
+        rimraf(OUTPUT_CUBE_PATH)
 
     def setUp(self):
-        rimraf(TEST_CUBE_ZARR)
-        TEST_CUBE.to_zarr(TEST_CUBE_ZARR)
+        self._clear_outputs()
+        TEST_CUBE.to_zarr(INPUT_CUBE_PATH)
+        self.assertEqual(INPUT_CUBE_FILE_SET, list_file_set(INPUT_CUBE_PATH))
 
     def tearDown(self):
-        rimraf(TEST_CUBE_ZARR)
+        self._clear_outputs()
+
+    def test_optimize_dataset(self):
+        self._test_optimize_dataset(unchunk_coords=False, in_place=False,
+                                    expected_output_path=OUTPUT_CUBE_PATH,
+                                    expected_cons_time=False,
+                                    expected_cons_time_bnds=False)
 
     def test_optimize_dataset_in_place(self):
-        self.assertEqual(TEST_CUBE_FILE_SET, list_file_set(TEST_CUBE_ZARR))
+        self._test_optimize_dataset(unchunk_coords=False, in_place=True,
+                                    expected_output_path=INPUT_CUBE_PATH,
+                                    expected_cons_time=False,
+                                    expected_cons_time_bnds=False)
 
-        optimize_dataset(TEST_CUBE_ZARR, in_place=True)
+    def test_optimize_dataset_unchunk_coords_true(self):
+        self._test_optimize_dataset(unchunk_coords=True, in_place=False,
+                                    expected_output_path=OUTPUT_CUBE_PATH,
+                                    expected_cons_time=True,
+                                    expected_cons_time_bnds=True)
 
-        expected_files = set(TEST_CUBE_FILE_SET)
+    def test_optimize_dataset_unchunk_coords_true_in_place(self):
+        self._test_optimize_dataset(unchunk_coords=True, in_place=True,
+                                    expected_output_path=INPUT_CUBE_PATH,
+                                    expected_cons_time=True,
+                                    expected_cons_time_bnds=True)
+
+    def test_optimize_dataset_unchunk_coords_str(self):
+        self._test_optimize_dataset(unchunk_coords='time', in_place=False,
+                                    expected_output_path=OUTPUT_CUBE_PATH,
+                                    expected_cons_time=True,
+                                    expected_cons_time_bnds=False)
+
+    def test_optimize_dataset_unchunk_coords_str_in_place(self):
+        self._test_optimize_dataset(unchunk_coords='time', in_place=True,
+                                    expected_output_path=INPUT_CUBE_PATH,
+                                    expected_cons_time=True,
+                                    expected_cons_time_bnds=False)
+
+    def test_optimize_dataset_unchunk_coords_str_list(self):
+        self._test_optimize_dataset(unchunk_coords=['time_bnds'], in_place=False,
+                                    expected_output_path=OUTPUT_CUBE_PATH,
+                                    expected_cons_time=False,
+                                    expected_cons_time_bnds=True)
+
+    def test_optimize_dataset_unchunk_coords_str_list_in_place(self):
+        self._test_optimize_dataset(unchunk_coords=['time_bnds'], in_place=True,
+                                    expected_output_path=INPUT_CUBE_PATH,
+                                    expected_cons_time=False,
+                                    expected_cons_time_bnds=True)
+
+    def test_optimize_dataset_unchunk_coords_str_tuple(self):
+        self._test_optimize_dataset(unchunk_coords=('time_bnds', 'time'), in_place=False,
+                                    expected_output_path=OUTPUT_CUBE_PATH,
+                                    expected_cons_time=True,
+                                    expected_cons_time_bnds=True)
+
+    def test_optimize_dataset_unchunk_coords_str_tuple_in_place(self):
+        self._test_optimize_dataset(unchunk_coords=('time_bnds', 'time'), in_place=True,
+                                    expected_output_path=INPUT_CUBE_PATH,
+                                    expected_cons_time=True,
+                                    expected_cons_time_bnds=True)
+
+    def _test_optimize_dataset(self, unchunk_coords: Union[bool, str, Sequence[str]], in_place: bool,
+                               expected_output_path: str, expected_cons_time: bool = False,
+                               expected_cons_time_bnds: bool = False):
+        if not in_place:
+            optimize_dataset(INPUT_CUBE_PATH, output_path=OUTPUT_CUBE_PATTERN,
+                             in_place=in_place, unchunk_coords=unchunk_coords)
+        else:
+            optimize_dataset(INPUT_CUBE_PATH,
+                             in_place=in_place, unchunk_coords=unchunk_coords)
+        self._assert_consolidated(expected_output_path, expected_cons_time, expected_cons_time_bnds)
+
+    def _assert_consolidated(self,
+                             cube_path: str,
+                             cons_time: bool = False,
+                             cons_time_bnds: bool = False):
+        self.assertTrue(os.path.isdir(cube_path))
+        expected_files = set(INPUT_CUBE_FILE_SET)
         expected_files.add('.zmetadata')
-        self.assertEqual(expected_files, list_file_set(TEST_CUBE_ZARR))
-
-    def test_optimize_dataset_in_place_unchunk_coords(self):
-        self.assertEqual(TEST_CUBE_FILE_SET, list_file_set(TEST_CUBE_ZARR))
-
-        optimize_dataset(TEST_CUBE_ZARR, in_place=True, unchunk_coords=True)
-
-        expected_files = set(TEST_CUBE_FILE_SET)
-        expected_files.add('.zmetadata')
-        expected_files.remove('time/1')
-        expected_files.remove('time/2')
-        expected_files.remove('time_bnds/1.0')
-        expected_files.remove('time_bnds/2.0')
-        self.assertEqual(expected_files, list_file_set(TEST_CUBE_ZARR))
+        if cons_time:
+            expected_files.remove('time/1')
+            expected_files.remove('time/2')
+        if cons_time_bnds:
+            expected_files.remove('time_bnds/1.0')
+            expected_files.remove('time_bnds/2.0')
+        self.assertEqual(expected_files, list_file_set(cube_path))
 
     def test_failures(self):
         with self.assertRaises(RuntimeError) as cm:
@@ -64,15 +134,15 @@ class OptimizeDatasetTest(unittest.TestCase):
         self.assertEqual('Input path must point to ZARR dataset directory.', f'{cm.exception}')
 
         with self.assertRaises(RuntimeError) as cm:
-            optimize_dataset(TEST_CUBE_ZARR, exception_type=RuntimeError)
+            optimize_dataset(INPUT_CUBE_PATH, exception_type=RuntimeError)
         self.assertEqual('Output path must be given.', f'{cm.exception}')
 
         with self.assertRaises(RuntimeError) as cm:
-            optimize_dataset(TEST_CUBE_ZARR, output_path=TEST_CUBE_ZARR, exception_type=RuntimeError)
+            optimize_dataset(INPUT_CUBE_PATH, output_path=INPUT_CUBE_PATH, exception_type=RuntimeError)
         self.assertEqual('Output path already exists.', f'{cm.exception}')
 
         with self.assertRaises(RuntimeError) as cm:
-            optimize_dataset(TEST_CUBE_ZARR, output_path='./' + TEST_CUBE_ZARR, exception_type=RuntimeError)
+            optimize_dataset(INPUT_CUBE_PATH, output_path='./' + INPUT_CUBE_PATH, exception_type=RuntimeError)
         self.assertEqual('Output path already exists.', f'{cm.exception}')
 
 

--- a/test/core/test_unchunk.py
+++ b/test/core/test_unchunk.py
@@ -1,10 +1,10 @@
 import os.path
 import unittest
 
-from xcube.core.new import new_cube
-from xcube.core.chunk import chunk_dataset
 from xcube.constants import FORMAT_NAME_ZARR
+from xcube.core.chunk import chunk_dataset
 from xcube.core.dsio import rimraf
+from xcube.core.new import new_cube
 from xcube.core.unchunk import unchunk_dataset
 
 
@@ -93,7 +93,16 @@ class UnchunkDatasetTest(unittest.TestCase):
     def test_unchunk_invalid_path(self):
         with self.assertRaises(ValueError) as cm:
             unchunk_dataset(self.TEST_ZARR + '.zip')
-        self.assertEqual("'test.zarr.zip' is not a valid ZARR directory", f'{cm.exception}')
+        self.assertEqual("'test.zarr.zip' is not a valid Zarr directory", f'{cm.exception}')
+
+    def test_unchunk_invalid_vars(self):
+        with self.assertRaises(ValueError) as cm:
+            unchunk_dataset(self.TEST_ZARR, var_names=['times'], coords_only=True)
+        self.assertEqual("variable 'times' is not a coordinate variable in 'test.zarr'", f'{cm.exception}')
+
+        with self.assertRaises(ValueError) as cm:
+            unchunk_dataset(self.TEST_ZARR, var_names=['CHL'], coords_only=False)
+        self.assertEqual("variable 'CHL' is not a variable in 'test.zarr'", f'{cm.exception}')
 
     def _assert_cube_files(self,
                            expected_a_files, expected_b_files,


### PR DESCRIPTION
Optimization: if `"shape"` and `"chunks"` are equal in `${var}/.zarray`, do not open the zarr array. This should improve efficiency of unchunk().