### PR TITLE
TypeSpecifier update

### DIFF
--- a/test/core/store/stores/test_directory.py
+++ b/test/core/store/stores/test_directory.py
@@ -195,8 +195,7 @@ class DirectoryDataStoreTest(unittest.TestCase):
 
         with self.assertRaises(DataStoreError) as cm:
             set(self.store.describe_data('cube-1-250-250.zarr', type_specifier='geodataframe'))
-        self.assertEqual('Data resource "cube-1-250-250.zarr" is not compatible with type specifier "geodataframe". '
-                         'Cannot create DataDescriptor.', f'{cm.exception}')
+        self.assertEqual('Type specifier "geodataframe" cannot be satisfied by type specifier "dataset" of data resource "cube-1-250-250.zarr"', f'{cm.exception}')
 
     def test_search_data(self):
         result = list(self.store.search_data())

--- a/test/core/store/stores/test_directory.py
+++ b/test/core/store/stores/test_directory.py
@@ -1,10 +1,11 @@
 import os.path
 import unittest
 
-from xcube.core.store import new_data_store
 from xcube.core.store import TYPE_SPECIFIER_CUBE
+from xcube.core.store import new_data_store
 from xcube.core.store.error import DataStoreError
 from xcube.core.store.stores.directory import DirectoryDataStore
+
 
 class DirectoryDataStoreTest(unittest.TestCase):
 
@@ -83,13 +84,12 @@ class DirectoryDataStoreTest(unittest.TestCase):
                          set(self.store.get_data_opener_ids(type_specifier='geodataframe')))
 
     def test_get_type_specifiers_for_data(self):
-        self.assertEqual(('dataset', ), self.store.get_type_specifiers_for_data('cube-1-250-250.zarr'))
-        self.assertEqual(('dataset', ), self.store.get_type_specifiers_for_data('cube.nc'))
+        self.assertEqual(('dataset',), self.store.get_type_specifiers_for_data('cube-1-250-250.zarr'))
+        self.assertEqual(('dataset',), self.store.get_type_specifiers_for_data('cube.nc'))
         with self.assertRaises(DataStoreError) as cm:
             set(self.store.get_type_specifiers_for_data('xyz.levels'))
         self.assertEqual('Data resource "xyz.levels" does not exist in store',
                          f'{cm.exception}')
-
 
     def test_get_data_writer_ids(self):
         self.assertEqual({'dataset:netcdf:posix',
@@ -122,45 +122,48 @@ class DirectoryDataStoreTest(unittest.TestCase):
                 ('cube-5-100-200.zarr', None),
                 ('cube.nc', None),
             },
-            set(self.store.get_data_ids()))
+            set(self.store.get_data_ids())
+        )
         self.assertEqual(
             {
                 ('cube-1-250-250.zarr', None),
                 ('cube-5-100-200.zarr', None),
                 ('cube.nc', None),
             },
-            set(self.store.get_data_ids('*')))
+            set(self.store.get_data_ids('*'))
+        )
         self.assertEqual(
             {
                 ('cube-1-250-250.zarr', None),
                 ('cube-5-100-200.zarr', None),
                 ('cube.nc', None),
             },
-            set(self.store.get_data_ids('dataset')))
+            set(self.store.get_data_ids('dataset'))
+        )
         self.assertEqual(
             set(),
-            set(self.store.get_data_ids('dataset[multilevel]')))
-        with self.assertRaises(ValueError) as cm:
-            set(self.store.get_data_ids(type_specifier='dataset[cube]'))
-        self.assertEqual("type_specifier must be one of ('dataset', 'dataset[multilevel]', 'geodataframe')",
-                         f'{cm.exception}')
+            set(self.store.get_data_ids('dataset[multilevel]'))
+        )
         self.assertEqual(
             {
                 ('cube-1-250-250.zarr', None),
                 ('cube-5-100-200.zarr', None),
                 ('cube.nc', None),
             },
-            set(self.store.get_data_ids(include_titles=False)))
+            set(self.store.get_data_ids(include_titles=False))
+        )
         self.assertEqual(
             {
                 ('cube-1-250-250.zarr', None),
                 ('cube-5-100-200.zarr', None),
                 ('cube.nc', None),
             },
-            set(self.store.get_data_ids('dataset', include_titles=False)))
+            set(self.store.get_data_ids('dataset', include_titles=False))
+        )
         self.assertEqual(
             set(),
-            set(self.store.get_data_ids('dataset[multilevel]', include_titles=False)))
+            set(self.store.get_data_ids('dataset[multilevel]', include_titles=False))
+        )
 
     def test_has_data(self):
         self.assertTrue(self.store.has_data('cube-1-250-250.zarr'))
@@ -195,7 +198,6 @@ class DirectoryDataStoreTest(unittest.TestCase):
         self.assertEqual('Data resource "cube-1-250-250.zarr" is not compatible with type specifier "geodataframe". '
                          'Cannot create DataDescriptor.', f'{cm.exception}')
 
-
     def test_search_data(self):
         result = list(self.store.search_data())
         self.assertEqual(3, len(result))
@@ -223,11 +225,6 @@ class DirectoryDataStoreTest(unittest.TestCase):
         self.assertEqual(result[1].type_specifier, TYPE_SPECIFIER_CUBE)
         self.assertEqual(result[2].data_id, 'cube.nc')
         self.assertEqual(result[2].type_specifier, TYPE_SPECIFIER_CUBE)
-
-        with self.assertRaises(ValueError) as cm:
-            list(self.store.search_data(type_specifier='dataset[cube]'))
-        self.assertEqual("type_specifier must be one of ('dataset', 'dataset[multilevel]', 'geodataframe')",
-                         f'{cm.exception}')
 
         result = list(self.store.search_data(type_specifier='geodataframe'))
         self.assertEqual(0, len(result))

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -21,7 +21,7 @@ class DatasetDescriptorTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             descriptor_dict = dict(data_id='xyz', type_specifier='tsr')
             DatasetDescriptor.from_dict(descriptor_dict)
