### PR TITLE
Forman xxx include dataset attributions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,7 @@
   where `compute_variables` is a function that receives the parent xcube dataset
   and is expected to return a new dataset with new variables. 
   
-* `xcube serve` now provides basic access control via OAuth2 bearer tokens (#263).
+* The `xcube serve` tool now provides basic access control via OAuth2 bearer tokens (#263).
   To configure a service instance with access control, add the following to the 
   `xcube serve` configuration file:
   
@@ -107,8 +107,16 @@
   in other words, create an overview of a cube. 
   By [Alberto S. Rabaneda](https://github.com/rabaneda).
  
-
-### Other
+* The `xcube serve` tool now also serves dataset attribution information which will be 
+  displayed in the xcube-viewer's map. To add attribution information, use the `DatasetAttribution` 
+  in to your `xcube serve` configuration. It can be used on top-level (for all dataset), 
+  or on individual datasets. Its value may be a single text entry or a list of texts:
+  For example: 
+  ```yaml
+  DatasetAttribution: 
+    - "© by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA."
+    - "Funded by EU H2020 DCS4COP project."
+  ```
 * The `xcube gen` tool now always produces consolidated xcube datasets when the output format is zarr. 
   Furthermore when appending to an existing zarr xcube dataset, the output now will be consolidated as well. 
   In addition, `xcube gen` can now append input time slices to existing optimized (consolidated) zarr xcube datasets.

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -2,6 +2,10 @@ Authentication:
   Domain: xcube-dev.eu.auth0.com
   Audience: https://xcube-dev/api/
 
+DatasetAttribution:
+  - "© by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA"
+  - "© by EU H2020 CyanoAlert project"
+
 Datasets:
   # Will only appear for unauthorized clients
   - Identifier: local

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -15,12 +15,13 @@ class CatalogueControllerTest(unittest.TestCase):
         self.assertIn("datasets", response)
         self.assertIsInstance(response["datasets"], list)
         self.assertEqual(2, len(response["datasets"]))
-        dataset = response["datasets"][0]
-        self.assertIsInstance(dataset, dict)
-        self.assertIn("id", dataset)
-        self.assertIn("title", dataset)
-        self.assertNotIn("variables", dataset)
-        self.assertNotIn("dimensions", dataset)
+
+        for dataset in response["datasets"]:
+            self.assertIsInstance(dataset, dict)
+            self.assertIn("id", dataset)
+            self.assertIn("title", dataset)
+            self.assertNotIn("variables", dataset)
+            self.assertNotIn("dimensions", dataset)
 
     def test_dataset_with_details(self):
         ctx = new_test_service_context()
@@ -30,12 +31,26 @@ class CatalogueControllerTest(unittest.TestCase):
         self.assertIn("datasets", response)
         self.assertIsInstance(response["datasets"], list)
         self.assertEqual(2, len(response["datasets"]))
-        dataset = response["datasets"][0]
-        self.assertIsInstance(dataset, dict)
-        self.assertIn("id", dataset)
-        self.assertIn("title", dataset)
-        self.assertIn("variables", dataset)
-        self.assertIn("dimensions", dataset)
+
+        demo_dataset = None
+        demo_1w_dataset = None
+        for dataset in response["datasets"]:
+            self.assertIsInstance(dataset, dict)
+            self.assertIn("id", dataset)
+            self.assertIn("title", dataset)
+            self.assertIn("attributions", dataset)
+            self.assertIn("variables", dataset)
+            self.assertIn("dimensions", dataset)
+            if dataset["id"] == "demo":
+                demo_dataset = dataset
+            if dataset["id"] == "demo-1w":
+                demo_1w_dataset = dataset
+
+        self.assertIsNotNone(demo_dataset)
+        self.assertIsNotNone(demo_1w_dataset)
+        self.assertEqual(["© by EU H2020 CyanoAlert project"], demo_dataset['attributions'])
+        self.assertEqual(["© by Brockmann Consult GmbH 2020, "
+                          "contains modified Copernicus Data 2019, processed by ESA"], demo_1w_dataset['attributions'])
 
     def test_dataset_with_point(self):
         ctx = new_test_service_context()

--- a/test/webapi/helpers.py
+++ b/test/webapi/helpers.py
@@ -13,7 +13,7 @@ def new_test_service_context(config_file_name: str = 'config.yml',
                              ml_dataset_openers: Dict[str, MultiLevelDatasetOpener] = None) -> ServiceContext:
     ctx = ServiceContext(base_dir=get_res_test_dir(), ml_dataset_openers=ml_dataset_openers)
     config_file = os.path.join(ctx.base_dir, config_file_name)
-    with open(config_file) as fp:
+    with open(config_file, encoding='utf-8') as fp:
         ctx.config = yaml.safe_load(fp)
     return ctx
 

--- a/test/webapi/res/test/config.yml
+++ b/test/webapi/res/test/config.yml
@@ -1,8 +1,12 @@
+DatasetAttribution:
+  - © by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA
+
 Datasets:
   - Identifier: demo
     Title: xcube-server Demonstration L2C Cube
     Path: ../../../../examples/serve/demo/cube-1-250-250.zarr
     Style: default
+    DatasetAttribution: © by EU H2020 CyanoAlert project
 
   - Identifier: demo-1w
     Title: xcube-server Demonstration L3 Cube

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -3,7 +3,6 @@ import json
 from typing import Dict, Tuple, List, Set
 
 import numpy as np
-
 from xcube.core.geom import get_dataset_bounds
 from xcube.core.timecoord import timestamp_to_iso_string
 from xcube.util.cmaps import get_cmaps
@@ -143,6 +142,12 @@ def get_dataset(ctx: ServiceContext,
     dataset_dict["dimensions"] = [get_dataset_coordinates(ctx, ds_id, dim_name) for dim_name in dim_names]
 
     dataset_dict["attrs"] = {key: ds.attrs[key] for key in sorted(list(ds.attrs.keys()))}
+
+    dataset_attributions = dataset_descriptor.get('DatasetAttribution', ctx.config.get('DatasetAttribution'))
+    if dataset_attributions is not None:
+        if isinstance(dataset_attributions, str):
+            dataset_attributions = [dataset_attributions]
+        dataset_dict['attributions'] = dataset_attributions
 
     place_groups = ctx.get_dataset_place_groups(ds_id, base_url)
     if place_groups:

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -223,7 +223,7 @@ class Service:
         if self.context.config_mtime != stat.st_mtime:
             self.context.config_mtime = stat.st_mtime
             try:
-                with open(config_file) as stream:
+                with open(config_file, encoding='utf-8') as stream:
                     self.context.config = yaml.safe_load(stream)
                 self.config_error = None
                 _LOG.info(f'configuration file {config_file!r} successfully loaded')


### PR DESCRIPTION
* The `xcube serve` tool now also serves dataset attribution information which will be 
  displayed in the xcube-viewer's map. To add attribution information, use the `DatasetAttribution` 
  in to your `xcube serve` configuration. It can be used on top-level (for all dataset), 
  or on individual datasets. Its value may be a single text entry or a list of texts:
  For example: 
  ```yaml
  DatasetAttribution: 
    - "© by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA."
    - "Funded by EU H2020 DCS4COP project."
  ```
* I haven't created a separate PR for the viewer as the required change boiled down to uncommenting an old TODO. So I pushed on its master directly. Please, if possible, review quickly, as this is needed for the CyanoAlert service.