### PR TITLE
Change from otc obs to aws s3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@
 ```yaml
     - Identifier: "OLCI-SNS-RAW-CUBE-2"
       FileSystem: "obs"
-      Endpoint: "http://obs.eu-de.otc.t-systems.com"
-      Path: "dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr"
+      Endpoint: "https://s3.eu-central-1.amazonaws.com/"
+      Path: "xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr"
       Anyonymous: true
       ...
     - ...
@@ -20,7 +20,7 @@
 ```python
     from xcube.core.dsio import open_cube 
     
-    public_url = "http://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr"
+    public_url = "https://s3.eu-central-1.amazonaws.com/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr"
     public_cube = open_cube(public_url, s3_kwargs=dict(anon=True))
 ```  
 * Extended `xcube.core.store.DataStore` docstring to include a basic convention for store open parameters. (#330)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ```yaml
     - Identifier: "OLCI-SNS-RAW-CUBE-2"
       FileSystem: "obs"
-      Endpoint: "https://s3.eu-central-1.amazonaws.com/"
+      Endpoint: "https://s3.eu-central-1.amazonaws.com"
       Path: "xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr"
       Anyonymous: true
       ...

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -175,9 +175,9 @@ Remotely Stored xcube Datasets
         Title: Remote OLCI L2C cube for region SNS
         BoundingBox: [0.0, 50, 5.0, 52.5]
         FileSystem: obs
-        Endpoint: "http://obs.eu-de.otc.t-systems.com"
-        Path: "dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr"
-        Region: "eu-de"
+        Endpoint: "https://s3.eu-central-1.amazonaws.com"
+        Path: "xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr"
+        Region: "eu-central-1"
         Style: default
         PlaceGroups:
           - PlaceGroupRef: inside-cube
@@ -208,7 +208,7 @@ notation of the *BoundingBox* is [lon_min,lat_min,lon_max,lat_max].
 cloud provider.
 
 *Path* [mandatory] leads to the specific location of the datacube. The particular datacube is stored in an
-OpenTelecomCloud S3 bucket called "dcs4cop-obs-02" and the datacube is called "OLCI-SNS-RAW-CUBE-2.zarr".
+OpenTelecomCloud S3 bucket called "xcube-examples" and the datacube is called "OLCI-SNS-RAW-CUBE-2.zarr".
 
 *Region* [mandatory] is the region where the specified cloud provider is operating.
 

--- a/docs/source/cli/xcube_tile.rst
+++ b/docs/source/cli/xcube_tile.rst
@@ -76,7 +76,7 @@ Example
 An example that uses a configuration file only::
 
 ```bash
-    xcube tile http://obs.eu-de.otc.t-systems.com/obs-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
+    xcube tile https://s3.eu-central-1.amazonaws.com/obs-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
       --labels time='2009-01-01/2009-12-30' \
       --vars analysed_sst,air_temperature_2m \
       --tile-size 270 \

--- a/docs/source/cli/xcube_tile.rst
+++ b/docs/source/cli/xcube_tile.rst
@@ -76,7 +76,7 @@ Example
 An example that uses a configuration file only::
 
 ```bash
-    xcube tile https://s3.eu-central-1.amazonaws.com/obs-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
+    xcube tile https://s3.eu-central-1.amazonaws.com/esdl-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
       --labels time='2009-01-01/2009-12-30' \
       --vars analysed_sst,air_temperature_2m \
       --tile-size 270 \

--- a/docs/source/viewer.rst
+++ b/docs/source/viewer.rst
@@ -1,6 +1,6 @@
 .. _`xcube viewer demo`: https://xcube-viewer.s3.eu-central-1.amazonaws.com/index.html
 .. _`xcube-viewer`: https://github.com/dcs4cop/xcube-viewer
-.. _`DCS4COP Demo viewer`: https://dcs4cop-demo-viewer.obs-website.eu-de.otc.t-systems.com/
+.. _`DCS4COP Demo viewer`: http://viewer.demo.dcs4cop.eu
 .. _`README`: https://github.com/dcs4cop/xcube-viewer/blob/master/README.md
 
 .. _`Earth System Data Lab`: https://www.earthsystemdatalab.net/
@@ -22,7 +22,7 @@ server instance locally then reload the viewer page, or configure the viewer wit
 To do so open the viewer's settings panels, select "Server". A "Select Server" panel is opened, click the "+"
 button to add a new server. Here are two demo servers that you may add for testing:
 
-* DCS4COP Demo Server (``https://xcube2.dcs4cop.eu/dcs4cop-dev/api/latest``) providing
+* DCS4COP Demo Server (``http://service.demo.dcs4cop.eu/xcube/api/latest``) providing
   ocean color variables in the North Sea area for the `Data Cube Service for Copernicus`_ (DCS4COP) EU project;
 * ESDL Server (``https://xcube.earthsystemdatalab.net``) providing global essential climate variables (ECVs)
   variables for the ESA `Earth System Data Lab`_.

--- a/examples/serve/demo/config-dcs4cop.yml
+++ b/examples/serve/demo/config-dcs4cop.yml
@@ -9,10 +9,10 @@ Datasets:
   - Identifier: cmems_sst_sns
     Title: "CMEMS SST SNS"
     BoundingBox: [0.0, 50, 5.0, 52.5]
-    Endpoint: "http://obs.eu-de.otc.t-systems.com"
-    Path: "dcs4cop-obs-01/dcs4cop-bc-sst-sns-l2c-v1.zarr"
+    Endpoint: "https://s3.eu-central-1.amazonaws.com/"
+    Path: "xcube-examples/bc-olci-sns-l2c-2017_1x1024x1024.zarr"
     FileSystem: "obs"
-    Region: "eu-de"
+    Region: "eu-central-1"
     Anonymous: true
     Style: default
 

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -55,9 +55,9 @@ Datasets:
     Title: Remote OLCI L2C cube for region SNS
     BoundingBox: [0.0, 50, 5.0, 52.5]
     FileSystem: obs
-    Endpoint: "http://obs.eu-de.otc.t-systems.com"
-    Path: "dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr"
-    Region: "eu-de"
+    Endpoint: "https://s3.eu-central-1.amazonaws.com"
+    Path: "xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr"
+    Region: "eu-central-1"
     Anonymous: true
     Style: default
     ChunkCacheSize: 250M

--- a/examples/tile/config-cci-cfs.yml
+++ b/examples/tile/config-cci-cfs.yml
@@ -1,6 +1,6 @@
 # Test me:
 #
-# xcube tile http://obs.eu-de.otc.t-systems.com/obs-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
+# xcube tile https://s3.eu-central-1.amazonaws.com/esdl-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
 #   --labels time='2009-01-01/2009-12-30' \
 #   --vars analysed_sst,air_temperature_2m \
 #   --tile-size 270 \

--- a/examples/tile/xcube_tile.bat
+++ b/examples/tile/xcube_tile.bat
@@ -1,4 +1,4 @@
-xcube tile http://obs.eu-de.otc.t-systems.com/obs-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr ^
+xcube tile https://s3.eu-central-1.amazonaws.com/esdl-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr ^
   --labels time='2009-01-01/2009-12-30' ^
   --vars analysed_sst,air_temperature_2m ^
   --tile-size 270 ^

--- a/examples/tile/xcube_tile.sh
+++ b/examples/tile/xcube_tile.sh
@@ -1,4 +1,4 @@
-xcube tile http://obs.eu-de.otc.t-systems.com/obs-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
+xcube tile https://s3.eu-central-1.amazonaws.com/esdl-esdc-v2.0.0/esdc-8d-0.083deg-1x2160x4320-2.0.0.zarr \
   --labels time='2009-01-01/2009-12-30' \
   --vars analysed_sst,air_temperature_2m \
   --tile-size 270 \

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -378,7 +378,7 @@ class GetPathOrObsStoreTest(S3Test):
     @moto.mock_s3
     def test_path_or_store_read_from_bucket(self):
         s3_store, consolidated = get_path_or_s3_store(
-            f'{MOTOSERVER_ENDPOINT_URL}/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', mode='r')
+            f'{MOTOSERVER_ENDPOINT_URL}/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', mode='r')
         self.assertIsInstance(s3_store, fsspec.mapping.FSMap)
         self.assertEqual(False, consolidated)
 
@@ -400,35 +400,35 @@ class GetPathOrObsStoreTest(S3Test):
 class ParseObsUrlAndKwargsTest(unittest.TestCase):
     def test_http(self):
         root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs(
-            'http://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr')
-        self.assertEqual('dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+            'https://s3.eu-central-1.amazonaws.com/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr')
+        self.assertEqual('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
         self.assertEqual({'key': None, 'secret': None}, s3_kwargs)
-        self.assertEqual({'endpoint_url': 'http://obs.eu-de.otc.t-systems.com'}, s3_client_kwargs)
+        self.assertEqual({'endpoint_url': 'https://s3.eu-central-1.amazonaws.com'}, s3_client_kwargs)
 
     def test_https_credentials(self):
         root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs(
-            'https://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', s3_client_kwargs={
+            'https://s3.eu-central-1.amazonaws.com/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', s3_client_kwargs={
                 'provider_access_key_id': 'bibo',
                 'provider_secret_access_key': '8625345',
             })
-        self.assertEqual('dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        self.assertEqual('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
         self.assertEqual({'key': 'bibo', 'secret': '8625345'}, s3_kwargs)
-        self.assertEqual({'endpoint_url': 'https://obs.eu-de.otc.t-systems.com'}, s3_client_kwargs)
+        self.assertEqual({'endpoint_url': 'https://s3.eu-central-1.amazonaws.com'}, s3_client_kwargs)
 
         root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs(
-            'https://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', s3_client_kwargs={
+            'https://s3.eu-central-1.amazonaws.com/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', s3_client_kwargs={
                 'aws_access_key_id': 'bibo',
                 'aws_secret_access_key': '8625345',
             })
-        self.assertEqual('dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        self.assertEqual('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
         self.assertEqual({'key': 'bibo', 'secret': '8625345'}, s3_kwargs)
-        self.assertEqual({'endpoint_url': 'https://obs.eu-de.otc.t-systems.com'}, s3_client_kwargs)
+        self.assertEqual({'endpoint_url': 'https://s3.eu-central-1.amazonaws.com'}, s3_client_kwargs)
 
     def test_s3(self):
-        root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs('s3://dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr',
+        root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs('s3://xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr',
                                                                     s3_kwargs={'anon': True},
                                                                     s3_client_kwargs={})
-        self.assertEqual('s3://dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        self.assertEqual('s3://xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
         self.assertEqual({'anon': True, 'key': None, 'secret': None}, s3_kwargs)
         self.assertEqual({}, s3_client_kwargs)
 
@@ -436,19 +436,19 @@ class ParseObsUrlAndKwargsTest(unittest.TestCase):
 class SplitBucketUrlTest(unittest.TestCase):
     def test_http(self):
         endpoint_url, root = split_s3_url(
-            'http://obs.eu-de.otc.t-systems.com/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr')
-        self.assertEqual('http://obs.eu-de.otc.t-systems.com', endpoint_url)
-        self.assertEqual('dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
-        endpoint_url, root = split_s3_url('https://xcube-serve:9098/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr')
+            'https://s3.eu-central-1.amazonaws.com/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr')
+        self.assertEqual('https://s3.eu-central-1.amazonaws.com', endpoint_url)
+        self.assertEqual('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        endpoint_url, root = split_s3_url('https://xcube-serve:9098/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr')
         self.assertEqual('https://xcube-serve:9098', endpoint_url)
-        self.assertEqual('dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        self.assertEqual('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
 
     def test_s3(self):
-        endpoint_url, root = split_s3_url('s3://dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr')
+        endpoint_url, root = split_s3_url('s3://xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr')
         self.assertEqual(None, endpoint_url)
-        self.assertEqual('s3://dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        self.assertEqual('s3://xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)
 
     def test_local(self):
-        endpoint_url, root = split_s3_url('/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr')
+        endpoint_url, root = split_s3_url('/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr')
         self.assertEqual(None, endpoint_url)
-        self.assertEqual('/dcs4cop-obs-02/OLCI-SNS-RAW-CUBE-2.zarr', root)
+        self.assertEqual('/xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', root)

--- a/test/core/test_timeslice.py
+++ b/test/core/test_timeslice.py
@@ -1,18 +1,14 @@
-import os
 import unittest
 
-import moto
 import numpy as np
-import s3fs
 import xarray as xr
 import zarr
 
 from xcube.core.new import new_cube
 from xcube.core.chunk import chunk_dataset
-from xcube.core.dsio import rimraf, write_dataset
+from xcube.core.dsio import rimraf
 from xcube.core.timeslice import find_time_slice, append_time_slice, insert_time_slice, replace_time_slice
 from test.core.diagnosticstore import DiagnosticStore, logging_observer
-from test.s3test import S3Test, MOTOSERVER_ENDPOINT_URL
 
 
 class TimeSliceTest(unittest.TestCase):

--- a/test/core/test_timeslice.py
+++ b/test/core/test_timeslice.py
@@ -1,14 +1,18 @@
+import os
 import unittest
 
+import moto
 import numpy as np
+import s3fs
 import xarray as xr
 import zarr
 
 from xcube.core.new import new_cube
 from xcube.core.chunk import chunk_dataset
-from xcube.core.dsio import rimraf
+from xcube.core.dsio import rimraf, write_dataset
 from xcube.core.timeslice import find_time_slice, append_time_slice, insert_time_slice, replace_time_slice
 from test.core.diagnosticstore import DiagnosticStore, logging_observer
+from test.s3test import S3Test, MOTOSERVER_ENDPOINT_URL
 
 
 class TimeSliceTest(unittest.TestCase):
@@ -167,8 +171,8 @@ class ZarrStoreTest(unittest.TestCase):
     @unittest.skipUnless(False, 'is enabled')
     def test_remote(self):
         import s3fs
-        endpoint_url = "http://obs.eu-de.otc.t-systems.com"
+        endpoint_url = "https://s3.eu-central-1.amazonaws.com"
         s3 = s3fs.S3FileSystem(anon=True, client_kwargs=dict(endpoint_url=endpoint_url))
-        s3_store = s3fs.S3Map(root="cyanoalert/cyanoalert-olci-lswe-l2c-v1.zarr", s3=s3, check=False)
+        s3_store = s3fs.S3Map(root="xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr", s3=s3, check=False)
         diagnostic_store = DiagnosticStore(s3_store, logging_observer(log_path='remote-cube.log'))
         xr.open_zarr(diagnostic_store)

--- a/test/webapi/test_s3buckethandlers.py
+++ b/test/webapi/test_s3buckethandlers.py
@@ -37,6 +37,6 @@ class S3BucketHandlersTest(unittest.TestCase):
         self.assertAlmostEqual(22.4421215, float(np.nanmax(conc_chl_values)), delta=1e-6)
 
     # def test_open_cube_from_obs(self):
-    #     ds = open_cube('dcs4cop-obs-01/OLCI-SNS-RAW-CUBE-2.zarr', format_name='zarr',
-    #                    endpoint_url='https://obs.eu-de.otc.t-systems.com')
+    #     ds = open_cube('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', format_name='zarr',
+    #                    endpoint_url='https://s3.eu-central-1.amazonaws.com/')
     #     self.assertIsNotNone(ds)


### PR DESCRIPTION
This PR changes all occurrences of http://obs.eu-de.otc.t-systems.com to https://s3.eu-central-1.amazonaws.com .The corresponding cubes have been copied to an aws s3 bucket called 'xcube-examples'. 
No implementation changes have been made. 