### PR TITLE
Additional timer for time series

### DIFF
--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -57,8 +57,8 @@ def get_ml_dataset_tile(ml_dataset: MultiLevelDataset,
                         trace_perf: bool = False,
                         exception_type: Type[Exception] = ValueError):
     labels = labels or {}
-    ds_id = hex(id(ml_dataset))
-    image_id = '-'.join(map(str, [ds_id, z, var_name, cmap_name, cmap_range]
+    ds_cache_id = hex(id(ml_dataset))
+    image_id = '-'.join(map(str, [ds_cache_id, z, ml_dataset.ds_id, var_name, cmap_name, cmap_range]
                             + [f'{dim_name}={dim_value}' for dim_name, dim_value in labels.items()]))
 
     if image_cache and image_id in image_cache:

--- a/xcube/webapi/controllers/timeseries.py
+++ b/xcube/webapi/controllers/timeseries.py
@@ -90,7 +90,8 @@ def get_time_series_for_point(ctx: ServiceContext,
     :return: Time-series data structure.
     """
     measure_time = measure_time_cm(disabled=not ctx.trace_perf)
-    with measure_time('get_time_series_for_point'):
+    with measure_time(f'get_time_series_for_point for dataset identifier {ds_name}, '
+                      f'variable {var_name} for lon {lon} and lat {lat}'):
         dataset = _get_time_series_dataset(ctx, ds_name, var_name)
         return _get_time_series_for_point(dataset, var_name,
                                           shapely.geometry.Point(lon, lat),
@@ -124,18 +125,21 @@ def get_time_series_for_geometry(ctx: ServiceContext,
            if it is a positive integer, the most recent valid values are returned.
     :return: Time-series data structure.
     """
-    dataset = _get_time_series_dataset(ctx, ds_name, var_name)
-    if not GeoJSON.is_geometry(geometry):
-        raise ServiceBadRequestError("Invalid GeoJSON geometry")
-    if isinstance(geometry, dict):
-        geometry = shapely.geometry.shape(geometry)
-    return _get_time_series_for_geometry(dataset, var_name,
-                                         geometry,
-                                         start_date=start_date,
-                                         end_date=end_date,
-                                         include_count=include_count,
-                                         include_stdev=include_stdev,
-                                         max_valids=max_valids)
+    measure_time = measure_time_cm(disabled=not ctx.trace_perf)
+    with measure_time(f'get_time_series_for_geometry for dataset identifier {ds_name} and variable {var_name}, '
+                      f'geometry type {geometry.get("type")} with coordinates {geometry.get("coordinates")}'):
+        dataset = _get_time_series_dataset(ctx, ds_name, var_name)
+        if not GeoJSON.is_geometry(geometry):
+            raise ServiceBadRequestError("Invalid GeoJSON geometry")
+        if isinstance(geometry, dict):
+            geometry = shapely.geometry.shape(geometry)
+        return _get_time_series_for_geometry(dataset, var_name,
+                                             geometry,
+                                             start_date=start_date,
+                                             end_date=end_date,
+                                             include_count=include_count,
+                                             include_stdev=include_stdev,
+                                             max_valids=max_valids)
 
 
 def get_time_series_for_geometry_collection(ctx: ServiceContext,


### PR DESCRIPTION
This PR adds more timers for racing time of retrieving time series and made a change to logging output, so that more logs can be associated to a particular dataset via the dataset identifier. No changes in code structure was made. 