-        self.assertEqual('type_specifier must be compatible with "dataset" type specifier, was "tsr"',
+        self.assertEqual('type_specifier must be compatible with type specifier "dataset", was "tsr"',
                          f'{cm.exception}')
 
     def test_from_dict_basic(self):

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -21,7 +21,7 @@ class DatasetDescriptorTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             descriptor_dict = dict(data_id='xyz', type_specifier='tsr')
             DatasetDescriptor.from_dict(descriptor_dict)
-        self.assertEqual('type_specifier must be compatible with type specifier "dataset", was "tsr"',
+        self.assertEqual('type_specifier must satisfy type specifier "dataset", was "tsr"',
                          f'{cm.exception}')
 
     def test_from_dict_basic(self):

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -21,7 +21,7 @@ class DatasetDescriptorTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             descriptor_dict = dict(data_id='xyz', type_specifier='tsr')
             DatasetDescriptor.from_dict(descriptor_dict)
-        self.assertEqual('type_specifier must satisfy type specifier "dataset", was "tsr"',
+        self.assertEqual('type_specifier must satisfy type specifier "dataset", but was "tsr"',
                          f'{cm.exception}')
 
     def test_from_dict_basic(self):

--- a/test/core/store/test_typespecifier.py
+++ b/test/core/store/test_typespecifier.py
@@ -20,6 +20,15 @@ class TypeSpecifierTest(unittest.TestCase):
         self.assertEqual('dataset', type_specifier.name)
         self.assertEqual(set(), type_specifier.flags)
 
+    def test_any(self):
+        type_specifier = TypeSpecifier(name='*')
+        self.assertEqual('*', type_specifier.name)
+
+    def test_any_and_flags(self):
+        with self.assertRaises(ValueError) as cm:
+            TypeSpecifier(name='*', flags={'cube'})
+        self.assertEqual('flags are not allowed if name is "*" (any)', f'{cm.exception}')
+
     def test_name_and_flags(self):
         type_specifier = TypeSpecifier(name='dataset', flags={'cube', 'multilevel'})
         self.assertEqual('dataset', type_specifier.name)
@@ -44,15 +53,14 @@ class TypeSpecifierTest(unittest.TestCase):
         self.assertTrue(type_specifier_1 == type_specifier_2)
 
     def test_equality_any(self):
-        type_specifier = TypeSpecifier(name='*', flags={'cube'})
+        type_specifier = TypeSpecifier(name='*')
         self.assertFalse(type_specifier == TypeSpecifier('geodataframe'))
         self.assertFalse(type_specifier == TypeSpecifier('geodataframe', flags={'cube'}))
         self.assertFalse(type_specifier == TypeSpecifier('dataset'))
         self.assertFalse(type_specifier == TypeSpecifier('dataset', flags={'multilevel'}))
         self.assertFalse(type_specifier == TypeSpecifier('dataset', flags={'multilevel', 'cube'}))
         self.assertFalse(type_specifier == TypeSpecifier('dataset', flags={'cube'}))
-        self.assertFalse(type_specifier == TypeSpecifier('*'))
-        self.assertTrue(type_specifier == TypeSpecifier('*', flags={'cube'}))
+        self.assertTrue(type_specifier == TypeSpecifier('*'))
 
     def test_it_satisfies_without_flags(self):
         type_specifier = TypeSpecifier(name='dataset')
@@ -96,9 +104,12 @@ class TypeSpecifierTest(unittest.TestCase):
         self.assertEqual(TypeSpecifier.normalize('dataset'), dataset_specifier)
 
     def test_parse(self):
-        parsed_specifier = TypeSpecifier.parse('dataset[cube,multilevel]')
-        self.assertEqual('dataset', parsed_specifier.name)
-        self.assertEqual({'cube', 'multilevel'}, parsed_specifier.flags)
+        self.assertEqual(TypeSpecifier('*'),
+                         TypeSpecifier.parse('*'))
+        self.assertEqual(TypeSpecifier('dataset'),
+                         TypeSpecifier.parse('dataset'))
+        self.assertEqual(TypeSpecifier('dataset', {'cube', 'multilevel'}),
+                         TypeSpecifier.parse('dataset[cube,multilevel]'))
 
     def test_parse_exception(self):
         with self.assertRaises(SyntaxError) as cm:

--- a/test/core/store/test_typespecifier.py
+++ b/test/core/store/test_typespecifier.py
@@ -1,16 +1,16 @@
-import geopandas as gpd
 import unittest
+
+import geopandas as gpd
 import xarray as xr
 
+from xcube.core.mldataset import BaseMultiLevelDataset
 from xcube.core.new import new_cube
 from xcube.core.store.typespecifier import TYPE_SPECIFIER_CUBE
 from xcube.core.store.typespecifier import TYPE_SPECIFIER_DATASET
 from xcube.core.store.typespecifier import TYPE_SPECIFIER_GEODATAFRAME
 from xcube.core.store.typespecifier import TYPE_SPECIFIER_MULTILEVEL_DATASET
-from xcube.core.store.typespecifier import get_type_specifier
 from xcube.core.store.typespecifier import TypeSpecifier
-
-from xcube.core.mldataset import BaseMultiLevelDataset
+from xcube.core.store.typespecifier import get_type_specifier
 
 
 class TypeSpecifierTest(unittest.TestCase):
@@ -41,7 +41,7 @@ class TypeSpecifierTest(unittest.TestCase):
     def test_equality_flag_order_is_irrelevant(self):
         type_specifier_1 = TypeSpecifier(name='dataset', flags={'cube', 'multilevel'})
         type_specifier_2 = TypeSpecifier(name='dataset', flags={'multilevel', 'cube'})
-        self.assertTrue(type_specifier_1  == type_specifier_2)
+        self.assertTrue(type_specifier_1 == type_specifier_2)
 
     def test_equality_any(self):
         type_specifier = TypeSpecifier(name='*', flags={'cube'})
@@ -54,23 +54,37 @@ class TypeSpecifierTest(unittest.TestCase):
         self.assertFalse(type_specifier == TypeSpecifier('*'))
         self.assertTrue(type_specifier == TypeSpecifier('*', flags={'cube'}))
 
-    def test_is_compatible(self):
-        type_specifier = TypeSpecifier(name='dataset', flags={'cube'})
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('geodataframe')))
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('geodataframe', flags={'cube'})))
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('dataset')))
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('dataset', flags={'multilevel'})))
-        self.assertTrue(type_specifier.is_compatible(TypeSpecifier('dataset', flags={'multilevel', 'cube'})))
-        self.assertTrue(type_specifier.is_compatible(TypeSpecifier('dataset', flags={'cube'})))
+    def test_it_satisfies_without_flags(self):
+        type_specifier = TypeSpecifier(name='dataset')
+        self._assert_it_not_satisfies(type_specifier, TypeSpecifier('dataset', flags={'cube'}))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('dataset'))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('*'))
 
-    def test_is_compatible_any(self):
-        type_specifier = TypeSpecifier(name='*', flags={'cube'})
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('geodataframe')))
-        self.assertTrue(type_specifier.is_compatible(TypeSpecifier('geodataframe', flags={'cube'})))
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('dataset')))
-        self.assertFalse(type_specifier.is_compatible(TypeSpecifier('dataset', flags={'multilevel'})))
-        self.assertTrue(type_specifier.is_compatible(TypeSpecifier('dataset', flags={'cube'})))
-        self.assertTrue(type_specifier.is_compatible(TypeSpecifier('dataset', flags={'multilevel', 'cube'})))
+    def test_it_satisfies_with_flags(self):
+        type_specifier = TypeSpecifier(name='dataset', flags={'cube'})
+        self._assert_it_not_satisfies(type_specifier, TypeSpecifier('geodataframe'))
+        self._assert_it_not_satisfies(type_specifier, TypeSpecifier('geodataframe', flags={'cube'}))
+        self._assert_it_not_satisfies(type_specifier, TypeSpecifier('dataset', flags={'multilevel'}))
+        self._assert_it_not_satisfies(type_specifier, TypeSpecifier('dataset', flags={'multilevel', 'cube'}))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('dataset'))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('dataset', flags={'cube'}))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('*'))
+
+    def test_it_satisfies_as_any(self):
+        type_specifier = TypeSpecifier(name='*')
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('geodataframe'))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('geodataframe', flags={'cube'}))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('dataset'))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('dataset', flags={'cube'}))
+        self._assert_it_satisfies(type_specifier, TypeSpecifier('*'))
+
+    def _assert_it_satisfies(self, a: TypeSpecifier, b: TypeSpecifier):
+        self.assertTrue(a.satisfies(b), f'"{a}" did unexpectedly not satisfy "{b}"')
+        self.assertTrue(b.is_satisfied_by(a), f'"{b}" is unexpectedly not satisfied by "{a}"')
+
+    def _assert_it_not_satisfies(self, a: TypeSpecifier, b: TypeSpecifier):
+        self.assertFalse(a.satisfies(b), f'"{a}" did unexpectedly satisfy "{b}"')
+        self.assertFalse(b.is_satisfied_by(a), f'"{b}" is unexpectedly satisfied by "{a}"')
 
     def test_normalize(self):
         dataset_flagged_specifier = TypeSpecifier(name='dataset', flags={'cube'})

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -21,20 +21,22 @@
 
 from typing import Tuple, Sequence, Mapping, Optional, Dict, Any, Union
 
-import numpy as np
 import geopandas as gpd
+import numpy as np
 import xarray as xr
 
 from xcube.core.mldataset import MultiLevelDataset
-from xcube.core.store.typespecifier import get_type_specifier
-from xcube.core.store.typespecifier import TypeSpecifier
+from xcube.core.store.typespecifier import TYPE_SPECIFIER_ANY
 from xcube.core.store.typespecifier import TYPE_SPECIFIER_DATASET
-from xcube.core.store.typespecifier import TYPE_SPECIFIER_MULTILEVEL_DATASET
 from xcube.core.store.typespecifier import TYPE_SPECIFIER_GEODATAFRAME
+from xcube.core.store.typespecifier import TYPE_SPECIFIER_MULTILEVEL_DATASET
+from xcube.core.store.typespecifier import TypeSpecifier
+from xcube.core.store.typespecifier import get_type_specifier
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_in
 from xcube.util.ipython import register_json_formatter
 from xcube.util.jsonschema import JsonObjectSchema
+
 
 # TODO: IMPORTANT: replace, reuse, or align with
 #   xcube.core.schema.CubeSchema class
@@ -44,7 +46,7 @@ from xcube.util.jsonschema import JsonObjectSchema
 # TODO: validate params
 
 
-def new_data_descriptor(data_id: str, data: Any) -> 'DataDescriptor':
+def new_data_descriptor(data_id: str, data: Any, require: bool = False) -> 'DataDescriptor':
     if isinstance(data, xr.Dataset):
         # TODO: implement me: data -> DatasetDescriptor
         return DatasetDescriptor(data_id=data_id, type_specifier=get_type_specifier(data))
@@ -54,6 +56,8 @@ def new_data_descriptor(data_id: str, data: Any) -> 'DataDescriptor':
     elif isinstance(data, gpd.GeoDataFrame):
         # TODO: implement me: data -> GeoDataFrameDescriptor
         return GeoDataFrameDescriptor(data_id=data_id, num_levels=5)
+    elif not require:
+        return DataDescriptor(data_id=data_id, type_specifier=TYPE_SPECIFIER_ANY)
     raise NotImplementedError()
 
 
@@ -73,7 +77,7 @@ class DataDescriptor:
                  time_period: str = None,
                  open_params_schema: JsonObjectSchema = None):
         assert_given(data_id, 'data_id')
-        assert_given(type_specifier, 'type_specifier')
+        self._assert_valid_type_specifier(type_specifier)
         self.data_id = data_id
         self.type_specifier = TypeSpecifier.normalize(type_specifier)
         self.crs = crs
@@ -98,6 +102,18 @@ class DataDescriptor:
             d['open_params_schema'] = self.open_params_schema.to_dict()
         return d
 
+    @classmethod
+    def _get_base_type_specifier(cls) -> TypeSpecifier:
+        return TYPE_SPECIFIER_ANY
+
+    @classmethod
+    def _assert_valid_type_specifier(cls, type_specifier: Optional[str]):
+        assert_given(type_specifier, 'type_specifier')
+        base_type_specifier = cls._get_base_type_specifier()
+        if not base_type_specifier.is_satisfied_by(type_specifier):
+            raise ValueError('type_specifier must satisfy'
+                             f' type specifier "{base_type_specifier}", but was "{type_specifier}"')
+
 
 class DatasetDescriptor(DataDescriptor):
     """
@@ -117,7 +133,6 @@ class DatasetDescriptor(DataDescriptor):
                  data_vars: Sequence['VariableDescriptor'] = None,
                  attrs: Mapping[str, any] = None,
                  open_params_schema: JsonObjectSchema = None):
-        self._assert_valid_type_specifier(type_specifier)
         super().__init__(data_id=data_id,
                          type_specifier=type_specifier,
                          crs=crs,
@@ -129,17 +144,6 @@ class DatasetDescriptor(DataDescriptor):
         self.dims = dict(dims) if dims else None
         self.data_vars = list(data_vars) if data_vars else None
         self.attrs = _convert_nans_to_none(dict(attrs)) if attrs else None
-
-    @classmethod
-    def _get_base_type_specifier(cls) -> TypeSpecifier:
-        return TYPE_SPECIFIER_DATASET
-
-    @classmethod
-    def _assert_valid_type_specifier(cls, type_specifier: str):
-        base_type_specifier = cls._get_base_type_specifier()
-        if not base_type_specifier.is_satisfied_by(type_specifier):
-            raise ValueError('type_specifier must satisfy'
-                             f' type specifier "{base_type_specifier}", was "{type_specifier}"')
 
     @classmethod
     def from_dict(cls, d: Mapping[str, Any]) -> 'DatasetDescriptor':
@@ -168,6 +172,10 @@ class DatasetDescriptor(DataDescriptor):
             d['data_vars'] = [vd.to_dict() for vd in self.data_vars]
         _copy_none_null_props(self, d, ['dims', 'attrs'])
         return d
+
+    @classmethod
+    def _get_base_type_specifier(cls) -> TypeSpecifier:
+        return TYPE_SPECIFIER_DATASET
 
 
 class VariableDescriptor:
@@ -221,10 +229,6 @@ class MultiLevelDatasetDescriptor(DatasetDescriptor):
         self.num_levels = num_levels
 
     @classmethod
-    def _get_base_type_specifier(cls) -> TypeSpecifier:
-        return TYPE_SPECIFIER_MULTILEVEL_DATASET
-
-    @classmethod
     def from_dict(cls, d: Mapping[str, Any]) -> 'MultiLevelDatasetDescriptor':
         """Create new instance from a JSON-serializable dictionary"""
         # TODO: implement me
@@ -235,6 +239,10 @@ class MultiLevelDatasetDescriptor(DatasetDescriptor):
         d = super().to_dict()
         d['num_levels'] = self.num_levels
         return d
+
+    @classmethod
+    def _get_base_type_specifier(cls) -> TypeSpecifier:
+        return TYPE_SPECIFIER_MULTILEVEL_DATASET
 
 
 class GeoDataFrameDescriptor(DataDescriptor):
@@ -253,11 +261,6 @@ class GeoDataFrameDescriptor(DataDescriptor):
                          **kwargs)
         self.feature_schema = feature_schema
 
-    def _assert_type_specifier(self, type_specifier: str):
-        if not TYPE_SPECIFIER_GEODATAFRAME.is_satisfied_by(type_specifier):
-            raise ValueError(f'type_specifier must be compatible with "{TYPE_SPECIFIER_GEODATAFRAME}" type specifier, '
-                             f'was "{type_specifier}"')
-
     @classmethod
     def from_dict(cls, d: Mapping[str, Any]) -> 'MultiLevelDatasetDescriptor':
         """Create new instance from a JSON-serializable dictionary"""
@@ -269,6 +272,10 @@ class GeoDataFrameDescriptor(DataDescriptor):
         d = super().to_dict()
         _copy_none_null_props(self, d, ['feature_schema'])
         return d
+
+    @classmethod
+    def _get_base_type_specifier(cls) -> TypeSpecifier:
+        return TYPE_SPECIFIER_GEODATAFRAME
 
 
 def _convert_nans_to_none(d: Dict[str, Any]) -> Dict[str, Any]:

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -138,7 +138,7 @@ class DatasetDescriptor(DataDescriptor):
     def _assert_valid_type_specifier(cls, type_specifier: str):
         base_type_specifier = cls._get_base_type_specifier()
         if not base_type_specifier.is_satisfied_by(type_specifier):
-            raise ValueError('type_specifier must be compatible with'
+            raise ValueError('type_specifier must satisfy'
                              f' type specifier "{base_type_specifier}", was "{type_specifier}"')
 
     @classmethod

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -153,7 +153,8 @@ class DataStore(DataOpener, ABC):
         """
 
     @abstractmethod
