### PR TITLE
restrict s3fs version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@
 
 ### Other
 
+* Restricted `s3fs` version in envrionment.yml in order to use a version which can handle pruned xcube datasets.
+  This restriction will be removed once changes in zarr PR https://github.com/zarr-developers/zarr-python/pull/650 
+  are merged and released. (#360)
 * Added a note in the `xcube chunk` CLI help, saying that there is a possibly more efficient way 
   to (re-)chunk datasets through the dedicated tool "rechunker", see https://rechunker.readthedocs.io
   (thanks to Ryan Abernathey for the hint). (#335)

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - pyproj >=2.1
   - pyyaml >=5.1
   - rasterio >=1.0
-  - s3fs >=0.5
+  - s3fs <0.5 # restriction needed until zarr release changes made in PR https://github.com/zarr-developers/zarr-python/pull/650
   - scipy >=1.2
   - setuptools >=41.0
   - shapely >=1.6


### PR DESCRIPTION
Only restricted s3fs: 
  - s3fs <0.5 # restriction needed until zarr release changes made in PR https://github.com/zarr-developers/zarr-python/pull/650
EDIT: 
needed because of this issue : https://github.com/dcs4cop/xcube/issues/360

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `docs/CHANGES.md`
* [x] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge