### PR TITLE
environment: remove proj4 & pyproj, restrict gdal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,7 +67,6 @@
 * Added a note in the `xcube chunk` CLI help, saying that there is a possibly more efficient way 
   to (re-)chunk datasets through the dedicated tool "rechunker", see https://rechunker.readthedocs.io
   (thanks to Ryan Abernathey for the hint). (#335)
-
 * For `xcube serve` dataset configurations where `FileSystem: obs`, users must now also 
   specify `Anonymous: True` for datasets in public object storage buckets. For example:
   ```yaml
@@ -79,6 +78,8 @@
     ...
   - ...
   ```  
+* In `environment.yml`, removed unnecessary explicit dependencies on `proj4` 
+  and `pyproj` and restricted `gdal` version to >=3.0,<3.1. 
 
 ## Changes in 0.5.1
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - cmocean >=2.0
   - dask >=1.2
   - fiona >=1.8
-  - gdal >=3.0
+  - gdal >=3.0,<3.1
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
@@ -22,9 +22,7 @@ dependencies:
   - numpy >=1.16
   - pandas >=1.1
   - pillow >=6.0
-  - proj4 >=5.2
   - pyjwt >=1.7
-  - pyproj >=2.1
   - pyyaml >=5.1
   - rasterio >=1.0
   - s3fs <0.5 # restriction needed until zarr release changes made in PR https://github.com/zarr-developers/zarr-python/pull/650


### PR DESCRIPTION
Closes Issue #374.

 - Remove the proj4 and pyproj dependencies from environment.yml, since
   xcube makes no direct use of these libraries.

 - Restrict GDAL version to <3.1 in environment.yml.
   reproject_crs_to_wgs84 doesn't work with gdal >=3.1, but up until
   now the dependency on proj4 had concealed this fact by indirectly
   restricting the GDAL version.

[Description of PR]

Checklist:

* n/a Add unit tests and/or doctests in docstrings
* n/a Add docstrings and API docs for any new/modified user-facing classes and functions
* n/a New/modified features documented in `docs/source/*`
* [x] Changes documented in `docs/CHANGES.md`
* [AppVeyor not configured; Travis currently out of credits] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge