### PR TITLE
Import ABCs from collections.abc (fixes #304)

### DIFF
--- a/test/core/diagnosticstore.py
+++ b/test/core/diagnosticstore.py
@@ -1,5 +1,5 @@
 import time
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from types import MethodType
 from typing import TypeVar, Iterator, List, Callable, Any, Tuple
 

--- a/xcube/core/store.py
+++ b/xcube/core/store.py
@@ -21,7 +21,7 @@
 
 import itertools
 import json
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from typing import Iterator, Dict, Tuple, Iterable, KeysView, Callable, Any, Union, Sequence
 
 import numpy as np

--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -20,7 +20,7 @@
 # SOFTWARE.
 
 import tempfile
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from typing import Dict, Union, Tuple
 
 import numpy as np


### PR DESCRIPTION
Import abstract base classes from collections.abc (preferred since Python 3.3, required from 3.9), rather than collections. Fixes #304 .