### PR TITLE
New timeseries web API operation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,13 @@
 
 ### New
 
+* Added new `/timeseries/{dataset}/{variable}` POST operation to xcube web API.
+  It extracts time-series for a given GeoJSON object provided as body.
+  It replaces all of the `/ts/{dataset}/{variable}/{geom-type}` operations.
+  The latter are still maintained for compatibility with the "VITO viewer". 
+  
 * The xcube web API provided through `xcube serve` can now serve RGBA tiles using the 
-  `dataset/{dataset}/variable/rgb/tiles/{z}/{y}/{x}` endpoint. The red, green, blue 
+  `dataset/{dataset}/rgb/tiles/{z}/{y}/{x}` operation. The red, green, blue 
   channels are computed from three configurable variables and normalisation ranges, 
   the alpha channel provides transparency for missing values. To specify a default
   RGB schema for a dataset, a colour mapping for the "pseudo-variable" named `rbg` 

--- a/test/core/test_ancvar.py
+++ b/test/core/test_ancvar.py
@@ -50,15 +50,15 @@ class FindAncillaryVarNamesTest(unittest.TestCase):
 
     def test_xcube_prefix_convention(self):
         a = self._new_array()
-        a_stdev = self._new_array()
+        a_std = self._new_array()
         a_count = self._new_array()
         b = self._new_array()
-        b_stdev = self._new_array()
+        b_std = self._new_array()
 
         ds = xr.Dataset(dict(a=a))
         self.assertEqual({}, find_ancillary_var_names(ds, 'a'))
 
-        ds = xr.Dataset(dict(a=a, a_stdev=a_stdev, a_count=a_count, b=b, b_stdev=b_stdev))
+        ds = xr.Dataset(dict(a=a, a_std=a_std, a_count=a_count, b=b, b_std=b_std))
         self.assertEqual({'number_of_observations': {'a_count'},
-                          'standard_error': {'a_stdev'}},
+                          'standard_error': {'a_std'}},
                          find_ancillary_var_names(ds, 'a'))

--- a/test/core/test_timeseries.py
+++ b/test/core/test_timeseries.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Set
 
 import numpy as np
 import xarray as xr
@@ -6,117 +7,107 @@ import xarray as xr
 from xcube.core.new import new_cube
 from xcube.core.timeseries import get_time_series
 
+POINT_GEOMETRY = dict(type='Point', coordinates=[20.0, 10.0])
+POLYGON_GEOMETRY = dict(type='Polygon', coordinates=[[[20.0, 10.0],
+                                                      [20.0, 20.0],
+                                                      [10.0, 20.0],
+                                                      [10.0, 10.0],
+                                                      [20.0, 10.0]]])
 
-class TsTest(unittest.TestCase):
+
+class GetTimeSeriesTest(unittest.TestCase):
 
     def test_point(self):
-        ts_ds = get_time_series(self.cube, dict(type='Point', coordinates=[20.0, 10.0]))
-        self.assert_dataset_ok(ts_ds, 1, True, False, False, True, False, False)
+        ts_ds = get_time_series(self.cube, POINT_GEOMETRY)
+        self.assert_dataset_ok(ts_ds, 1, {'A', 'B'})
 
     def test_polygon(self):
-        ts_ds = get_time_series(self.cube,
-                                dict(type='Polygon',
-                                     coordinates=[[[20.0, 10.0],
-                                                   [20.0, 20.0],
-                                                   [10.0, 20.0],
-                                                   [10.0, 10.0],
-                                                   [20.0, 10.0]]]))
-        self.assert_dataset_ok(ts_ds, 100, True, False, False, True, False, False)
+        ts_ds = get_time_series(self.cube, POLYGON_GEOMETRY)
+        self.assert_dataset_ok(ts_ds, 100, {'A_mean', 'B_mean'})
 
-    def test_polygon_incl_count_stdev(self):
+    def test_polygon_agg_median_mean_std(self):
         ts_ds = get_time_series(self.cube,
-                                dict(type='Polygon',
-                                     coordinates=[[[20.0, 10.0],
-                                                   [20.0, 20.0],
-                                                   [10.0, 20.0],
-                                                   [10.0, 10.0],
-                                                   [20.0, 10.0]]]),
-                                include_count=True,
-                                include_stdev=True)
-        self.assert_dataset_ok(ts_ds, 100, True, True, True, True, True, True)
+                                POLYGON_GEOMETRY,
+                                agg_methods=['mean', 'std', 'median'])
+        self.assert_dataset_ok(ts_ds, 100, {'A_mean', 'A_median', 'A_std', 'B_mean', 'B_median', 'B_std'})
 
-    def test_polygon_incl_count(self):
+    def test_polygon_agg_median_mean_std_groupby(self):
         ts_ds = get_time_series(self.cube,
-                                dict(type='Polygon',
-                                     coordinates=[[[20.0, 10.0],
-                                                   [20.0, 20.0],
-                                                   [10.0, 20.0],
-                                                   [10.0, 10.0],
-                                                   [20.0, 10.0]]]),
-                                include_count=True)
-        self.assert_dataset_ok(ts_ds, 100, True, True, False, True, True, False)
-
-    def test_polygon_incl_stdev_var_subs(self):
-        ts_ds = get_time_series(self.cube,
-                                dict(type='Polygon',
-                                     coordinates=[[[20.0, 10.0],
-                                                   [20.0, 20.0],
-                                                   [10.0, 20.0],
-                                                   [10.0, 10.0],
-                                                   [20.0, 10.0]]]),
-                                var_names=['B'],
-                                include_stdev=True)
-        self.assert_dataset_ok(ts_ds, 100, False, False, False, True, False, True)
-
-    def test_polygon_using_groupby(self):
-        ts_ds = get_time_series(self.cube,
-                                dict(type='Polygon',
-                                     coordinates=[[[20.0, 10.0],
-                                                   [20.0, 20.0],
-                                                   [10.0, 20.0],
-                                                   [10.0, 10.0],
-                                                   [20.0, 10.0]]]),
-                                include_count=True,
-                                include_stdev=True,
+                                POLYGON_GEOMETRY,
+                                agg_methods=['mean', 'std', 'median'],
                                 use_groupby=True)
-        self.assert_dataset_ok(ts_ds, 100, True, True, True, True, True, True)
+        self.assert_dataset_ok(ts_ds, 100, {'A_mean', 'A_median', 'A_std', 'B_mean', 'B_median', 'B_std'})
+
+    def test_polygon_agg_mean_count(self):
+        ts_ds = get_time_series(self.cube,
+                                POLYGON_GEOMETRY,
+                                agg_methods=['mean', 'count'])
+        self.assert_dataset_ok(ts_ds, 100, {'A_mean', 'A_count', 'B_mean', 'B_count'})
+
+    def test_polygon_agg_mean_std_var_subs(self):
+        ts_ds = get_time_series(self.cube,
+                                POLYGON_GEOMETRY,
+                                var_names=['B'],
+                                agg_methods=['mean', 'std'])
+        self.assert_dataset_ok(ts_ds, 100, {'B_mean', 'B_std'})
+
+    def test_polygon_deprecated_incl_count_stdev(self):
+        ts_ds = get_time_series(self.cube,
+                                POLYGON_GEOMETRY,
+                                include_count=True,
+                                include_stdev=True)
+        self.assert_dataset_ok(ts_ds, 100, {'A_mean', 'A_count', 'A_std', 'B_mean', 'B_count', 'B_std'})
 
     def test_no_vars(self):
         ts_ds = get_time_series(self.cube,
-                                dict(type='Polygon',
-                                     coordinates=[[[20.0, 10.0],
-                                                   [20.0, 20.0],
-                                                   [10.0, 20.0],
-                                                   [10.0, 10.0],
-                                                   [20.0, 10.0]]]),
+                                POLYGON_GEOMETRY,
                                 var_names=[])
         self.assertIsNone(ts_ds)
+
+    def test_illegal_agg_methods(self):
+        with self.assertRaises(ValueError) as cm:
+            get_time_series(self.cube, POLYGON_GEOMETRY, agg_methods=['mean', 'median', 'stdev'])
+        self.assertEqual('invalid aggregation method: stdev', f'{cm.exception}')
+
+        with self.assertRaises(ValueError) as cm:
+            get_time_series(self.cube, POLYGON_GEOMETRY, agg_methods=['median', 'stdev', 'avg'])
+        self.assertEqual('invalid aggregation methods: avg, stdev', f'{cm.exception}')
 
     def setUp(self):
         shape = 25, 180, 360
         dims = 'time', 'lat', 'lon'
         self.ts_a = np.linspace(1, 25, 25)
+        self.ts_a_mean = np.linspace(1, 25, 25)
         self.ts_a_count = np.array(25 * [100])
-        self.ts_a_stdev = np.array(25 * [0.0])
+        self.ts_a_std = np.array(25 * [0.0])
         self.ts_b = np.linspace(0, 1, 25)
+        self.ts_b_mean = np.linspace(0, 1, 25)
         self.ts_b_count = np.array(25 * [100])
-        self.ts_b_stdev = np.array(25 * [0.0])
+        self.ts_b_std = np.array(25 * [0.0])
         self.cube = new_cube(time_periods=25,
                              variables=dict(
-                                 A=xr.DataArray(np.broadcast_to(self.ts_a.reshape(25, 1, 1), shape), dims=dims),
-                                 B=xr.DataArray(np.broadcast_to(self.ts_b.reshape(25, 1, 1), shape), dims=dims)
+                                 A=xr.DataArray(np.broadcast_to(self.ts_a.reshape((25, 1, 1)), shape), dims=dims),
+                                 B=xr.DataArray(np.broadcast_to(self.ts_b.reshape((25, 1, 1)), shape), dims=dims)
                              ))
         self.cube = self.cube.chunk(chunks=dict(time=1, lat=180, lon=180))
 
-    def assert_dataset_ok(self, ts_ds,
-                          expected_max_number_of_observations=0,
-                          expected_a=False,
-                          expected_a_count=False,
-                          expected_a_stdev=False,
-                          expected_b=False,
-                          expected_b_count=False,
-                          expected_b_stdev=False):
+    def assert_dataset_ok(self, ts_ds: xr.Dataset,
+                          expected_max_number_of_observations: int = 0,
+                          expected_var_names: Set = None):
+        expected_var_names = expected_var_names or set()
         self.assertIsNotNone(ts_ds)
         self.assertEqual(expected_max_number_of_observations, ts_ds.attrs.get('max_number_of_observations'))
-        self.assert_variable_ok(ts_ds, 'A', expected_a, self.ts_a)
-        self.assert_variable_ok(ts_ds, 'A_count', expected_a_count, self.ts_a_count)
-        self.assert_variable_ok(ts_ds, 'A_stdev', expected_a_stdev, self.ts_a_stdev)
-        self.assert_variable_ok(ts_ds, 'B', expected_b, self.ts_b)
-        self.assert_variable_ok(ts_ds, 'B_count', expected_b_count, self.ts_b_count)
-        self.assert_variable_ok(ts_ds, 'B_stdev', expected_b_stdev, self.ts_b_stdev)
+        self.assert_variable_ok(ts_ds, 'A', expected_var_names, self.ts_a)
+        self.assert_variable_ok(ts_ds, 'A_mean', expected_var_names, self.ts_a_mean)
+        self.assert_variable_ok(ts_ds, 'A_count', expected_var_names, self.ts_a_count)
+        self.assert_variable_ok(ts_ds, 'A_std', expected_var_names, self.ts_a_std)
+        self.assert_variable_ok(ts_ds, 'B', expected_var_names, self.ts_b)
+        self.assert_variable_ok(ts_ds, 'B_mean', expected_var_names, self.ts_b_mean)
+        self.assert_variable_ok(ts_ds, 'B_count', expected_var_names, self.ts_b_count)
+        self.assert_variable_ok(ts_ds, 'B_std', expected_var_names, self.ts_b_std)
 
-    def assert_variable_ok(self, ts_ds, name, expected_in, expected_values):
-        if expected_in:
+    def assert_variable_ok(self, ts_ds, name, expected_var_names: Set, expected_values):
+        if name in expected_var_names:
             self.assertIn(name, ts_ds)
             self.assertEqual(('time',), ts_ds[name].dims)
             self.assertEqual(25, ts_ds[name].size)

--- a/test/mixins.py
+++ b/test/mixins.py
@@ -1,0 +1,63 @@
+from typing import Any
+import array
+
+# noinspection PyUnresolvedReferences
+class AlmostEqualDeepMixin:
+
+    def assertAlmostEqualDeep(self,
+                              first: Any,
+                              second: Any,
+                              msg: str = None,
+                              places: int = None,
+                              delta: float = None):
+        """
+        Performs self.assertAlmostEqual() on number, and numbers in dictionaries and sequences.
+
+        Note that decimal places (from zero) are usually not the same
+        as significant digits (measured from the most significant digit).
+
+        If the two objects compare equal then they will automatically
+        compare almost equal.
+        """
+        if first == second:
+            # shortcut
+            return
+
+        if isinstance(first, float) or isinstance(second, float):
+            self.assertAlmostEqual(first, second, msg=msg, places=places, delta=delta)
+            # success
+            return
+
+        if isinstance(first, set) or isinstance(second, set):
+            # we currently cannot almost-equal-compare sets, but it is possible:
+            #  - first remove items from both sets that are strictly equal
+            #  - secondly remove items from both sets that are almost equal
+            #  - are both empty in the end?
+            self.assertEqual(first, second, msg=msg)
+            # success
+            return
+
+        if isinstance(first, dict) and isinstance(second, dict):
+            if len(first) != len(second):
+                self.assertEqual(first, second, msg=msg)  # fail
+            for key, first_value in first.items():
+                if key not in second:
+                    self.assertEqual(first, second, msg=msg)  # fail
+                second_value = second[key]
+                self.assertAlmostEqualDeep(first_value, second_value, msg=msg, delta=delta, places=places)
+            for key, second_value in second.items():
+                if key not in first:
+                    self.assertEqual(first, second, msg=msg)  # fail
+            # success
+            return
+
+        if isinstance(first, (list, tuple, array.array)) and isinstance(second, (list, tuple, array.array)):
+            if len(first) != len(second):
+                # let fail
+                self.assertEqual(first, second, msg=msg)
+            for first_value, second_value in zip(first, second):
+                self.assertAlmostEqualDeep(first_value, second_value, msg=msg, delta=delta, places=places)
+            # success
+            return
+
+        self.assertEqual(first, second, msg=msg)

--- a/test/test_mixins.py
+++ b/test/test_mixins.py
@@ -1,0 +1,84 @@
+import unittest
+
+from .mixins import AlmostEqualDeepMixin
+
+
+class AlmostEqualDeepMixinTest(unittest.TestCase, AlmostEqualDeepMixin):
+    def test_int_and_float_7_places_default(self):
+        self.assertAlmostEqualDeep(0, 0.8e-8)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(0, 0.8e-7)
+
+    def test_int(self):
+        self.assertAlmostEqualDeep(45, 45)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(45, 54)
+
+    def test_str(self):
+        self.assertAlmostEqualDeep("abc", "abc")
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep("abc", "Abc")
+
+    def test_bool(self):
+        self.assertAlmostEqualDeep(True, True)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(True, False)
+
+    def test_set(self):
+        expected = {'a', 1.1256, True}
+        self.assertAlmostEqualDeep(expected, expected)
+        self.assertAlmostEqualDeep(expected, {'a', 1.1256, True})
+        with self.assertRaises(AssertionError):
+            # We currently don't test sets
+            self.assertAlmostEqualDeep(expected, {'a', 1.1251, True}, places=2)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, {'a', 1.1256, False})
+
+    def test_dict(self):
+        expected = {'a': 1.1256, 'b': 5}
+        self.assertAlmostEqualDeep(expected, expected)
+        self.assertAlmostEqualDeep(expected, {'a': 1.1256, 'b': 5})
+        self.assertAlmostEqualDeep(expected, {'a': 1.1251, 'b': 5}, places=3)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, {'a': 1.1251, 'b': 5}, places=4)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, {'a': 1.1256, 'b': 6})
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, [1, 2, 3])
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, 3456)
+
+    def test_list(self):
+        expected = ['a', 1.1256, True]
+        self.assertAlmostEqualDeep(expected, expected)
+        self.assertAlmostEqualDeep(expected, ['a', 1.1256, True])
+        self.assertAlmostEqualDeep(expected, ('a', 1.1256, True))
+        self.assertAlmostEqualDeep(expected, ['a', 1.1251, True], places=3)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, ['a', 1.1251, True], places=4)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, ['a', 1.1256, False], places=4)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, [1, 2, 3])
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, 3456)
+
+    def test_list_dict_tuple(self):
+        expected = [
+            {'a': True, 'b': (1.1256, 45, True)},
+            {'a': False, 'b': (2.1256, 46, False)}
+        ]
+        self.assertAlmostEqualDeep(expected, expected)
+        self.assertAlmostEqualDeep(expected, [
+            {'a': True, 'b': (1.1256, 45, True)},
+            {'a': False, 'b': (2.1256, 46, False)}
+        ])
+        self.assertAlmostEqualDeep(expected, [
+            {'a': True, 'b': (1.1251, 45, True)},
+            {'a': False, 'b': (2.1259, 46, False)}
+        ], places=3)
+        with self.assertRaises(AssertionError):
+            self.assertAlmostEqualDeep(expected, [
+                {'a': True, 'b': (1.1251, 45, True)},
+                {'a': False, 'b': (2.1259, 46, False)}
+            ], places=4)

