### PR TITLE
Forman 370 io dump with config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Enhancements 
 
+* CLI tool `xcube io dump` now has new `--config` and `--type` options. (#370)
+
 * New function `xcube.core.store.get_data_store()` and new class `xcube.core.store.DataStorePool` 
   allow for maintaining a set of pre-configured data store instances. This will be used
   in future xcube tools that utilise multiple data stores, e.g. "xcube gen", "xcube serve". (#364)

--- a/test/cli/test_io.py
+++ b/test/cli/test_io.py
@@ -1,6 +1,10 @@
+import json
 import os.path
 
+import yaml
+
 from test.cli.helpers import CliTest
+from xcube.core.dsio import rimraf
 
 
 class IOTest(CliTest):
@@ -102,3 +106,44 @@ class IOWriterTest(CliTest):
     def test_info(self):
         result = self.invoke_cli(['io', 'writer', 'info', 'dataset:zarr:posix'])
         self.assertEqual(0, result.exit_code)
+
+
+class IODumpTest(CliTest):
+    STORE_CONF = {
+        "this_dir": {
+            "store_id": "directory",
+            "store_params": {
+                "base_dir": "."
+            }
+        }
+    }
+
+    def setUp(self) -> None:
+        with open('store-conf.yml', 'w') as fp:
+            yaml.dump(self.STORE_CONF, fp)
+        with open('store-conf.json', 'w') as fp:
+            json.dump(self.STORE_CONF, fp)
+
+    def tearDown(self) -> None:
+        rimraf('store-dump.json')
+        rimraf('store-conf.yml')
+        rimraf('out.json')
+
+    def test_help_option(self):
+        result = self.invoke_cli(['io', 'dump', '--help'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_yaml_config(self):
+        result = self.invoke_cli(['io', 'dump', '-c', 'store-conf.yml'])
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.exists('store-dump.json'))
+
+    def test_json_config_output(self):
+        result = self.invoke_cli(['io', 'dump', '-c', 'store-conf.json', '-o', 'out.json'])
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.exists('out.json'))
+
+    def test_json_config_type(self):
+        result = self.invoke_cli(['io', 'dump', '-c', 'store-conf.json', '-t', 'dataset[cube]'])
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.exists('store-dump.json'))

--- a/test/core/store/stores/test_directory.py
+++ b/test/core/store/stores/test_directory.py
@@ -1,10 +1,12 @@
 import os.path
 import unittest
 
+from xcube.core.store import DataStoreError
 from xcube.core.store import TYPE_SPECIFIER_CUBE
+from xcube.core.store import TYPE_SPECIFIER_DATASET
 from xcube.core.store import new_data_store
-from xcube.core.store.error import DataStoreError
 from xcube.core.store.stores.directory import DirectoryDataStore
+from xcube.util.jsonschema import JsonObjectSchema
 
 
 class DirectoryDataStoreTest(unittest.TestCase):
@@ -46,6 +48,29 @@ class DirectoryDataStoreTest(unittest.TestCase):
             set(schema.properties.keys())
         )
         self.assertEqual(set(), schema.required)
+
+    def test_get_search_params_schema(self):
+        schema = self.store.get_search_params_schema()
+        self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertEqual({}, schema.properties)
+        self.assertEqual(False, schema.additional_properties)
+
+        schema = self.store.get_search_params_schema(type_specifier='geodataframe')
+        self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertEqual({}, schema.properties)
+        self.assertEqual(False, schema.additional_properties)
+
+    def test_search_data(self):
+        result = list(self.store.search_data(type_specifier=TYPE_SPECIFIER_CUBE))
+        self.assertTrue(len(result) > 0)
+
+        result = list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET))
+        self.assertTrue(len(result) > 0)
+
+        with self.assertRaises(DataStoreError) as cm:
+            list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET,
+                                        time_range=['2020-03-01', '2020-03-04'], bbox=[52, 11, 54, 12]))
+        self.assertEqual('Unsupported search parameters: time_range, bbox', f'{cm.exception}')
 
     def test_get_write_data_params_schema(self):
         schema = self.store.get_write_data_params_schema()

