### PR TITLE
Removing restrictins to lower versions of s3fs and removing dependency of fsspec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 ## Changes in 0.6.1 (in development)
 
 ### Other
-* Added  and restricted `sspec <=0.6.2` version in envrionment.yml in order to use a version which can handle pruned 
+* Removed restrictions of `fsspec <=0.6.2` as well as the restriction of a lower version of `s3fs`, because 
+  https://github.com/zarr-developers/zarr-python/pull/650 has been released with `zarr=2.6.1` (#360)
+* ~~Added  and restricted `fsspec <=0.6.2` version in environment.yml in order to use a version which can handle pruned 
   xcube datasets. This restriction and dependency will be removed once changes in zarr PR 
-  https://github.com/zarr-developers/zarr-python/pull/650 are merged and released. (#360)
+  https://github.com/zarr-developers/zarr-python/pull/650 are merged and released. (#360)~~
 
 ## Changes in 0.6.0
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - cmocean >=2.0
   - dask >=1.2
   - fiona >=1.8
-  - fsspec <=0.6.2 # restriction needed until zarr release changes made in PR https://github.com/zarr-developers/zarr-python/pull/650
   - gdal >=3.0,<3.1
   - geopandas >=0.8
   - jdcal >=1.4.1
@@ -26,7 +25,7 @@ dependencies:
   - pyjwt >=1.7
   - pyyaml >=5.1
   - rasterio >=1.0
-  - s3fs <0.5 # restriction needed until zarr release changes made in PR https://github.com/zarr-developers/zarr-python/pull/650
+  - s3fs >=0.5.1
   - scipy >=1.2
   - setuptools >=41.0
   - shapely >=1.6
@@ -34,7 +33,7 @@ dependencies:
   - strict-rfc3339 >=0.7 # for python-jsonschema date-time format validation
   - tornado >=6.0
   - xarray >=0.16.1
-  - zarr >=2.4
+  - zarr >=2.6.1
   # Testing
   - flake8 >=3.7
   - moto >=1.3


### PR DESCRIPTION
[Description of PR]
changed packages restrictions, because zarr 2.6.1 has been released which fixes issue #360. Closes #360

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `docs/CHANGES.md`
* [x] AppVeyor and Travis CI passes
* [ ] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge