### PR TITLE
Fix dockerfile such that serving from docker container works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM continuumio/miniconda3:latest
 MAINTAINER helge.dzierzon@brockmann-consult.de
 
 LABEL name=xcube
-LABEL version=0.3.0.dev1
+LABEL version=0.4.0.dev0
 LABEL conda_env=xcube
 
 # Ensure usage of bash (simplifies source activate calls)
@@ -42,4 +42,4 @@ EXPOSE 8000
 
 # Start server
 ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["source activate xcube && xcube"]
+CMD ["source activate xcube && xcube serve --address 0.0.0.0 --port 8000 --config ./examples/serve/demo/config.yml --verbose"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  server-xcube:
+    build: .
+    ports:
+      - 8080:8000


### PR DESCRIPTION
When serving xcubes from inside a docker container the address has to be
set to 0.0.0.0 for it to work. This is not documented anywhere and the
error message was not quite clear. I've added a docker compose file so
all anyone has to do is 'docker-compose up -d' this will spin up the
image in such a way that the xcube-viewer immediately picks up on it.