-    def get_data_ids(self, type_specifier: str = None, include_titles = True) -> Iterator[Tuple[str, Optional[str]]]:
+    def get_data_ids(self, type_specifier: str = None, include_titles: bool = True) -> \
+            Iterator[Tuple[str, Optional[str]]]:
         """
         Get an iterator over the data resource identifiers for the given type *type_specifier*.
         If *type_specifier* is omitted, all data resource identifiers are returned.

--- a/xcube/core/store/stores/directory.py
+++ b/xcube/core/store/stores/directory.py
@@ -34,6 +34,7 @@ from xcube.core.store import TYPE_SPECIFIER_ANY
 from xcube.core.store import TYPE_SPECIFIER_DATASET
 from xcube.core.store import TYPE_SPECIFIER_GEODATAFRAME
 from xcube.core.store import TYPE_SPECIFIER_MULTILEVEL_DATASET
+from xcube.core.store import TypeSpecifier
 from xcube.core.store import find_data_opener_extensions
 from xcube.core.store import find_data_writer_extensions
 from xcube.core.store import get_data_accessor_predicate
@@ -41,7 +42,6 @@ from xcube.core.store import get_type_specifier
 from xcube.core.store import new_data_descriptor
 from xcube.core.store import new_data_opener
 from xcube.core.store import new_data_writer
-from xcube.core.store import TypeSpecifier
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_in
 from xcube.util.assertions import assert_instance
@@ -113,37 +113,36 @@ class DirectoryDataStore(MutableDataStore):
         actual_type_specifier, _, _ = self._get_accessor_id_parts(data_id)
         return actual_type_specifier,
 
-    def get_data_ids(self, type_specifier: str = None, include_titles: bool = True) -> Iterator[Tuple[str, Optional[str]]]:
-        if type_specifier:
-            type_specifier = TypeSpecifier.parse(type_specifier)
-        if type_specifier == TYPE_SPECIFIER_ANY:
-            type_specifier = None
-        self._assert_valid_type_specifier(type_specifier)
+    def get_data_ids(self, type_specifier: str = None, include_titles: bool = True) -> \
+            Iterator[Tuple[str, Optional[str]]]:
+        if type_specifier is not None:
+            type_specifier = TypeSpecifier.normalize(type_specifier)
         # TODO: Use os.walk(), which provides a generator rather than a list
         # os.listdir does not guarantee any ordering of the entries, so
         # sort them to ensure predictable behaviour.
         for data_id in sorted(os.listdir(self._base_dir)):
-            accessor_id_parts = self._get_accessor_id_parts(data_id, require=False)
-            if accessor_id_parts:
-                actual_type_specifier, _, _ = accessor_id_parts
-                actual_type_specifier = TypeSpecifier.normalize(actual_type_specifier)
-                if type_specifier is None or type_specifier.is_compatible(actual_type_specifier):
+            actual_type_specifier = self._get_type_specifier_for_data_id(data_id, require=False)
+            if actual_type_specifier is not None:
+                if type_specifier is None or actual_type_specifier.satisfies(type_specifier):
                     yield data_id, None
 
     def has_data(self, data_id: str, type_specifier: str = None) -> bool:
         assert_given(data_id, 'data_id')
-        actual_type_specifier, _, _ = self._get_accessor_id_parts(data_id)
-        if type_specifier and not TypeSpecifier.parse(type_specifier).is_compatible(actual_type_specifier):
-            return False
+        if type_specifier:
+            actual_type_specifier = self._get_type_specifier_for_data_id(data_id)
+            if not actual_type_specifier.satisfies(type_specifier):
+                return False
         path = self._resolve_data_id_to_path(data_id)
         return os.path.exists(path)
 
     def describe_data(self, data_id: str, type_specifier: str = None) -> DataDescriptor:
         self._assert_valid_data_id(data_id)
-        actual_type_specifier, _, _ = self._get_accessor_id_parts(data_id)
-        if type_specifier and not TypeSpecifier.parse(type_specifier).is_compatible(actual_type_specifier):
-            raise DataStoreError(f'Data resource "{data_id}" is not compatible with type specifier "{type_specifier}". '
-                                 f'Cannot create DataDescriptor.')
+        if type_specifier is not None:
+            actual_type_specifier = self._get_type_specifier_for_data_id(data_id)
+            if not actual_type_specifier.satisfies(type_specifier):
+                raise DataStoreError(
+                    f'Data resource "{data_id}" is not compatible with type specifier "{type_specifier}". '
+                    f'Cannot create DataDescriptor.')
         data = self.open_data(data_id)
         return new_data_descriptor(data_id, data)
 
@@ -273,7 +272,7 @@ class DirectoryDataStore(MutableDataStore):
         return os.path.join(self._base_dir, data_id)
 
     def _assert_valid_type_specifier(self, type_specifier: Optional[TypeSpecifier]):
-        if type_specifier:
+        if type_specifier is not None:
             assert_in(type_specifier, self.get_type_specifiers(), 'type_specifier')
 
     def _get_opener_id(self, data_id: str):
@@ -306,6 +305,13 @@ class DirectoryDataStore(MutableDataStore):
                 raise DataStoreError(f'No accessor found for data resource "{data_id}"')
             return []
         return extensions
+
+    def _get_type_specifier_for_data_id(self, data_id: str, require=True) -> Optional[TypeSpecifier]:
+        accessor_id_parts = self._get_accessor_id_parts(data_id, require=require)
+        if accessor_id_parts is None:
+            return None
+        actual_type_specifier, _, _ = accessor_id_parts
+        return TypeSpecifier.parse(actual_type_specifier)
 
     @classmethod
     def _get_accessor_id_parts(cls, data_id: str, require=True) -> Optional[Tuple[str, str, str]]:

--- a/xcube/core/store/stores/memory.py
+++ b/xcube/core/store/stores/memory.py
@@ -91,8 +91,8 @@ class MemoryDataStore(MutableDataStore):
         if type_specifier is not None:
             data_type_specifier = get_type_specifier(self._data_dict[data_id])
             if data_type_specifier is None or not data_type_specifier.satisfies(type_specifier):
-                raise DataStoreError(f'Data resource "{data_id}" is not compatible with '
-                                     f'type specifier "{type_specifier}". Cannot create DataDescriptor.')
+                raise DataStoreError(f'Type specifier "{type_specifier}" cannot be satisfied'
+                                     f' by type specifier "{data_type_specifier}" of data resource "{data_id}"')
         return new_data_descriptor(data_id, self._data_dict[data_id])
 
     @classmethod

--- a/xcube/core/store/stores/memory.py
+++ b/xcube/core/store/stores/memory.py
@@ -66,17 +66,23 @@ class MemoryDataStore(MutableDataStore):
         return str(type_specifier),
 
     def get_data_ids(self, type_specifier: str = None, include_titles: bool = True) -> Iterator[Tuple[str, Optional[str]]]:
-        for data_id, data in self._data_dict.items():
-            if type_specifier is None or TypeSpecifier.normalize(type_specifier).is_compatible(get_type_specifier(data)):
+        if type_specifier is None:
+            for data_id, data in self._data_dict.items():
                 yield data_id, None
+        else:
+            type_specifier = TypeSpecifier.normalize(type_specifier)
+            for data_id, data in self._data_dict.items():
+                data_type_specifier = get_type_specifier(data)
+                if data_type_specifier is None or data_type_specifier.satisfies(type_specifier):
+                    yield data_id, None
 
     def has_data(self, data_id: str, type_specifier: str = None) -> bool:
         assert_given(data_id, 'data_id')
-        if not data_id in self._data_dict:
+        if data_id not in self._data_dict:
             return False
         if type_specifier is not None:
             data_type_specifier = get_type_specifier(self._data_dict[data_id])
-            if not TypeSpecifier.parse(type_specifier).is_compatible(data_type_specifier):
+            if data_type_specifier is None or not data_type_specifier.satisfies(type_specifier):
                 return False
         return True
 
@@ -84,7 +90,7 @@ class MemoryDataStore(MutableDataStore):
         self._assert_valid_data_id(data_id)
         if type_specifier is not None:
             data_type_specifier = get_type_specifier(self._data_dict[data_id])
-            if not data_type_specifier.is_compatible(type_specifier):
+            if data_type_specifier is None or not data_type_specifier.satisfies(type_specifier):
                 raise DataStoreError(f'Data resource "{data_id}" is not compatible with '
                                      f'type specifier "{type_specifier}". Cannot create DataDescriptor.')
         return new_data_descriptor(data_id, self._data_dict[data_id])

--- a/xcube/core/store/stores/s3.py
+++ b/xcube/core/store/stores/s3.py
@@ -130,7 +130,7 @@ class S3DataStore(MutableDataStore):
     def has_data(self, data_id: str, type_specifier: str = None) -> bool:
         if type_specifier:
             data_type_specifier, _, _ = self._get_accessor_id_parts(data_id)
-            if not TypeSpecifier.parse(type_specifier).is_compatible(data_type_specifier):
+            if not TypeSpecifier.parse(data_type_specifier).satisfies(type_specifier):
                 return False
         path = self._resolve_data_id_to_path(data_id)
         return self._s3.exists(path)

--- a/xcube/core/store/typespecifier.py
+++ b/xcube/core/store/typespecifier.py
@@ -95,7 +95,7 @@ class TypeSpecifier:
             return False
         if not other_type.flags:
             return True
-        return len(other_type.flags.difference(self.flags)) == 0
+        return other_type.flags.issubset(self.flags)
 
     def is_satisfied_by(self, other: Union[str, "TypeSpecifier"]) -> bool:
         """


### PR DESCRIPTION
In this PR, I
* replaced `TypeSpecifier.is_compatible()` by pair `TypeSpecifier.satifies()` and `TypeSpecifier.is_satisfied_by()`;
* updated default store implementations memory, directory, s3.

**IMPORTANT**:

`DirectoryStore.get_data_ids()` and `DirectoryStore.search_data()` no longer raise `ValueError` when they receive a `type_specifier` that they do not support. I believe it is ok and more user friendly, because it is a part of a user's request (a search param, if you like). If the store does not have any such data, it simply returns empty sets. This should be default behaviour for all stores.