--- a/test/core/store/stores/test_memory.py
+++ b/test/core/store/stores/test_memory.py
@@ -78,10 +78,12 @@ class MemoryCubeStoreTest(unittest.TestCase):
         schema = self.store.get_search_params_schema()
         self.assertIsInstance(schema, JsonObjectSchema)
         self.assertEqual({}, schema.properties)
+        self.assertEqual(False, schema.additional_properties)
 
         schema = self.store.get_search_params_schema(type_specifier='geodataframe')
         self.assertIsInstance(schema, JsonObjectSchema)
         self.assertEqual({}, schema.properties)
+        self.assertEqual(False, schema.additional_properties)
 
     def test_search_data(self):
         result = list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET))
@@ -101,8 +103,9 @@ class MemoryCubeStoreTest(unittest.TestCase):
         self.assertEqual(result[1].type_specifier, TYPE_SPECIFIER_CUBE)
 
         with self.assertRaises(DataStoreError) as cm:
-            list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET, data_id='cube_1', name='bibo'))
-        self.assertEqual('Unsupported search_params "data_id", "name"', f'{cm.exception}')
+            list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET,
+                                        time_range=['2020-03-01', '2020-03-04'], bbox=[52, 11, 54, 12]))
+        self.assertEqual('Unsupported search parameters: time_range, bbox', f'{cm.exception}')
 
     def test_get_data_opener_ids(self):
         self.assertEqual(('*:*:memory',), self.store.get_data_opener_ids())

--- a/test/core/store/stores/test_s3.py
+++ b/test/core/store/stores/test_s3.py
@@ -6,8 +6,12 @@ import xarray as xr
 from test.s3test import S3Test, MOTO_SERVER_ENDPOINT_URL
 from xcube.core.new import new_cube
 from xcube.core.store import DataStoreError
+from xcube.core.store import TYPE_SPECIFIER_CUBE
+from xcube.core.store import TYPE_SPECIFIER_DATASET
 from xcube.core.store import new_data_store
 from xcube.core.store.stores.s3 import S3DataStore
+from xcube.util.jsonschema import JsonObjectSchema
+
 
 BUCKET_NAME = 'xcube-test'
 
@@ -61,6 +65,29 @@ class S3DataStoreTest(S3Test):
             set(schema.properties.keys())
         )
         self.assertEqual(set(), schema.required)
+
+    def test_get_search_params_schema(self):
+        schema = self.store.get_search_params_schema()
+        self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertEqual({}, schema.properties)
+        self.assertEqual(False, schema.additional_properties)
+
+        schema = self.store.get_search_params_schema(type_specifier='geodataframe')
+        self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertEqual({}, schema.properties)
+        self.assertEqual(False, schema.additional_properties)
+
+    # def test_search_data(self):
+    #     result = list(self.store.search_data(type_specifier=TYPE_SPECIFIER_CUBE))
+    #     self.assertTrue(len(result) > 0)
+    #
+    #     result = list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET))
+    #     self.assertTrue(len(result) > 0)
+    #
+    #     with self.assertRaises(DataStoreError) as cm:
+    #         list(self.store.search_data(type_specifier=TYPE_SPECIFIER_DATASET,
+    #                                     time_range=['2020-03-01', '2020-03-04'], bbox=[52, 11, 54, 12]))
+    #     self.assertEqual('Unsupported search parameters: time_range, bbox', f'{cm.exception}')
 
     def test_get_write_data_params_schema(self):
         schema = self.store.get_write_data_params_schema()

--- a/test/core/store/stores/test_s3.py
+++ b/test/core/store/stores/test_s3.py
@@ -77,6 +77,7 @@ class S3DataStoreTest(S3Test):
         self.assertEqual({}, schema.properties)
         self.assertEqual(False, schema.additional_properties)
 
+    # TODO (forman): Fixme! Currently get boto3 errors when running out-commented test
     # def test_search_data(self):
     #     result = list(self.store.search_data(type_specifier=TYPE_SPECIFIER_CUBE))
     #     self.assertTrue(len(result) > 0)

--- a/test/core/store/test_store.py
+++ b/test/core/store/test_store.py
@@ -1,6 +1,8 @@
 import unittest
 
+from xcube.core.store import DataStoreError
 from xcube.core.store.store import find_data_store_extensions