--- a/test/webapi/controllers/test_timeseries.py
+++ b/test/webapi/controllers/test_timeseries.py
@@ -1,0 +1,215 @@
+import unittest
+
+import numpy as np
+
+from test.mixins import AlmostEqualDeepMixin
+from test.webapi.helpers import new_test_service_context
+from xcube.webapi.controllers.timeseries import get_time_series
+
+
+class TimeSeriesControllerTest(unittest.TestCase, AlmostEqualDeepMixin):
+
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+    def test_get_time_series_for_point(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Point", coordinates=[2.1, 51.4]),
+                                        start_date=np.datetime64('2017-01-15'),
+                                        end_date=np.datetime64('2017-01-29'))
+        expected_result = [{'mean': 3.534773588180542, 'time': '2017-01-16T10:09:22Z'},
+                           {'mean': None, 'time': '2017-01-25T09:35:51Z'},
+                           {'mean': None, 'time': '2017-01-26T10:50:17Z'},
+                           {'mean': 20.12085723876953, 'time': '2017-01-28T09:58:11Z'}]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_point_out_of_bounds(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Point", coordinates=[-150.0, -30.0]))
+        expected_result = []
+        self.assertEqual(expected_result, actual_result)
+
+    def test_get_time_series_for_point_one_valid(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Point", coordinates=[2.1, 51.4]),
+                                        agg_methods=['mean', 'count'],
+                                        start_date=np.datetime64('2017-01-15'),
+                                        end_date=np.datetime64('2017-01-29'),
+                                        max_valids=1)
+        expected_result = [{'mean': 20.12085723876953, 'time': '2017-01-28T09:58:11Z'}]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_point_only_valids(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Point", coordinates=[2.1, 51.4]),
+                                        start_date=np.datetime64('2017-01-15'),
+                                        end_date=np.datetime64('2017-01-29'),
+                                        max_valids=-1)
+        expected_result = [{'mean': 3.534773588180542, 'time': '2017-01-16T10:09:22Z'},
+                           {'mean': 20.12085723876953, 'time': '2017-01-28T09:58:11Z'}]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_polygon(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Polygon", coordinates=[[
+                                            [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                        ]]),
+                                        agg_methods=['mean', 'count'])
+        expected_result = [{'count': 122392,
+                            'count_tot': 159600,
+                            'mean': 56.12519223634024,
+                            'time': '2017-01-16T10:09:22Z'},
+                           {'count': 0,
+                            'count_tot': 159600,
+                            'mean': None,
+                            'time': '2017-01-25T09:35:51Z'},
+                           {'count': 0,
+                            'count_tot': 159600,
+                            'mean': None,
+                            'time': '2017-01-26T10:50:17Z'},
+                           {'count': 132066,
+                            'count_tot': 159600,
+                            'mean': 49.70755256053988,
+                            'time': '2017-01-28T09:58:11Z'},
+                           {'count': 0,
+                            'count_tot': 159600,
+                            'mean': None,
+                            'time': '2017-01-30T10:46:34Z'}]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_polygon_with_all_agg_methods(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Polygon", coordinates=[[
+                                            [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                        ]]),
+                                        agg_methods=['mean', 'median', 'std', 'min', 'max', 'count'])
+
+        expected_result = [{'count': 122392,
+                            'count_tot': 159600,
+                            'max': 166.57278442382812,
+                            'mean': 56.12519223634024,
+                            'median': 48.009796142578125,
+                            'min': 0.02251400426030159,
+                            'std': 40.78859862094861,
+                            'time': '2017-01-16T10:09:22Z'},
+                           {'count': 0,
+                            'count_tot': 159600,
+                            'max': None,
+                            'mean': None,
+                            'median': None,
+                            'min': None,
+                            'std': None,
+                            'time': '2017-01-25T09:35:51Z'},
+                           {'count': 0,
+                            'count_tot': 159600,
+                            'max': None,
+                            'mean': None,
+                            'median': None,
+                            'min': None,
+                            'std': None,
+                            'time': '2017-01-26T10:50:17Z'},
+                           {'count': 132066,
+                            'count_tot': 159600,
+                            'max': 158.7908477783203,
+                            'mean': 49.70755256053988,
+                            'median': 39.326446533203125,
+                            'min': 0.02607600949704647,
+                            'std': 34.98868194514787,
+                            'time': '2017-01-28T09:58:11Z'},
+                           {'count': 0,
+                            'count_tot': 159600,
+                            'max': None,
+                            'mean': None,
+                            'median': None,
+                            'min': None,
+                            'std': None,
+                            'time': '2017-01-30T10:46:34Z'}]
+
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_polygon_one_valid(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Polygon", coordinates=[[
+                                            [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                        ]]),
+                                        agg_methods=['mean', 'count'],
+                                        max_valids=1)
+        expected_result = [{'count': 132066,
+                            'count_tot': 159600,
+                            'mean': 49.70755256053988,
+                            'time': '2017-01-28T09:58:11Z'}]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_polygon_only_valids(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx, 'demo', 'conc_tsm',
+                                        dict(type="Polygon", coordinates=[[
+                                            [1., 51.], [2., 51.], [2., 52.], [1., 52.], [1., 51.]
+                                        ]]),
+                                        agg_methods=['mean', 'count'],
+                                        max_valids=-1)
+        expected_result = [{'count': 122392,
+                            'count_tot': 159600,
+                            'mean': 56.12519223634024,
+                            'time': '2017-01-16T10:09:22Z'},
+                           {'count': 132066,
+                            'count_tot': 159600,
+                            'mean': 49.70755256053988,
+                            'time': '2017-01-28T09:58:11Z'}]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_point_collection(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx,
+                                        'demo', 'conc_tsm',
+                                        dict(type="GeometryCollection",
+                                             geometries=[
+                                                 dict(type="Point", coordinates=[2.1, 51.4])]),
+                                        agg_methods=['mean', 'count'],
+                                        start_date=np.datetime64('2017-01-15'),
+                                        end_date=np.datetime64('2017-01-29'))
+        expected_result = [[{'mean': 3.534773588180542, 'time': '2017-01-16T10:09:22Z'},
+                            {'mean': None, 'time': '2017-01-25T09:35:51Z'},
+                            {'mean': None, 'time': '2017-01-26T10:50:17Z'},
+                            {'mean': 20.12085723876953, 'time': '2017-01-28T09:58:11Z'}]]
+        self.assertAlmostEqualDeep(expected_result, actual_result)
+
+    def test_get_time_series_for_polygon_collection(self):
+        ctx = new_test_service_context()
+        actual_result = get_time_series(ctx,
+                                        'demo', 'conc_tsm',
+                                        dict(type="GeometryCollection",
+                                             geometries=[dict(type="Polygon", coordinates=[[
+                                                 [1., 51.], [2., 51.], [2., 52.], [1., 52.],
+                                                 [1., 51.]
+                                             ]])]),
+                                        agg_methods=['mean', 'count'])
+        expected_result = [[{'count': 122392,
+                             'count_tot': 159600,
+                             'mean': 56.12519223634024,
+                             'time': '2017-01-16T10:09:22Z'},
+                            {'count': 0,
+                             'count_tot': 159600,
+                             'mean': None,
+                             'time': '2017-01-25T09:35:51Z'},
+                            {'count': 0,
+                             'count_tot': 159600,
+                             'mean': None,
+                             'time': '2017-01-26T10:50:17Z'},
+                            {'count': 132066,
+                             'count_tot': 159600,
+                             'mean': 49.70755256053988,
+                             'time': '2017-01-28T09:58:11Z'},
+                            {'count': 0,
+                             'count_tot': 159600,
+                             'mean': None,
+                             'time': '2017-01-30T10:46:34Z'}]]
+
+        self.assertAlmostEqualDeep(expected_result, actual_result)

--- a/test/webapi/controllers/test_timeseries.py
+++ b/test/webapi/controllers/test_timeseries.py
@@ -259,3 +259,17 @@ class CollectTimeSeriesResultTest(unittest.TestCase, AlmostEqualDeepMixin):
         self.assertEqual([{'a': 2.0, 'b': None, 'c': 0.7, 'time': '2010-04-08T00:00:00Z'},
                           {'a': 3.0, 'b': 23.0, 'c': None, 'time': '2010-04-09T00:00:00Z'}],
                          result)
