### PR TITLE
Configure Zarr store cache size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### New
 
 * The xcube web API provided through `xcube serve` can now serve RGBA tiles using the 
-  `dataset/{dataset}/variable/rgb/tiles/{z}/{y}/{x}` endpoint. The reg, green, blue 
+  `dataset/{dataset}/variable/rgb/tiles/{z}/{y}/{x}` endpoint. The red, green, blue 
   channels are computed from three configurable variables and normalisation ranges, 
   the alpha channel provides transparency for missing values. To specify a default
   RGB schema for a dataset, a colour mapping for the "pseudo-variable" named `rbg` 
@@ -143,6 +143,22 @@
 
 ### Enhancements
 
+* The `xcube serve` tool now also allows for per-dataset configuration
+  of *chunk caches* for datasets read from remote object storage locations. 
+  Chunk caching avoids recurring fetching of remote data chunks for same
+  region of interest.
+  It can be configured as default for all remote datasets at top-level of 
+  the configuration file:
+  ```
+  DatasetChunkCacheSize = 100M
+  ```
+  or in individual dataset definitions:
+  ```
+  Datasets: 
+     - Identifier: ...
+       ChunkCacheSize: 2G
+       ...
+  ```
 * CLI command `xcube resample` has been enhanced by a new value for the 
   frequency option `--frequency all`
   With this value it will be possible to create mean, max , std, ... of the whole dataset,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -150,7 +150,7 @@
   It can be configured as default for all remote datasets at top-level of 
   the configuration file:
   ```
-  DatasetChunkCacheSize = 100M
+  DatasetChunkCacheSize: 100M
   ```
   or in individual dataset definitions:
   ```

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -6,6 +6,8 @@ DatasetAttribution:
   - "© by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA"
   - "© by EU H2020 CyanoAlert project"
 
+DatasetChunkCacheSize: 100M
+
 Datasets:
   # Will only appear for unauthorized clients
   - Identifier: local
@@ -45,6 +47,7 @@ Datasets:
     Path: "dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr"
     Region: "eu-de"
     Style: default
+    ChunkCacheSize: 250M
     PlaceGroups:
       - PlaceGroupRef: inside-cube
       - PlaceGroupRef: outside-cube

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -331,20 +331,20 @@ class ContextManagerTest(unittest.TestCase):
 
 class GetPathOrStoreTest(unittest.TestCase):
     def test_path_or_store_read_from_bucket(self):
-        path = _get_path_or_store('http://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr',
-                                  mode='read')[0]
+        path, _, _ = _get_path_or_store('http://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr',
+                                        mode='read')
         self.assertIsInstance(path, fsspec.mapping.FSMap)
 
     def test_path_or_store_write_to_bucket(self):
-        path = _get_path_or_store('http://obs.eu-de.otc.t-systems.com/fake_bucket/fake_cube.zarr',
-                                  mode='write',
-                                  client_kwargs={'aws_access_key_id': 'some_fake_id',
-                                                 'aws_secret_access_key': 'some_fake_key'})[0]
+        path, _, _ = _get_path_or_store('http://obs.eu-de.otc.t-systems.com/fake_bucket/fake_cube.zarr',
+                                        mode='write',
+                                        client_kwargs={'aws_access_key_id': 'some_fake_id',
+                                                       'aws_secret_access_key': 'some_fake_key'})
         self.assertIsInstance(path, fsspec.mapping.FSMap)
 
     def test_path_or_store_read_from_local(self):
-        path = _get_path_or_store('../examples/serve/demo/cube-1-250-250.zarr',
-                                  mode='read')[0]
+        path, _, _ = _get_path_or_store('../examples/serve/demo/cube-1-250-250.zarr',
+                                        mode='read')
         self.assertIsInstance(path, str)
 
 

--- a/test/webapi/test_service.py
+++ b/test/webapi/test_service.py
@@ -1,32 +1,7 @@
 import re
 import unittest
 
-from xcube.webapi.service import url_pattern, parse_mem_size, new_default_config
-
-
-class TileCacheConfigTest(unittest.TestCase):
-    def test_parse_mem_size(self):
-        self.assertEqual({'no_cache': True}, parse_mem_size(""))
-        self.assertEqual({'no_cache': True}, parse_mem_size("0"))
-        self.assertEqual({'no_cache': True}, parse_mem_size("0M"))
-        self.assertEqual({'no_cache': True}, parse_mem_size("off"))
-        self.assertEqual({'no_cache': True}, parse_mem_size("OFF"))
-        self.assertEqual({'capacity': 200001}, parse_mem_size("200001"))
-        self.assertEqual({'capacity': 200001}, parse_mem_size("200001B"))
-        self.assertEqual({'capacity': 300000}, parse_mem_size("300K"))
-        self.assertEqual({'capacity': 3000000}, parse_mem_size("3M"))
-        self.assertEqual({'capacity': 7000000}, parse_mem_size("7m"))
-        self.assertEqual({'capacity': 2000000000}, parse_mem_size("2g"))
-        self.assertEqual({'capacity': 2000000000}, parse_mem_size("2G"))
-        self.assertEqual({'capacity': 1000000000000}, parse_mem_size("1T"))
-
-        with self.assertRaises(ValueError) as cm:
-            parse_mem_size("7n")
-        self.assertEqual("invalid tile cache size: '7N'", f"{cm.exception}")
-
-        with self.assertRaises(ValueError) as cm:
-            parse_mem_size("-2g")
-        self.assertEqual("negative tile cache size: '-2G'", f"{cm.exception}")
+from xcube.webapi.service import url_pattern, new_default_config
 
 
 class DefaultConfigTest(unittest.TestCase):

--- a/test/webapi/test_service.py
+++ b/test/webapi/test_service.py
@@ -1,31 +1,31 @@
 import re
 import unittest
 
-from xcube.webapi.service import url_pattern, parse_tile_cache_config, new_default_config
+from xcube.webapi.service import url_pattern, parse_mem_size, new_default_config
 
 
 class TileCacheConfigTest(unittest.TestCase):
-    def test_parse_tile_cache_config(self):
-        self.assertEqual({'no_cache': True}, parse_tile_cache_config(""))
-        self.assertEqual({'no_cache': True}, parse_tile_cache_config("0"))
-        self.assertEqual({'no_cache': True}, parse_tile_cache_config("0M"))
-        self.assertEqual({'no_cache': True}, parse_tile_cache_config("off"))
-        self.assertEqual({'no_cache': True}, parse_tile_cache_config("OFF"))
-        self.assertEqual({'capacity': 200001}, parse_tile_cache_config("200001"))
-        self.assertEqual({'capacity': 200001}, parse_tile_cache_config("200001B"))
-        self.assertEqual({'capacity': 300000}, parse_tile_cache_config("300K"))
-        self.assertEqual({'capacity': 3000000}, parse_tile_cache_config("3M"))
-        self.assertEqual({'capacity': 7000000}, parse_tile_cache_config("7m"))
-        self.assertEqual({'capacity': 2000000000}, parse_tile_cache_config("2g"))
-        self.assertEqual({'capacity': 2000000000}, parse_tile_cache_config("2G"))
-        self.assertEqual({'capacity': 1000000000000}, parse_tile_cache_config("1T"))
+    def test_parse_mem_size(self):
+        self.assertEqual({'no_cache': True}, parse_mem_size(""))
+        self.assertEqual({'no_cache': True}, parse_mem_size("0"))
+        self.assertEqual({'no_cache': True}, parse_mem_size("0M"))
+        self.assertEqual({'no_cache': True}, parse_mem_size("off"))
+        self.assertEqual({'no_cache': True}, parse_mem_size("OFF"))
+        self.assertEqual({'capacity': 200001}, parse_mem_size("200001"))
+        self.assertEqual({'capacity': 200001}, parse_mem_size("200001B"))
+        self.assertEqual({'capacity': 300000}, parse_mem_size("300K"))
+        self.assertEqual({'capacity': 3000000}, parse_mem_size("3M"))
+        self.assertEqual({'capacity': 7000000}, parse_mem_size("7m"))
+        self.assertEqual({'capacity': 2000000000}, parse_mem_size("2g"))
+        self.assertEqual({'capacity': 2000000000}, parse_mem_size("2G"))
+        self.assertEqual({'capacity': 1000000000000}, parse_mem_size("1T"))
 
         with self.assertRaises(ValueError) as cm:
-            parse_tile_cache_config("7n")
+            parse_mem_size("7n")
         self.assertEqual("invalid tile cache size: '7N'", f"{cm.exception}")
 
         with self.assertRaises(ValueError) as cm:
-            parse_tile_cache_config("-2g")
+            parse_mem_size("-2g")
         self.assertEqual("negative tile cache size: '-2G'", f"{cm.exception}")
 
 

--- a/xcube/util/cache.py
+++ b/xcube/util/cache.py
@@ -27,9 +27,10 @@ import time
 from abc import ABCMeta, abstractmethod
 from threading import RLock
 
+from typing import Optional
+
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
-# _DEBUG_CACHE = True
 _DEBUG_CACHE = False
 
 
@@ -428,3 +429,22 @@ def _compute_object_size(obj):
                         1)
     else:
         return sys.getsizeof(obj)
+
+
+def parse_mem_size(mem_size_text: str) -> Optional[int]:
+    mem_size_text = mem_size_text.upper()
+    if mem_size_text != "" and mem_size_text not in ("OFF", "NONE", "NULL", "FALSE"):
+        unit = mem_size_text[-1]
+        factors = {"B": 10 ** 0, "K": 10 ** 3, "M": 10 ** 6, "G": 10 ** 9, "T": 10 ** 12}
+        try:
+            if unit in factors:
+                capacity = int(mem_size_text[0: -1]) * factors[unit]
+            else:
+                capacity = int(mem_size_text)
+        except ValueError:
+            raise ValueError(f"invalid memory size: {mem_size_text!r}")
+        if capacity > 0:
+            return capacity
+        elif capacity < 0:
+            raise ValueError(f"negative memory size: {mem_size_text!r}")
+    return None

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -688,7 +688,7 @@ def _open_ml_dataset_from_python_code(ctx: ServiceContext,
     callable_name = dataset_descriptor.get('Function', COMPUTE_DATASET)
     input_dataset_ids = dataset_descriptor.get('InputDatasets', [])
     input_parameters = dataset_descriptor.get('InputParameters', {})
-    chunk_cache_capacity = self.get_dataset_chunk_cache_capacity(dataset_descriptor)
+    chunk_cache_capacity = ctx.get_dataset_chunk_cache_capacity(dataset_descriptor)
     if chunk_cache_capacity:
         warnings.warn('chunk cache size is not effective for datasets computed from scripts')
     for input_dataset_id in input_dataset_ids:

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -657,7 +657,7 @@ def _open_ml_dataset_from_object_storage(ctx: ServiceContext,
     region_name = None
     if 'Region' in dataset_descriptor:
         region_name = dataset_descriptor['Region']
-    chunk_cache_capacity = self.get_dataset_chunk_cache_capacity(dataset_descriptor)
+    chunk_cache_capacity = ctx.get_dataset_chunk_cache_capacity(dataset_descriptor)
     return open_ml_dataset_from_object_storage(path,
                                                data_format=data_format,
                                                ds_id=ds_id,

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -676,7 +676,7 @@ def _open_ml_dataset_from_local_fs(ctx: ServiceContext,
     ds_id = dataset_descriptor.get('Identifier')
     path = ctx.get_descriptor_path(dataset_descriptor, f"dataset descriptor {ds_id}")
     data_format = dataset_descriptor.get('Format')
-    chunk_cache_capacity = self.get_dataset_chunk_cache_capacity(dataset_descriptor)
+    chunk_cache_capacity = ctx.get_dataset_chunk_cache_capacity(dataset_descriptor)
     if chunk_cache_capacity:
         warnings.warn('chunk cache size is not effective for datasets stored in local file systems')
     return open_ml_dataset_from_local_fs(path,

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -113,7 +113,7 @@ class Service:
         options.log_to_stderr = log_to_stderr
         enable_pretty_logging()
 
-        tile_cache_config = parse_tile_cache_config(tile_cache_size)
+        tile_cache_config = parse_mem_size(tile_cache_size)
 
         config = None
         if cube_paths:
@@ -394,22 +394,22 @@ def url_pattern(pattern: str):
     return reg_expr
 
 
-def parse_tile_cache_config(tile_cache_size: str) -> Dict[str, Any]:
-    tile_cache_size = tile_cache_size.upper()
-    if tile_cache_size != "" and tile_cache_size != "OFF":
-        unit = tile_cache_size[-1]
+def parse_mem_size(mem_size_text: str) -> Dict[str, Any]:
+    mem_size_text = mem_size_text.upper()
+    if mem_size_text != "" and mem_size_text != "OFF":
+        unit = mem_size_text[-1]
         factors = {"B": 10 ** 0, "K": 10 ** 3, "M": 10 ** 6, "G": 10 ** 9, "T": 10 ** 12}
         try:
             if unit in factors:
-                capacity = int(tile_cache_size[0: -1]) * factors[unit]
+                capacity = int(mem_size_text[0: -1]) * factors[unit]
             else:
-                capacity = int(tile_cache_size)
+                capacity = int(mem_size_text)
         except ValueError:
-            raise ValueError(f"invalid tile cache size: {tile_cache_size!r}")
+            raise ValueError(f"invalid memory size: {mem_size_text!r}")
         if capacity > 0:
             return dict(capacity=capacity)
         elif capacity < 0:
-            raise ValueError(f"negative tile cache size: {tile_cache_size!r}")
+            raise ValueError(f"negative memory size: {mem_size_text!r}")
     return dict(no_cache=True)
 
 


### PR DESCRIPTION
The `xcube serve` tool now also allows for per-dataset configuration
of *chunk caches* for datasets read from remote object storage locations. 
Chunk caching avoids recurring fetching of remote data chunks for same
region of interest.
It can be configured as default for all remote datasets at top-level of 
the configuration file:
```
DatasetChunkCacheSize: 100M
```
or in individual dataset definitions:
```
Datasets: 
 - Identifier: ...
   ChunkCacheSize: 2G
   ...
```

Closes #288