+from xcube.core.store.store import get_data_store_class
 from xcube.core.store.store import get_data_store_params_schema
 from xcube.util.jsonschema import JsonObjectSchema
 
@@ -19,3 +21,12 @@ class ExtensionRegistryTest(unittest.TestCase):
 
         schema = get_data_store_params_schema('directory')
         self.assertIsInstance(schema, JsonObjectSchema)
+
+    def test_get_data_store_class(self):
+        cls = get_data_store_class('memory')
+        self.assertIsInstance(cls, type)
+
+        with self.assertRaises(DataStoreError) as cm:
+            get_data_store_class('pippo')
+        self.assertEqual('Unknown data store "pippo" (may be due to missing xcube plugin)',
+                         f'{cm.exception}')

--- a/test/core/store/test_storepool.py
+++ b/test/core/store/test_storepool.py
@@ -72,7 +72,7 @@ class DataStoreConfigTest(unittest.TestCase):
 
     def test_from_dict(self):
         store_config = DataStoreConfig.from_dict({'description': 'Local files',
-                                                  'name': 'Local',
+                                                  'title': 'Local',
                                                   'store_id': 'directory',
                                                   'store_params': {'base_dir': '.'}})
         self.assertIsInstance(store_config, DataStoreConfig)

--- a/test/core/store/test_storepool.py
+++ b/test/core/store/test_storepool.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import jsonschema
+import yaml
 
 from xcube.core.store import DataStore
 from xcube.core.store import DataStoreConfig
@@ -122,7 +123,7 @@ class DataStorePoolTest(unittest.TestCase):
             DataStorePool.from_dict(store_configs)
         self.assertTrue("Failed validating 'type' in schema" in f'{cm.exception}', msg=f'{cm.exception}')
 
