### PR TITLE
rectify CLI: handle multiple var specifiers correctly

### DIFF
--- a/test/cli/test_rectify.py
+++ b/test/cli/test_rectify.py
@@ -1,0 +1,41 @@
+import os
+from typing import List
+import xarray as xr
+from test.cli.helpers import CliDataTest, TEST_ZARR_DIR
+from xcube.core.verify import assert_cube
+
+
+class RectifyTest(CliDataTest):
+
+    def outputs(self) -> List[str]:
+        return ['out.zarr']
+
+    def test_rectify_multiple_comma_separated_vars(self):
+        """Test that rectify selects the desired variables when
+        multiple --var options, some with multiple comma-separated
+        variable names as an argument, are passed."""
+
+        # For now, specify the image geometry explicitly with --size, --point,
+        # and --res to avoid triggering an "invalid y_min" ValueError when
+        # ImageGeom tries to determine it automatically. Once Issue #303 has
+        # been fixed, these options can be omitted.
+
+        result = self.invoke_cli(['rectify',
+                                  '--size', '508,253',
+                                  '--point', '-179.5,-89.5',
+                                  '--res', '0.7071067811865475',
+                                  '--var', 'precipitation,temperature',
+                                  '--var', 'soil_moisture',
+                                  TEST_ZARR_DIR])
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual('Opening dataset from \'test.zarr\'...\n'
+                         'Rectifying...\n'
+                         'Writing rectified dataset to \'out.zarr\'...\n'
+                         'Done.\n',
+                         result.stdout)
+        self.assertTrue(os.path.isdir('out.zarr'))
+        ds = xr.open_zarr('out.zarr')
+        assert_cube(ds)
+        self.assertIn('precipitation', ds)
+        self.assertIn('temperature', ds)
+        self.assertIn('soil_moisture', ds)

--- a/xcube/cli/rectify.py
+++ b/xcube/cli/rectify.py
@@ -18,6 +18,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+import functools
+import operator
 from typing import Sequence, Optional, Tuple
 
 import click
@@ -85,9 +88,14 @@ def rectify(dataset: str,
     input_path = dataset
 
     xy_var_names = parse_cli_sequence(xy_var_names,
-                                      metavar='VARIABLES', num_items=2, item_plural_name='names')
-    var_names = parse_cli_sequence(var_names,
-                                   metavar='VARIABLES', item_plural_name='names')
+                                      metavar='VARIABLES', num_items=2,
+                                      item_plural_name='names')
+    var_name_lists = [parse_cli_sequence(var_name_specifier,
+                                         metavar='VARIABLES',
+                                         item_plural_name='names')
+                      for var_name_specifier in var_names]
+    var_name_flat_list = functools.reduce(operator.iconcat, var_name_lists, [])
+
     output_size = parse_cli_sequence(output_size,
                                      metavar='SIZE', num_items=2, item_plural_name='sizes',
                                      item_parser=int, item_validator=assert_positive_int_item)
@@ -101,7 +109,7 @@ def rectify(dataset: str,
     # noinspection PyBroadException
     _rectify(input_path,
              xy_var_names,
-             var_names,
+             var_name_flat_list,
              output_path,
              output_format,
              output_size,


### PR DESCRIPTION
Improve parsing of values of `--var` options supplied to the "xcube rectify" CLI command so that any combination of repeated options and comma-separated variables is handled correctly. Fixes #305.