+
+    def test_count(self):
+        self.maxDiff = None
+
+        time_series_ds = xr.Dataset(
+            data_vars=dict(time=xr.DataArray(pd.date_range(start='2010-04-05', periods=3, freq='1D'), dims='time'),
+                           c=xr.DataArray([23, 78, 74], dims='time')),
+            attrs=dict(max_number_of_observations=82))
+
+        result = _collect_timeseries_result(time_series_ds, {'count': 'c'}, max_valids=-1)
+        self.assertEqual([{'count': 23, 'count_tot': 82, 'time': '2010-04-05T00:00:00Z'},
+                          {'count': 78, 'count_tot': 82, 'time': '2010-04-06T00:00:00Z'},
+                          {'count': 74, 'count_tot': 82, 'time': '2010-04-07T00:00:00Z'}],
+                         result)

--- a/test/webapi/controllers/test_ts_legacy.py
+++ b/test/webapi/controllers/test_ts_legacy.py
@@ -3,11 +3,12 @@ import unittest
 import numpy as np
 
 from test.webapi.helpers import new_test_service_context
-from xcube.webapi.controllers.timeseries import get_time_series_info, get_time_series_for_point, \
+from xcube.webapi.controllers.ts_legacy import get_time_series_info, get_time_series_for_point, \
     get_time_series_for_geometry, get_time_series_for_geometry_collection
+from test.mixins import AlmostEqualDeepMixin
 
 
-class TimeSeriesControllerTest(unittest.TestCase):
+class TimeSeriesControllerTest(unittest.TestCase, AlmostEqualDeepMixin):
 
     def setUp(self) -> None:
         self.maxDiff = None
@@ -37,7 +38,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                         'result': {'average': 20.12085723876953,
                                                    'totalCount': 1,
                                                    'validCount': 1}}]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_point_one_valid(self):
         ctx = new_test_service_context()
@@ -50,7 +51,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                         'result': {'average': 20.12085723876953,
                                                    'totalCount': 1,
                                                    'validCount': 1}}]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_point_only_valids(self):
         ctx = new_test_service_context()
@@ -67,7 +68,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                         'result': {'average': 20.12085723876953,
                                                    'totalCount': 1,
                                                    'validCount': 1}}]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_point_with_uncertainty(self):
         ctx = new_test_service_context()
@@ -77,16 +78,14 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                   end_date=np.datetime64('2017-01-29'))
         expected_result = {'results': [{'date': '2017-01-22T00:00:00Z',
                                         'result': {'average': 3.534773588180542,
-                                                   'uncertainty': 0.0,
                                                    'totalCount': 1,
                                                    'validCount': 1}},
                                        {'date': '2017-01-29T00:00:00Z',
                                         'result': {'average': 20.12085723876953,
-                                                   'uncertainty': 0.0,
                                                    'totalCount': 1,
                                                    'validCount': 1}}]}
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_point(self):
         ctx = new_test_service_context()
@@ -107,7 +106,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                         'result': {'average': 20.12085723876953,
                                                    'totalCount': 1,
                                                    'validCount': 1}}]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon(self):
         ctx = new_test_service_context()
@@ -136,7 +135,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                         'result': {'average': None,
                                                    'totalCount': 159600,
                                                    'validCount': 0}}]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_with_stdev(self):
         ctx = new_test_service_context()
@@ -173,7 +172,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    'uncertainty': None,
                                                    'validCount': 0}}]}
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_one_valid(self):
         ctx = new_test_service_context()
@@ -188,7 +187,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                    'totalCount': 159600,
                                                    'validCount': 132066}}]}
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometry_polygon_only_valids(self):
         ctx = new_test_service_context()
@@ -206,7 +205,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                         'result': {'average': 49.70755256053988,
                                                    'totalCount': 159600,
                                                    'validCount': 132066}}]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometries_incl_point(self):
         ctx = new_test_service_context()
@@ -230,7 +229,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                          'result': {'average': 20.12085723876953,
                                                     'totalCount': 1,
                                                     'validCount': 1}}]]}
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_for_geometries_incl_polygon(self):
         ctx = new_test_service_context()
@@ -263,7 +262,7 @@ class TimeSeriesControllerTest(unittest.TestCase):
                                                     'totalCount': 159600,
                                                     'validCount': 0}}]]}
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertAlmostEqualDeep(expected_result, actual_result)
 
     def test_get_time_series_info(self):
         self.maxDiff = None

--- a/test/webapi/controllers/test_ts_legacy.py
+++ b/test/webapi/controllers/test_ts_legacy.py
@@ -8,7 +8,7 @@ from xcube.webapi.controllers.ts_legacy import get_time_series_info, get_time_se
 from test.mixins import AlmostEqualDeepMixin
 
 
-class TimeSeriesControllerTest(unittest.TestCase, AlmostEqualDeepMixin):
+class TsLegacyControllerTest(unittest.TestCase, AlmostEqualDeepMixin):
 
     def setUp(self) -> None:
         self.maxDiff = None

--- a/test/webapi/test_handlers.py
+++ b/test/webapi/test_handlers.py
@@ -300,11 +300,69 @@ class HandlersTest(AsyncHTTPTestCase):
         response = self.fetch(self.prefix + '/places/inside-cube/bibo')
         self.assertResourceNotFoundResponse(response, 'Dataset "bibo" not found')
 
-    def test_fetch_time_series_info(self):
+    def test_fetch_timeseries_invalid_body(self):
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='')
+        self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON object in request body')
+
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type":"Point"}')
+        self.assertBadRequestResponse(response, 'GeoJSON object expected')
+
+    def test_fetch_timeseries_geometry(self):
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "Point", "coordinates": [1, 51]}')
+        self.assertResponseOK(response)
+
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type":"Polygon", "coordinates": [[[1, 51], [2, 51], [2, 52], [1, 51]]]}')
+        self.assertResponseOK(response)
+
+    def test_fetch_timeseries_geometry_collection(self):
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "GeometryCollection", "geometries": null}')
+        self.assertResponseOK(response)
+
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "GeometryCollection", "geometries": []}')
+        self.assertResponseOK(response)
+
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "GeometryCollection", "geometries": '
+                                   '[{"type": "Point", "coordinates": [1, 51]}]}')
+        self.assertResponseOK(response)
+
+    def test_fetch_timeseries_feature(self):
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "Feature", '
+                                   ' "properties": {}, '
+                                   ' "geometry": {"type": "Point", "coordinates": [1, 51]}'
+                                   '}')
+        self.assertResponseOK(response)
+
+
+    def test_fetch_timeseries_feature_collection(self):
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "FeatureCollection", "features": null}')
+        self.assertResponseOK(response)
+
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "FeatureCollection", "features": []}')
+        self.assertResponseOK(response)
+
+        response = self.fetch(self.prefix + '/timeseries/demo/conc_chl', method="POST",
+                              body='{"type": "FeatureCollection", "features": ['
+                                   '  {"type": "Feature", "properties": {}, '
+                                   '   "geometry": {"type": "Point", "coordinates": [1, 51]}}'
+                                   ']}')
+        self.assertResponseOK(response)
+
+
+    def test_fetch_ts_legacy_info(self):
         response = self.fetch(self.prefix + '/ts')
         self.assertResponseOK(response)
 
-    def test_fetch_time_series_point(self):
+    def test_fetch_ts_legacy_point(self):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/point')
         self.assertBadRequestResponse(response, 'Missing query parameter "lon"')
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/point?lon=2.1')
@@ -316,7 +374,7 @@ class HandlersTest(AsyncHTTPTestCase):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/point?lon=2.1&lat=51.1')
         self.assertResponseOK(response)
 
-    def test_fetch_time_series_geometry(self):
+    def test_fetch_ts_legacy_geometry(self):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometry', method="POST",
                               body='')
         self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON geometry in request body')
@@ -331,7 +389,7 @@ class HandlersTest(AsyncHTTPTestCase):
 
         self.assertResponseOK(response)
 
-    def test_fetch_time_series_geometries(self):
+    def test_fetch_ts_legacy_geometries(self):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/geometries', method="POST",
                               body='')
         self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON geometry collection in request body')
@@ -349,7 +407,7 @@ class HandlersTest(AsyncHTTPTestCase):
                                    '[{"type": "Point", "coordinates": [1, 51]}]}')
         self.assertResponseOK(response)
 
-    def test_fetch_time_series_features(self):
+    def test_fetch_ts_legacy_features(self):
         response = self.fetch(self.prefix + '/ts/demo/conc_chl/features', method="POST",
                               body='')
         self.assertBadRequestResponse(response, 'Invalid or missing GeoJSON feature collection in request body')

--- a/xcube/core/timeseries.py
+++ b/xcube/core/timeseries.py
@@ -19,7 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Union, Sequence, Optional
+import warnings
+from typing import Union, Sequence, Optional, AbstractSet
 
 import numpy as np
 import shapely.geometry
@@ -32,12 +33,32 @@ from xcube.core.verify import assert_cube
 
 Date = Union[np.datetime64, str]
 
+AGG_MEAN = 'mean'
+AGG_MEDIAN = 'median'
+AGG_STD = 'std'
+AGG_MIN = 'min'
+AGG_MAX = 'max'
+AGG_COUNT = 'count'
+
+MUST_LOAD = True
+CAN_COMPUTE = False
+
+AGG_METHODS = {
+    AGG_MEAN: CAN_COMPUTE,
+    AGG_MEDIAN: MUST_LOAD,
+    AGG_STD: CAN_COMPUTE,
+    AGG_MIN: CAN_COMPUTE,
+    AGG_MAX: CAN_COMPUTE,
+    AGG_COUNT: CAN_COMPUTE
+}
+
 
 def get_time_series(cube: xr.Dataset,
                     geometry: GeometryLike = None,
                     var_names: Sequence[str] = None,
                     start_date: Date = None,
                     end_date: Date = None,
+                    agg_methods: Union[str, Sequence[str], AbstractSet[str]] = AGG_MEAN,
                     include_count: bool = False,
                     include_stdev: bool = False,
                     use_groupby: bool = False,
@@ -64,9 +85,12 @@ def get_time_series(cube: xr.Dataset,
     :param var_names: Optional sequence of names of variables to be included.
     :param start_date: Optional start date.
     :param end_date: Optional end date.
-    :param include_count: Whether to include the number of valid observations for each time step.
+    :param agg_methods: Aggregation methods. May be single string or sequence of strings. Possible values are
+           'mean', 'median', 'min', 'max', 'std', 'count'. Defaults to 'mean'.
            Ignored if geometry is a point.
-    :param include_stdev: Whether to include standard deviation for each time step.
+    :param include_count: Deprecated. Whether to include the number of valid observations for each time step.
+           Ignored if geometry is a point.
+    :param include_stdev: Deprecated. Whether to include standard deviation for each time step.
            Ignored if geometry is a point.
     :param use_groupby: Use group-by operation. May increase or decrease runtime performance and/or memory consumption.
     :param cube_asserted:  If False, *cube* will be verified, otherwise it is expected to be a valid cube.
@@ -77,6 +101,23 @@ def get_time_series(cube: xr.Dataset,
         assert_cube(cube)
 
     geometry = convert_geometry(geometry)
+
+    agg_methods = agg_methods or [AGG_MEAN]
+    if isinstance(agg_methods, str):
+        agg_methods = [agg_methods]
+    agg_methods = set(agg_methods)
+    if include_count:
+        warnings.warn("keyword argument 'include_count' has been deprecated, "
+                      f"use 'agg_methods=[{AGG_COUNT!r}, ...]' instead")
+        agg_methods.add(AGG_COUNT)
+    if include_stdev:
+        warnings.warn("keyword argument 'include_stdev' has been deprecated, "
+                      f"use 'agg_methods=[{AGG_STD!r}, ...]' instead")
+        agg_methods.add(AGG_STD)
+    invalid_agg_methods = agg_methods - set(AGG_METHODS.keys())
+    if invalid_agg_methods:
+        s = 's' if len(invalid_agg_methods) > 1 else ''
+        raise ValueError(f'invalid aggregation method{s}: {", ".join(sorted(list(invalid_agg_methods)))}')
 
     dataset = select_variables_subset(cube, var_names)
     if len(dataset.data_vars) == 0:
@@ -99,41 +140,37 @@ def get_time_series(cube: xr.Dataset,
             return None
         mask = dataset['__mask__']
         max_number_of_observations = np.count_nonzero(mask)
-        dataset = dataset.drop('__mask__')
+        dataset = dataset.drop_vars(['__mask__'])
     else:
         max_number_of_observations = dataset.lat.size * dataset.lon.size
 
-    ds_count = None
-    ds_stdev = None
+    must_load = len(agg_methods) > 1 or any(AGG_METHODS[agg_method] == MUST_LOAD for agg_method in agg_methods)
+    if must_load:
+        dataset.load()
+
+    agg_datasets = []
     if use_groupby:
         time_group = dataset.groupby('time')
-        ds_mean = time_group.mean(skipna=True, dim=xr.ALL_DIMS)
-        if include_count:
-            ds_count = time_group.count(dim=xr.ALL_DIMS)
-        if include_stdev:
-            ds_stdev = time_group.std(skipna=True, dim=xr.ALL_DIMS)
+        for agg_method in agg_methods:
+            method = getattr(time_group, agg_method)
+            if agg_method == 'count':
+                agg_dataset = method(dim=xr.ALL_DIMS)
+            else:
+                agg_dataset = method(dim=xr.ALL_DIMS, skipna=True)
+            agg_datasets.append(agg_dataset)
     else:
-        ds_mean = dataset.mean(dim=('lat', 'lon'), skipna=True)
-        if include_count:
-            ds_count = dataset.count(dim=('lat', 'lon'))
-        if include_stdev:
-            ds_stdev = dataset.std(dim=('lat', 'lon'), skipna=True)
+        for agg_method in agg_methods:
+            method = getattr(dataset, agg_method)
+            if agg_method == 'count':
+                agg_dataset = method(dim=('lat', 'lon'))
+            else:
+                agg_dataset = method(dim=('lat', 'lon'), skipna=True)
+            agg_datasets.append(agg_dataset)
 
-    if ds_count is not None:
-        ds_count = ds_count.rename(name_dict=dict({v: f"{v}_count" for v in ds_count.data_vars}))
+    agg_datasets = [agg_dataset.rename(name_dict=dict({v: f"{v}_{agg_method}" for v in agg_dataset.data_vars}))
+                    for agg_method, agg_dataset in zip(agg_methods, agg_datasets)]
 
-    if ds_stdev is not None:
-        ds_stdev = ds_stdev.rename(name_dict=dict({v: f"{v}_stdev" for v in ds_stdev.data_vars}))
-
-    if ds_count is not None and ds_stdev is not None:
-        ts_dataset = xr.merge([ds_mean, ds_stdev, ds_count])
-    elif ds_count is not None:
-        ts_dataset = xr.merge([ds_mean, ds_count])
-    elif ds_stdev is not None:
-        ts_dataset = xr.merge([ds_mean, ds_stdev])
-    else:
-        ts_dataset = ds_mean
-
+    ts_dataset = xr.merge(agg_datasets)
     ts_dataset = ts_dataset.assign_attrs(max_number_of_observations=max_number_of_observations)
 
     return ts_dataset

--- a/xcube/util/geojson.py
+++ b/xcube/util/geojson.py
@@ -53,6 +53,13 @@ class GeoJSON:
         return False
 
     @classmethod
+    def is_geometry_collection(cls, obj: Any) -> bool:
+        type_name = cls.get_type_name(obj)
+        if type_name == cls.GEOMETRY_COLLECTION_TYPE:
+            return cls._is_valid_sequence(obj, 'geometries')
+        return False
+
+    @classmethod
     def get_geometry_collection_geometries(cls, obj: Any) -> Optional[Sequence[Dict]]:
         type_name = cls.get_type_name(obj)
         if type_name == cls.GEOMETRY_COLLECTION_TYPE:

--- a/xcube/webapi/app.py
+++ b/xcube/webapi/app.py
@@ -27,7 +27,7 @@ from xcube.webapi.context import normalize_prefix
 from xcube.webapi.handlers import GetNE2TileHandler, GetDatasetVarTileHandler, InfoHandler, GetNE2TileGridHandler, \
     GetDatasetVarTileGridHandler, GetWMTSCapabilitiesXmlHandler, GetColorBarsJsonHandler, GetColorBarsHtmlHandler, \
     GetDatasetsHandler, FindPlacesHandler, FindDatasetPlacesHandler, \
-    GetDatasetCoordsHandler, GetTsLegacyInfoHandler, GetTsLegacyForPointHandler, WMTSKvpHandler, \
+    GetDatasetCoordsHandler, GetTimeSeriesHandler, GetTsLegacyInfoHandler, GetTsLegacyForPointHandler, WMTSKvpHandler, \
     GetTsLegacyForGeometryHandler, GetTsLegacyForFeaturesHandler, GetTsLegacyForGeometriesHandler, \
     GetPlaceGroupsHandler, GetDatasetVarLegendHandler, GetDatasetHandler, GetWMTSTileHandler, GetS3BucketObjectHandler, \
     ListS3BucketHandler, GetDatasetPlaceGroupsHandler, GetDatasetPlaceGroupHandler
@@ -104,6 +104,11 @@ def new_application(prefix: str = None, base_dir: str = '.'):
          FindPlacesHandler),
         (prefix + url_pattern('/places/{{place_group_id}}/{{ds_id}}'),
          FindDatasetPlacesHandler),
+
+        # Time-Series API
+
+        (prefix + url_pattern('/timeseries/{{ds_id}}/{{var_name}}'),
+         GetTimeSeriesHandler),
 
         # Legacy time-series API (for VITO's DCS4COP viewer only)
 

--- a/xcube/webapi/app.py
+++ b/xcube/webapi/app.py
@@ -27,8 +27,8 @@ from xcube.webapi.context import normalize_prefix
 from xcube.webapi.handlers import GetNE2TileHandler, GetDatasetVarTileHandler, InfoHandler, GetNE2TileGridHandler, \
     GetDatasetVarTileGridHandler, GetWMTSCapabilitiesXmlHandler, GetColorBarsJsonHandler, GetColorBarsHtmlHandler, \
     GetDatasetsHandler, FindPlacesHandler, FindDatasetPlacesHandler, \
-    GetDatasetCoordsHandler, GetTimeSeriesInfoHandler, GetTimeSeriesForPointHandler, WMTSKvpHandler, \
-    GetTimeSeriesForGeometryHandler, GetTimeSeriesForFeaturesHandler, GetTimeSeriesForGeometriesHandler, \
+    GetDatasetCoordsHandler, GetTsLegacyInfoHandler, GetTsLegacyForPointHandler, WMTSKvpHandler, \
+    GetTsLegacyForGeometryHandler, GetTsLegacyForFeaturesHandler, GetTsLegacyForGeometriesHandler, \
     GetPlaceGroupsHandler, GetDatasetVarLegendHandler, GetDatasetHandler, GetWMTSTileHandler, GetS3BucketObjectHandler, \
     ListS3BucketHandler, GetDatasetPlaceGroupsHandler, GetDatasetPlaceGroupHandler
 from xcube.webapi.service import url_pattern
@@ -105,17 +105,17 @@ def new_application(prefix: str = None, base_dir: str = '.'):
         (prefix + url_pattern('/places/{{place_group_id}}/{{ds_id}}'),
          FindDatasetPlacesHandler),
 
-        # Time-series API (for VITO's DCS4COP viewer only, PRELIMINARY & UNSTABLE - will be revised soon)
+        # Legacy time-series API (for VITO's DCS4COP viewer only)
 
         (prefix + url_pattern('/ts'),
-         GetTimeSeriesInfoHandler),
+         GetTsLegacyInfoHandler),
         (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/point'),
-         GetTimeSeriesForPointHandler),
+         GetTsLegacyForPointHandler),
         (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/geometry'),
-         GetTimeSeriesForGeometryHandler),
+         GetTsLegacyForGeometryHandler),
         (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/geometries'),
-         GetTimeSeriesForGeometriesHandler),
+         GetTsLegacyForGeometriesHandler),
         (prefix + url_pattern('/ts/{{ds_id}}/{{var_name}}/features'),
-         GetTimeSeriesForFeaturesHandler),
+         GetTsLegacyForFeaturesHandler),
     ])
     return application

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -213,6 +213,17 @@ class ServiceContext:
                     raise ServiceResourceNotFoundError(f'Variable "{var_name}" not found in dataset "{ds_id}"')
         return dataset
 
+    def get_time_series_dataset(self, ds_id: str, var_name: str = None) -> xr.Dataset:
+        descriptor = self.get_dataset_descriptor(ds_id)
+        ts_ds_name = descriptor.get('TimeSeriesDataset', ds_id)
+        try:
+            # Try to get more efficient, time-chunked dataset
+            return self.get_dataset(ts_ds_name, expected_var_names=[var_name] if var_name else None)
+        except ServiceResourceNotFoundError:
+            # This happens, if the dataset pointed to by 'TimeSeriesDataset'
+            # does not contain the variable given by var_name.
+            return self.get_dataset(ds_id, expected_var_names=[var_name] if var_name else None)
+
     def get_variable_for_z(self, ds_id: str, var_name: str, z_index: int) -> xr.DataArray:
         ml_dataset = self.get_ml_dataset(ds_id)
         index = ml_dataset.num_levels - 1 - z_index

--- a/xcube/webapi/controllers/timeseries.py
+++ b/xcube/webapi/controllers/timeseries.py
@@ -1,0 +1,301 @@
+# The MIT License (MIT)
+# Copyright (c) 2020 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+This module implements the controller for the "/ts" handler.
+It is maintained for legacy reasons only (DCS4COP VITO viewer).
+"""
+
+from typing import Dict, List, Optional, Union, Sequence, Any, Set, Tuple
+
+import numpy as np
+import shapely.geometry
+import xarray as xr
+
+from xcube.constants import LOG
+from xcube.core import timeseries
+from xcube.core.ancvar import find_ancillary_var_names
+from xcube.core.timecoord import timestamp_to_iso_string
+from xcube.util.geojson import GeoJSON
+from xcube.util.perf import measure_time
+from xcube.webapi.context import ServiceContext
+from xcube.webapi.errors import ServiceBadRequestError
+
+TimeSeriesValue = Dict[str, Union[str, bool, int, float, None]]
+TimeSeries = List[TimeSeriesValue]
+TimeSeriesCollection = List[TimeSeries]
+GeoJsonObj = Dict[str, Any]
+GeoJsonFeature = GeoJsonObj
+GeoJsonGeometry = GeoJsonObj
+
+
+def get_time_series(ctx: ServiceContext,
+                    ds_name: str, var_name: str,
+                    geo_json: GeoJsonObj,
+                    agg_methods: Union[str, Sequence[str]] = None,
+                    start_date: np.datetime64 = None,
+                    end_date: np.datetime64 = None,
+                    max_valids: int = None,
+                    incl_ancillary_vars: bool = False) -> Union[TimeSeries, TimeSeriesCollection]:
+    """
+    Get the time-series for a given GeoJSON object *geo_json*.
+
+    If *geo_json* is a single geometry or feature a list of time-series values is returned.
+    If *geo_json* is a single geometry collection or feature collection a collection of lists of time-series values
+    is returned so that geometry/feature collection and time-series collection elements are corresponding
+    at same indices.
+
+    A time series value always contains the key "time" whose value is an ISO date/time string. Other entries
+    are values with varying keys depending on the geometry type and *agg_methods*. Their values may be
+    either a bool, int, float or None.
+    For point geometries the second key is "value".
+    For non-point geometries that cover spatial areas, there will be values for all keys given by *agg_methods*.
+
+    :param ctx: Service context object
+    :param ds_name: The dataset identifier.
+    :param var_name: The variable name.
+    :param geo_json: The GeoJSON object that is a or has a geometry or collection of geometryies.
+    :param start_date: An optional start date.
+    :param end_date: An optional end date.
+    :param agg_methods: Spatial aggregation methods for geometries that cover a spatial area.
+    :param max_valids: Optional number of valid points.
+           If it is None (default), also missing values are returned as NaN;
+           if it is -1 only valid values are returned;
+           if it is a positive integer, the most recent valid values are returned.
+    :param incl_ancillary_vars: For point geometries, include values of ancillary variables, if any.
+    :return: Time-series data structure.
+    """
+    agg_methods = timeseries.normalize_agg_methods(agg_methods, exception_type=ServiceBadRequestError)
+
+    dataset = ctx.get_time_series_dataset(ds_name, var_name=var_name)
+    geo_json_geometries, is_collection = _to_geo_json_geometries(geo_json)
+    geometries = _to_shapely_geometries(geo_json_geometries)
+
+    with measure_time() as time_result:
+        results = _get_time_series_for_geometries(dataset,
+                                                  var_name,
+                                                  geometries,
+                                                  start_date=start_date,
+                                                  end_date=end_date,
+                                                  agg_methods=agg_methods,
+                                                  max_valids=max_valids,
+                                                  incl_ancillary_vars=incl_ancillary_vars)
+
+    if ctx.trace_perf:
+        LOG.info(f'get_time_series: dataset id {ds_name}, variable {var_name}, '
+                 f'{len(results)} x {len(results[0])} values, took {time_result.duration} seconds')
+
+    return results[0] if not is_collection and len(results) == 1 else results
+
+
+def _get_time_series_for_geometries(dataset: xr.Dataset,
+                                    var_name: str,
+                                    geometries: List[shapely.geometry.base.BaseGeometry],
+                                    agg_methods: Set[str],
+                                    start_date: np.datetime64 = None,
+                                    end_date: np.datetime64 = None,
+                                    max_valids=None,
+                                    incl_ancillary_vars=False) -> TimeSeriesCollection:
+    time_series_collection = []
+    for geometry in geometries:
+        time_series = _get_time_series_for_geometry(dataset,
+                                                    var_name,
+                                                    geometry,
+                                                    agg_methods,
+                                                    start_date=start_date,
+                                                    end_date=end_date,
+                                                    max_valids=max_valids,
+                                                    incl_ancillary_vars=incl_ancillary_vars)
+        time_series_collection.append(time_series)
+    return time_series_collection
+
+
+def _get_time_series_for_geometry(dataset: xr.Dataset,
+                                  var_name: str,
+                                  geometry: shapely.geometry.base.BaseGeometry,
+                                  agg_methods: Set[str],
+                                  start_date: np.datetime64 = None,
+                                  end_date: np.datetime64 = None,
+                                  max_valids: int = None,
+                                  incl_ancillary_vars=False) -> TimeSeries:
+    if isinstance(geometry, shapely.geometry.Point):
+        return _get_time_series_for_point(dataset, var_name,
+                                          geometry,
+                                          agg_methods,
+                                          start_date=start_date,
+                                          end_date=end_date,
+                                          max_valids=max_valids,
+                                          incl_ancillary_vars=incl_ancillary_vars)
+
+    time_series_ds = timeseries.get_time_series(dataset,
+                                                geometry,
+                                                [var_name],
+                                                agg_methods=agg_methods,
+                                                start_date=start_date,
+                                                end_date=end_date)
+    if time_series_ds is None:
+        return []
+
+    variables = {agg_method: time_series_ds[f'{var_name}_{agg_method}'] for agg_method in agg_methods}
+
+    return _collect_ts_result(time_series_ds,
+                              variables,
+                              max_valids=max_valids)
+
+
+def _get_time_series_for_point(dataset: xr.Dataset,
+                               var_name: str,
+                               point: shapely.geometry.Point,
+                               agg_methods: Set[str],
+                               start_date: np.datetime64 = None,
+                               end_date: np.datetime64 = None,
+                               max_valids: int = None,
+                               incl_ancillary_vars=False) -> TimeSeries:
+    var_key = None
+    if timeseries.AGG_MEAN in agg_methods:
+        var_key = timeseries.AGG_MEAN
+    elif timeseries.AGG_MEDIAN in agg_methods:
+        var_key = timeseries.AGG_MEDIAN
+    elif timeseries.AGG_MIN in agg_methods or timeseries.AGG_MAX in agg_methods:
+        var_key = timeseries.AGG_MIN
+    if not var_key:
+        raise RuntimeError('Aggregation methods must include one of "mean", "median", "min", "max"')
+
+    roles_to_anc_var_names = dict()
+    if incl_ancillary_vars:
+        roles_to_anc_var_name_sets = find_ancillary_var_names(dataset, var_name, same_shape=True, same_dims=True)
+        for role, roles_to_anc_var_name_sets in roles_to_anc_var_name_sets.items():
+            if role:
+                roles_to_anc_var_names[role] = roles_to_anc_var_name_sets.pop()
+
+    var_names = [var_name] + list(set(roles_to_anc_var_names.values()))
+
+    time_series_ds = timeseries.get_time_series(dataset, point, var_names, start_date=start_date, end_date=end_date)
+    if time_series_ds is None:
+        return []
+
+    variables = {var_key: time_series_ds[var_name]}
+    for role, anc_var_name in roles_to_anc_var_names.items():
+        variables[role] = time_series_ds[anc_var_name]
+
+    return _collect_ts_result(time_series_ds,
+                              variables,
+                              max_valids=max_valids)
+
+
+def _collect_ts_result(time_series_ts: xr.Dataset,
+                       variables: Dict[str, xr.DataArray],
+                       max_valids: int = None) -> TimeSeries:
+    if not (max_valids is None or max_valids == -1 or max_valids > 0):
+        raise ValueError('max_valids must be either None, -1 or positive')
+
+    time = time_series_ts.time
+    max_number_of_observations = time_series_ts.attrs.get('max_number_of_observations', 1)
+    num_times = time.size
+    time_series = []
+
+    max_valids_is_pos = max_valids is not None and max_valids > 0
+    if max_valids_is_pos:
+        time_indexes = range(num_times - 1, -1, -1)
+    else:
+        time_indexes = range(num_times)
+
+    for time_index in time_indexes:
+
+        if len(time_series) == max_valids:
+            break
+
+        time_series_value = dict()
+        all_null = True
+        for time_series_key, var in variables.items():
+            var_values = var.values
+            var_value = var_values[time_index]
+            if np.isfinite(var_value):
+                all_null = False
+                if np.issubdtype(var_value.dtype, np.dtype(bool)):
+                    var_value = bool(var_value)
+                elif np.issubdtype(var_value.dtype, np.dtype(int)):
+                    var_value = int(var_value)
+                elif np.issubdtype(var_value.dtype, np.dtype(float)):
+                    var_value = float(var_value)
+            else:
+                var_value = None
+            time_series_value[time_series_key] = var_value
+
+        has_count = 'count' in time_series_value
+        no_obs = all_null or (has_count and time_series_value['count'] == 0)
+        if no_obs and max_valids is not None:
+            continue
+
+        time_series_value['time'] = timestamp_to_iso_string(time[time_index].values)
+        if has_count:
+            time_series_value['count_tot'] = max_number_of_observations
+
+        time_series.append(time_series_value)
+
+    if max_valids_is_pos:
+        time_series = time_series[::-1]
+
+    return time_series
+
+
+def _to_shapely_geometries(geo_json_geometries: List[GeoJsonGeometry]) -> List[shapely.geometry.base.BaseGeometry]:
+    geometries = []
+    for geo_json_geometry in geo_json_geometries:
+        try:
+            geometry = shapely.geometry.shape(geo_json_geometry)
+        except (TypeError, ValueError) as e:
+            raise ServiceBadRequestError("Invalid GeoJSON geometry encountered") from e
+        geometries.append(geometry)
+    return geometries
+
+
+def _to_geo_json_geometries(geo_json: GeoJsonObj) -> Tuple[List[GeoJsonGeometry], bool]:
+    is_collection = False
+    if GeoJSON.is_feature(geo_json):
+        geometry = _get_feature_geometry(geo_json)
+        geometries = [geometry]
+    elif GeoJSON.is_feature_collection(geo_json):
+        is_collection = True
+        features = GeoJSON.get_feature_collection_features(geo_json)
+        geometries = [_get_feature_geometry(feature) for feature in features] if features else []
+    elif GeoJSON.is_geometry_collection(geo_json):
+        is_collection = True
+        geometries = GeoJSON.get_geometry_collection_geometries(geo_json)
+    elif GeoJSON.is_geometry(geo_json):
+        geometries = [geo_json]
+    else:
+        raise ServiceBadRequestError("GeoJSON object expected")
+    return geometries, is_collection
+
+
+def _get_feature_geometry(feature: GeoJsonFeature) -> GeoJsonGeometry:
+    geometry = GeoJSON.get_feature_geometry(feature)
+    if geometry is None or not GeoJSON.is_geometry(geometry):
+        raise ServiceBadRequestError("GeoJSON feature without geometry")
+    return geometry
+
+
+def _get_float_value(values: Optional[np.ndarray], index: int) -> Optional[float]:
+    if values is None:
+        return None
+    value = float(values[index])
+    return None if np.isnan(value) else value

--- a/xcube/webapi/handlers.py
+++ b/xcube/webapi/handlers.py
@@ -36,7 +36,7 @@ from xcube.webapi.controllers.catalogue import get_datasets, get_dataset_coordin
 from xcube.webapi.controllers.places import find_places, find_dataset_places
 from xcube.webapi.controllers.tiles import get_dataset_tile, get_dataset_tile_grid, get_ne2_tile, get_ne2_tile_grid, \
     get_legend
-from xcube.webapi.controllers.timeseries import get_time_series_info, get_time_series_for_point, \
+from xcube.webapi.controllers.ts_legacy import get_time_series_info, get_time_series_for_point, \
     get_time_series_for_geometry, \
     get_time_series_for_geometry_collection, get_time_series_for_feature_collection
 from xcube.webapi.controllers.wmts import get_wmts_capabilities_xml
@@ -66,8 +66,8 @@ class WMTSKvpHandler(ServiceRequestHandler):
             raise ServiceBadRequestError('Value for "service" parameter must be "WMTS"')
         request = self.params.get_query_argument('request')
         if request == "GetCapabilities":
-            version = self.params.get_query_argument("version", _WMTS_VERSION)
-            if version != _WMTS_VERSION:
+            wmts_version = self.params.get_query_argument("version", _WMTS_VERSION)
+            if wmts_version != _WMTS_VERSION:
                 raise ServiceBadRequestError(f'Value for "version" parameter must be "{_WMTS_VERSION}"')
             capabilities = await IOLoop.current().run_in_executor(None,
                                                                   get_wmts_capabilities_xml,
@@ -77,8 +77,8 @@ class WMTSKvpHandler(ServiceRequestHandler):
             await self.finish(capabilities)
 
         elif request == "GetTile":
-            version = self.params.get_query_argument("version", _WMTS_VERSION)
-            if version != _WMTS_VERSION:
+            wmts_version = self.params.get_query_argument("version", _WMTS_VERSION)
+            if wmts_version != _WMTS_VERSION:
                 raise ServiceBadRequestError(f'Value for "version" parameter must be "{_WMTS_VERSION}"')
             layer = self.params.get_query_argument("layer")
             try:
@@ -467,7 +467,7 @@ class InfoHandler(ServiceRequestHandler):
 
 
 # noinspection PyAbstractClass
-class GetTimeSeriesInfoHandler(ServiceRequestHandler):
+class GetTsLegacyInfoHandler(ServiceRequestHandler):
 
     async def get(self):
         response = await IOLoop.current().run_in_executor(None, get_time_series_info, self.service_context)
@@ -476,7 +476,7 @@ class GetTimeSeriesInfoHandler(ServiceRequestHandler):
 
 
 # noinspection PyAbstractClass
-class GetTimeSeriesForPointHandler(ServiceRequestHandler):
+class GetTsLegacyForPointHandler(ServiceRequestHandler):
 
     async def get(self, ds_id: str, var_name: str):
         lon = self.params.get_query_argument_float('lon')
@@ -499,7 +499,7 @@ class GetTimeSeriesForPointHandler(ServiceRequestHandler):
 
 
 # noinspection PyAbstractClass
-class GetTimeSeriesForGeometryHandler(ServiceRequestHandler):
+class GetTsLegacyForGeometryHandler(ServiceRequestHandler):
 
     async def post(self, ds_id: str, var_name: str):
         start_date = self.params.get_query_argument_datetime('startDate', default=None)
@@ -523,7 +523,7 @@ class GetTimeSeriesForGeometryHandler(ServiceRequestHandler):
 
 
 # noinspection PyAbstractClass
-class GetTimeSeriesForGeometriesHandler(ServiceRequestHandler):
+class GetTsLegacyForGeometriesHandler(ServiceRequestHandler):
 
     async def post(self, ds_id: str, var_name: str):
         start_date = self.params.get_query_argument_datetime('startDate', default=None)
@@ -547,7 +547,7 @@ class GetTimeSeriesForGeometriesHandler(ServiceRequestHandler):
 
 
 # noinspection PyAbstractClass
-class GetTimeSeriesForFeaturesHandler(ServiceRequestHandler):
+class GetTsLegacyForFeaturesHandler(ServiceRequestHandler):
 
     async def post(self, ds_id: str, var_name: str):
         start_date = self.params.get_query_argument_datetime('startDate', default=None)

--- a/xcube/webapi/res/openapi.yml
+++ b/xcube/webapi/res/openapi.yml
@@ -31,6 +31,8 @@ tags:
     description: Tiles API
   - name: time-series
     description: Time-series API
+  - name: ts-legacy
+    description: Time-series API (Legacy)
   - name: places
     description: Places API
 
@@ -398,14 +400,42 @@ paths:
         '404':
           description: Resource not found.
 
+  '/timeseries/{dataset}/{variable}':
+    post:
+      tags:
+        - time-series
+      operationId: getTimeSeries
+      summary: Compute time-series for GeoJSON object
+      description: Compute a time series given a GeoJSON object.
+      parameters:
+        - $ref: '#/components/parameters/dataset'
+        - $ref: '#/components/parameters/variable'
+        - $ref: '#/components/parameters/aggMethod'
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'
+        - $ref: '#/components/parameters/maxValids'
+      requestBody:
+        $ref: '#/components/requestBodies/GeoJsonObject'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TsLegacy'
+        '400':
+          description: Invalid query parameters
+        '500':
+          description: Unexpected error.
+
   ########################################################################################
-  # Time-Series (PRELIMINARY & UNSTABLE - will be revised soon)
+  # Time-Series Legacy API (for compatibility with VITO viewer)
   ########################################################################################
 
   '/ts':
     get:
       tags:
-        - time-series
+        - ts-legacy
       operationId: getTimeSeriesInfo
       summary: List time stamps for variables
       description: Returns for each variable the times in UTC format for which data is available.
@@ -415,14 +445,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimeSeriesInfo'
+                $ref: '#/components/schemas/TsLegacyInfo'
         '500':
           description: Unexpected error.
 
   '/ts/{dataset}/{variable}/point':
     get:
       tags:
-        - time-series
+        - ts-legacy
       operationId: getTimeSeriesForPoint
       summary: Compute time-series for point
       description: Compute a time series given a coordinate and a product.
@@ -440,7 +470,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimeSeries'
+                $ref: '#/components/schemas/TsLegacy'
         '400':
           description: Invalid query parameters
         '500':
@@ -449,7 +479,7 @@ paths:
   '/ts/{dataset}/{variable}/geometry':
     post:
       tags:
-        - time-series
+        - ts-legacy
       operationId: getTimeSeriesForGeometry
       summary: Compute time-series for geometry
       description: Compute a time series given a GeoJSON geometry object.
@@ -467,7 +497,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimeSeries'
+                $ref: '#/components/schemas/TsLegacy'
         '400':
           description: Invalid query parameters
         '500':
@@ -476,7 +506,7 @@ paths:
   '/ts/{dataset}/{variable}/geometries':
     post:
       tags:
-        - time-series
+        - ts-legacy
       operationId: getTimeSeriesForGeometries
       summary: Compute time-series for geometries
       description: Compute a time series given a GeoJSON geometry collection object.
@@ -494,7 +524,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimeSeries'
+                $ref: '#/components/schemas/TsLegacy'
         '400':
           description: Invalid query parameters
         '500':
@@ -503,7 +533,7 @@ paths:
   '/ts/{dataset}/{variable}/features':
     post:
       tags:
-        - time-series
+        - ts-legacy
       operationId: getTimeSeriesForFeature
       summary: Compute time-series for feature collection
       description: Compute a time series given a GeoJSON feature collection object.
@@ -521,7 +551,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimeSeries'
+                $ref: '#/components/schemas/TsLegacy'
         '400':
           description: Invalid query parameters
         '500':
@@ -1041,14 +1071,60 @@ components:
             minItems: 0
             items:
               $ref: '#/components/schemas/GeoJsonFeature'
-    TimeSeriesInfo:
+    TimeSeriesResponse:
+      type: object
+      properties:
+        result:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimeSeries'
+    TimeSeries:
+      type: object
+      properties:
+        result:
+          type: array
+          minItems: 0
+          items:
+            $ref: '#/components/schemas/TimeSeriesValue'
+    TimeSeriesValue:
+      type: object
+      required:
+        - time
+      properties:
+        time:
+          type: string
+          example: 1970-01-01T10:30:24Z
+        count:
+          type: number
+          format: int64
+          minimum: 0
+        countTot:
+          type: number
+          format: int64
+          minimum: 0
+        mean:
+          type: number
+          format: double
+        std:
+          type: number
+          format: double
+        median:
+          type: number
+          format: double
+        min:
+          type: number
+          format: double
+        max:
+          type: number
+          format: double
+    TsLegacyInfo:
       type: object
       properties:
         layers:
           type: array
           items:
-            $ref: '#/components/schemas/TimeSeriesVariableInfo'
-    TimeSeriesVariableInfo:
+            $ref: '#/components/schemas/TsLegacyVariableInfo'
+    TsLegacyVariableInfo:
       type: object
       properties:
         name:
@@ -1072,21 +1148,21 @@ components:
             ymax:
               type: number
               format: double
-    TimeSeries:
+    TsLegacy:
       type: object
       properties:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/TimeSeriesEntry'
-    TimeSeriesEntry:
+            $ref: '#/components/schemas/TsLegacyEntry'
+    TsLegacyEntry:
       type: object
       properties:
         result:
-          $ref: '#/components/schemas/ArithmeticMean'
+          $ref: '#/components/schemas/TsLegacyResult'
         date:
           type: string
-    ArithmeticMean:
+    TsLegacyResult:
       type: object
       properties:
         totalCount:


### PR DESCRIPTION
Added new `/timeseries/{dataset}/{variable}` POST operation to xcube web API. It extracts time-series for a given GeoJSON object provided as body. It replaces all of the `/ts/{dataset}/{variable}/{geom-type}` operations. The latter are still maintained for compatibility with the "VITO viewer". 

This PR should have no impact on other xcube functions.
