### PR TITLE
Configure rgb style via cli parameter --style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@
 
 * `xcube serve CUBE` will now use the last path component of `CUBE`as dataset title.
 
+### Enhancements in 0.5.0.dev2
+
+* `xcube serve` now allows to specify a default RGB schema for a dataset, 
+  a colour mapping for the "pseudo-variable" named `rbg` via the `--style` cli parameter:
+  In order to configure an RGB image based on three variables, please use:
+  `rgb=(Red=(<var>=(<vmin>,<vmax>)),Green=(<var>=(<vmin>,<vmax>)),Blue=(<var>=(<vmin>,<vmax>)))`.
+
 ### New in 0.5.0.dev1
 
 * `xcube serve` can now be run with AWS credentials (#296). 

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -44,3 +44,13 @@ class ServerCliTest(CliDataTest):
     def test_help(self):
         with self.assertRaises(SystemExit):
             main(args=["--help"])
+
+    def test_styles_with_rgb(self):
+        result = self.invoke_cli(["serve", "examples/serve/demo/cube-1-250-250.zarr", "--styles",
+                                  "rgb=(Yellow=(conc_chl=(.0,0.25)),Green=(conc_tsm=(.0,0.25)),"
+                                  "Blue=(kd389=(.0,0.25)))"])
+        self.assertEqual(1, result.exit_code)
+        self.assertEqual('Error: For a default RGB schema, Red, Green and Blue need to be specified: '
+                         'rgb=(Red=(<var>=(<vmin>,<vmax>)),Green=(<var>=(<vmin>,<vmax>)),'
+                         'Blue=(<var>=(<vmin>,<vmax>)))\n',
+                         result.output[:])

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -150,6 +150,11 @@ def _handle_rgb_styles(styles):
     from xcube.cli.common import parse_cli_kwargs
 
     rgb = re.search(r"rgb=\(Red=\(.*\),Green=\(.*\),Blue=\(.*\)\)", styles)
+    if not rgb:
+        raise click.ClickException("For a default RGB schema, Red, Green and Blue need to be specified: "
+                                   "rgb=(Red=(<var>=(<vmin>,<vmax>)),Green=(<var>=(<vmin>,<vmax>)),"
+                                   "Blue=(<var>=(<vmin>,<vmax>)))")
+
     colors = re.split('rgb=\(', rgb.group())[1][:-1]
     rgb_dict = {'rgb': {}}
     for element in re.findall('[^\)\)]+\)\)', colors):

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -443,21 +443,31 @@ def new_default_config(cube_paths: List[str],
         dataset_list.append(dataset_descriptor)
         index += 1
 
-
     config = dict(Datasets=dataset_list)
     if styles:
         color_mappings = {}
         for var_name, style_data in styles.items():
-            try:
-                value_min, value_max, color_bar_name = style_data
-                style = dict(ValueRange=[value_min, value_max], ColorBar=color_bar_name)
-            except (TypeError, ValueError):
+            if var_name == 'rgb':
+                color_mappings[var_name] = {}
+                for key in style_data.keys():
+                    for style_variable in style_data[key].keys():
+                        try:
+                            value_min, value_max = style_data[key][style_variable]
+                            style = dict(Variable=style_variable, ValueRange=[value_min, value_max])
+                        except (TypeError, ValueError):
+                            raise ValueError(f"illegal style: {var_name}={style_data!r}")
+                        color_mappings[var_name][key] = style
+            else:
                 try:
-                    value_min, value_max = style_data
-                    style = dict(ValueRange=[value_min, value_max])
+                    value_min, value_max, color_bar_name = style_data
+                    style = dict(ValueRange=[value_min, value_max], ColorBar=color_bar_name)
                 except (TypeError, ValueError):
-                    raise ValueError(f"illegal style: {var_name}={style_data!r}")
-            color_mappings[var_name] = style
+                    try:
+                        value_min, value_max = style_data
+                        style = dict(ValueRange=[value_min, value_max])
+                    except (TypeError, ValueError):
+                        raise ValueError(f"illegal style: {var_name}={style_data!r}")
+                color_mappings[var_name] = style
         config["Styles"] = [dict(Identifier="default", ColorMappings=color_mappings)]
     return config
 


### PR DESCRIPTION
 `xcube serve` now allows to specify a default RGB schema for a dataset, 
  a colour mapping for the "pseudo-variable" named `rbg` via the `--style` cli parameter:
  In order to configure an RGB image based on three variables, please use:
  `rgb=(Red=(<var>=(<vmin>,<vmax>)),Green=(<var>=(<vmin>,<vmax>)),Blue=(<var>=(<vmin>,<vmax>)))`