-    def test_from_file(self):
+    def test_from_json_file(self):
         store_configs = {
             "ram-1": {
                 "store_id": "memory"
@@ -134,6 +135,26 @@ class DataStorePoolTest(unittest.TestCase):
         path = 'test-store-configs.json'
         with open(path, 'w') as fp:
             json.dump(store_configs, fp, indent=2)
+        try:
+            pool = DataStorePool.from_file(path)
+            self.assertIsInstance(pool, DataStorePool)
+            self.assertEqual(['ram-1', 'ram-2'], pool.store_instance_ids)
+        finally:
+            import os
+            os.remove(path)
+
+    def test_from_yaml_file(self):
+        store_configs = {
+            "ram-1": {
+                "store_id": "memory"
+            },
+            "ram-2": {
+                "store_id": "memory"
+            }
+        }
+        path = 'test-store-configs.yaml'
+        with open(path, 'w') as fp:
+            yaml.dump(store_configs, fp, indent=2)
         try:
             pool = DataStorePool.from_file(path)
             self.assertIsInstance(pool, DataStorePool)

--- a/xcube/cli/io.py
+++ b/xcube/cli/io.py
@@ -190,9 +190,12 @@ def writer_info(writer_id: str):
 def dump(output_file_path: str, config_file_path: Optional[str], type_specifier: Optional[str]):
     """
     Dump metadata of given data stores.
-    Dumps metadata for every data resources for given data stores.
-    Configured data stores may be passed via the CONFIG option.
-    For example, this YAML configuration configures a directory data store:
+
+    Dumps data store metadata and metadata for a store's data resources
+    for given data stores  into a JSON file.
+    Data stores may be selected and configured by a configuration file CONFIG,
+    which may have JSON or YAML format.
+    For example, this YAML configuration configures a single directory data store:
 
     \b
     this_dir:

--- a/xcube/cli/io.py
+++ b/xcube/cli/io.py
@@ -157,8 +157,8 @@ def opener_info(opener_id: str):
     if description:
         print(description)
     from xcube.core.store import new_data_opener
-    opener = new_data_opener(opener_id)
-    params_schema = opener.get_open_data_params_schema()
+    opener_ = new_data_opener(opener_id)
+    params_schema = opener_.get_open_data_params_schema()
     print(_format_params_schema(params_schema))
 
 
@@ -174,8 +174,8 @@ def writer_info(writer_id: str):
     if description:
         print(description)
     from xcube.core.store import new_data_writer
-    writer = new_data_writer(writer_id)
-    params_schema = writer.get_write_data_params_schema()
+    writer_ = new_data_writer(writer_id)
+    params_schema = writer_.get_write_data_params_schema()
     print(_format_params_schema(params_schema))
 
 
@@ -228,11 +228,6 @@ def dump(output_file_path: str, config_file_path: Optional[str], type_specifier:
             print(f'error: cannot open store "{store_instance_id}": {error}', file=sys.stderr)
             continue
 
-        # datasets_list = []
-        # for data_id, title in store_instance.get_data_ids(type_specifier=type_specifier, include_titles=True):
-        #     dsd = store_instance.describe_data(data_id)
-        #     datasets_list.append(dsd.to_dict())
-
         try:
             search_result = [dsd.to_dict() for dsd in store_instance.search_data(type_specifier=type_specifier)]
         except BaseException as error:
@@ -240,9 +235,11 @@ def dump(output_file_path: str, config_file_path: Optional[str], type_specifier:
             continue
 
         store_config = store_pool.get_store_config(store_instance_id)
-        stores.append(dict(store_id=store_instance_id,
+        stores.append(dict(store_instance_id=store_instance_id,
+                           store_id=store_instance_id,
                            title=store_config.title,
                            description=store_config.description,
+                           type_specifier=type_specifier,
                            datasets=search_result))
         print('Done after {:.2f} seconds'.format(time.perf_counter() - t0))
 
@@ -302,6 +299,7 @@ io.add_command(dump)
 # from xcube.util.jsonschema import JsonObjectSchema
 
 
+# noinspection PyUnresolvedReferences
 def _format_params_schema(params_schema: 'xcube.util.jsonschema.JsonObjectSchema') -> str:
     text = []
     if params_schema.properties:
@@ -314,6 +312,7 @@ def _format_params_schema(params_schema: 'xcube.util.jsonschema.JsonObjectSchema
     return '\n'.join(text)
 
 
+# noinspection PyUnresolvedReferences
 def _format_required_params_schema(params_schema: 'xcube.util.jsonschema.JsonObjectSchema') -> str:
     text = ['Required parameters:']
     for param_name, param_schema in params_schema.properties.items():
@@ -322,6 +321,7 @@ def _format_required_params_schema(params_schema: 'xcube.util.jsonschema.JsonObj
     return '\n'.join(text)
 
 
+# noinspection PyUnresolvedReferences
 def _format_param_schema(param_schema: 'xcube.util.jsonschema.JsonSchema'):
     from xcube.util.undefined import UNDEFINED
     param_info = []
@@ -359,14 +359,17 @@ def _dump_extensions(point: str) -> int:
     return count
 
 
+# noinspection PyUnresolvedReferences
 def _dump_store_openers(data_store: 'xcube.core.store.DataStore', data_id: str = None) -> int:
     return _dump_named_extensions(EXTENSION_POINT_DATA_OPENERS, data_store.get_data_opener_ids(data_id=data_id))
 
 
+# noinspection PyUnresolvedReferences
 def _dump_store_writers(data_store: 'xcube.core.store.DataStore') -> int:
     return _dump_named_extensions(EXTENSION_POINT_DATA_WRITERS, data_store.get_data_writer_ids())
 
 
+# noinspection PyUnresolvedReferences
 def _dump_store_data_ids(data_store: 'xcube.core.store.DataStore') -> int:
     count = 0
     for data_id, title in data_store.get_data_ids():
@@ -387,6 +390,7 @@ def _dump_named_extensions(point: str, names: Sequence[str]) -> int:
     return count
 
 
+# noinspection PyUnresolvedReferences
 def _dump_data_resources(data_store: 'xcube.core.store.DataStore') -> int:
     count = 0
     for data_id, title in data_store.get_data_ids():
@@ -395,6 +399,7 @@ def _dump_data_resources(data_store: 'xcube.core.store.DataStore') -> int:
     return count
 
 
+# noinspection PyUnresolvedReferences
 def _new_data_store(store_id: str, store_params: List[str]) -> 'xcube.core.store.DataStore':
     from xcube.core.store import get_data_store_params_schema
     from xcube.core.store import new_data_store

--- a/xcube/core/store/__init__.py
+++ b/xcube/core/store/__init__.py
@@ -35,6 +35,7 @@ from .descriptor import MultiLevelDatasetDescriptor
 from .descriptor import VariableDescriptor
 from .descriptor import new_data_descriptor
 from .error import DataStoreError
+from .search import DefaultSearchMixin
 from .store import DataStore
 from .store import MutableDataStore
 from .store import find_data_store_extensions

--- a/xcube/core/store/search.py
+++ b/xcube/core/store/search.py
@@ -1,0 +1,41 @@
+from typing import Iterator
+
+from xcube.core.store import DataDescriptor
+from xcube.core.store import DataStoreError
+from xcube.util.jsonschema import JsonObjectSchema
+
+
+# noinspection PyUnresolvedReferences
+class DefaultSearchMixin:
+    """
+    A mixin for data store implementations that implements default search behaviour.
+    It is expected that such data stores have no dedicated search parameters.
+    """
+
+    # noinspection PyUnusedLocal,PyMethodMayBeStatic
+    def get_search_params_schema(self, type_specifier: str = None) -> JsonObjectSchema:
+        """
+        Get search parameters JSON object schema.
+
+        The default implementation returns a schema that does not allow for any search parameters.
+
+        :param type_specifier:
+        :return: a JSON object schema for the search parameters
+        """
+        return JsonObjectSchema(additional_properties=False)
+
+    def search_data(self, type_specifier: str = None, **search_params) -> Iterator[DataDescriptor]:
+        """
+        Search the data store.
+
+        The default implementation returns all data resources that may be filtered using
+        the optional *type_specifier*.
+
+        :param type_specifier: Type specifier to filter returned data resources.
+        :param search_params: Not supported (yet)
+        :return: an iterator of :class:DataDescriptor instances
+        """
+        if search_params:
+            raise DataStoreError(f'Unsupported search parameters: {", ".join(search_params.keys())}')
+        for data_id, _ in self.get_data_ids(type_specifier=type_specifier, include_titles=False):
+            yield self.describe_data(data_id)

--- a/xcube/core/store/store.py
+++ b/xcube/core/store/store.py
@@ -67,7 +67,7 @@ def get_data_store_class(data_store_id: str,
     """
     extension_registry = extension_registry or get_extension_registry()
     if not extension_registry.has_extension(EXTENSION_POINT_DATA_STORES, data_store_id):
-        raise DataStoreError(f'Unknown data store "{data_store_id}"')
+        raise DataStoreError(f'Unknown data store "{data_store_id}" (may be due to missing xcube plugin)')
     return extension_registry.get_component(EXTENSION_POINT_DATA_STORES, data_store_id)
 
 

--- a/xcube/core/store/storepool.py
+++ b/xcube/core/store/storepool.py
@@ -122,7 +122,7 @@ class DataStoreConfig:
         DATA_STORE_CONFIG_SCHEMA.validate_instance(d)
         return DataStoreConfig(d['store_id'],
                                store_params=d.get('store_params'),
-                               title=d.get('name'),
+                               title=d.get('title'),
                                description=d.get('description'))
 
     def to_dict(self) -> Dict[str, Any]:

--- a/xcube/core/store/storepool.py
+++ b/xcube/core/store/storepool.py
@@ -21,7 +21,8 @@
 
 import json
 from typing import Any, Dict, Optional, List
-
+import os.path
+import yaml
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonObjectSchema
@@ -234,8 +235,10 @@ class DataStorePool:
 
     @classmethod
     def from_file(cls, path: str) -> 'DataStorePool':
+        _, ext = os.path.splitext(path)
+        lib = json if ext == '.json' else yaml
         with open(path) as fp:
-            store_configs = json.load(fp)
+            store_configs = lib.load(fp)
         return cls.from_dict(store_configs)
 
     @classmethod

--- a/xcube/core/store/stores/directory.py
+++ b/xcube/core/store/stores/directory.py
@@ -36,6 +36,7 @@ from xcube.core.store import TYPE_SPECIFIER_GEODATAFRAME
 from xcube.core.store import TYPE_SPECIFIER_MULTILEVEL_DATASET
 from xcube.core.store import TypeSpecifier
 from xcube.core.store import find_data_opener_extensions
+from xcube.core.store import DefaultSearchMixin
 from xcube.core.store import find_data_writer_extensions
 from xcube.core.store import get_data_accessor_predicate
 from xcube.core.store import get_type_specifier
@@ -75,7 +76,7 @@ _TYPE_SPECIFIER_TO_ACCESSOR_TO_DEFAULT_FILENAME_EXT = {
 #   - Introduce a file-system-abstracting base class or mixin, see module "fsspec" and impl. "s3fs" as  used in Dask!
 #   - Introduce something like MultiOpenerStoreMixin/MultiWriterStoreMixin!
 
-class DirectoryDataStore(MutableDataStore):
+class DirectoryDataStore(DefaultSearchMixin, MutableDataStore):
     """
     A cube store that stores cubes in a directory in the local file system.
 
@@ -155,15 +156,6 @@ class DirectoryDataStore(MutableDataStore):
                                      f' by type specifier "{actual_type_specifier}" of data resource "{data_id}"')
         else:
             raise DataStoreError(f'Data resource "{data_id}" not found')
-
-    def get_search_params_schema(self, type_specifier: str = None) -> JsonObjectSchema:
-        return JsonObjectSchema()
-
-    def search_data(self, type_specifier: str = None, **search_params) -> Iterator[DataDescriptor]:
-        if search_params:
-            raise DataStoreError(f'Unsupported search_params "{tuple(search_params.keys())}"')
-        for data_id in self.get_data_ids(type_specifier=type_specifier):
-            yield self.describe_data(data_id[0])
 
     def get_data_opener_ids(self, data_id: str = None, type_specifier: Optional[str] = None) -> Tuple[str, ...]:
         if type_specifier:

--- a/xcube/core/store/stores/s3.py
+++ b/xcube/core/store/stores/s3.py
@@ -30,17 +30,18 @@ import xarray as xr
 from xcube.core.mldataset import MultiLevelDataset
 from xcube.core.store import DataDescriptor
 from xcube.core.store import DataStoreError
+from xcube.core.store import DefaultSearchMixin
 from xcube.core.store import MutableDataStore
 from xcube.core.store import TYPE_SPECIFIER_ANY
 from xcube.core.store import TYPE_SPECIFIER_DATASET
 from xcube.core.store import TYPE_SPECIFIER_MULTILEVEL_DATASET
+from xcube.core.store import TypeSpecifier
 from xcube.core.store import find_data_opener_extensions
 from xcube.core.store import find_data_writer_extensions
 from xcube.core.store import get_data_accessor_predicate
 from xcube.core.store import get_type_specifier
 from xcube.core.store import new_data_opener
 from xcube.core.store import new_data_writer
-from xcube.core.store import TypeSpecifier
 from xcube.core.store.accessors.dataset import S3Mixin
 from xcube.util.assertions import assert_condition
 from xcube.util.assertions import assert_given
@@ -71,7 +72,7 @@ _TYPE_SPECIFIER_TO_ACCESSOR_TO_DEFAULT_FILENAME_EXT = {
 #   - Introduce a file-system-abstracting base class or mixin, see module "fsspec" and impl. "s3fs" as  used in Dask!
 #   - Introduce something like MultiOpenerStoreMixin/MultiWriterStoreMixin!
 
-class S3DataStore(MutableDataStore):
+class S3DataStore(DefaultSearchMixin, MutableDataStore):
     """
     A cube store that stores cubes in a directory in the local file system.
 
@@ -136,15 +137,6 @@ class S3DataStore(MutableDataStore):
         return self._s3.exists(path)
 
     def describe_data(self, data_id: str, type_specifier: str = None) -> DataDescriptor:
-        # TODO: implement me
-        raise NotImplementedError()
-
-    @classmethod
-    def get_search_params_schema(self, type_specifier: str = None) -> JsonObjectSchema:
-        # TODO: implement me
-        raise NotImplementedError()
-
-    def search_data(self, type_specifier: str = None, **search_params) -> Iterator[DataDescriptor]:
         # TODO: implement me
         raise NotImplementedError()
 


### PR DESCRIPTION
CLI tool `xcube io dump` now has new `--config` and `--type` options. (#370)

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `docs/CHANGES.md`
* [x] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge