### PR TITLE
Added missing descriptor implementations

### DIFF
--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -45,22 +45,25 @@ class DataDescriptorTest(unittest.TestCase):
         self.assertEqual('geodataframe', descriptor.type_specifier)
 
     def test_from_dict_full(self):
-        descriptor_dict = dict(data_id='xyz',
-                               type_specifier='tsr',
-                               crs='EPSG:9346',
-                               bbox=(10., 20., 30., 40.),
-                               spatial_res=20.,
-                               time_range=('2017-06-05', '2017-06-27'),
-                               time_period='daily',
-                               open_params_schema=dict(type="object",
-                                                       properties=dict(variable_names=
-                                                                       dict(type='array',
-                                                                            items=dict(
-                                                                                type='string')
-                                                                            )
-                                                                       )
-                                                       )
-                               )
+        descriptor_dict = dict(
+            data_id='xyz',
+            type_specifier='tsr',
+            crs='EPSG:9346',
+            bbox=(10., 20., 30., 40.),
+            spatial_res=20.,
+            time_range=('2017-06-05', '2017-06-27'),
+            time_period='daily',
+            open_params_schema=dict(
+                type="object",
+                properties=dict(
+                    variable_names=dict(
+                        type='array',
+                        items=dict(
+                            type='string')
+                    )
+                )
+            )
+        )
         descriptor = DataDescriptor.from_dict(descriptor_dict)
         self.assertIsNotNone(descriptor)
         self.assertEqual('xyz', descriptor.data_id)
@@ -79,8 +82,7 @@ class DataDescriptorTest(unittest.TestCase):
                                        bbox=(10., 20., 30., 40.),
                                        spatial_res=20.,
                                        time_range=('2017-06-05', '2017-06-27'),
-                                       time_period='daily'
-                                       )
+                                       time_period='daily')
         descriptor_dict = descriptor.to_dict()
         self.assertEqual(dict(data_id='xyz',
                               type_specifier='dataset[cube]',
@@ -88,8 +90,7 @@ class DataDescriptorTest(unittest.TestCase):
                               bbox=(10., 20., 30., 40.),
                               spatial_res=20.,
                               time_range=('2017-06-05', '2017-06-27'),
-                              time_period='daily',
-                              ),
+                              time_period='daily'),
                          descriptor_dict)
 
 

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -2,9 +2,95 @@ import unittest
 
 import numpy as np
 
+from xcube.core.store.descriptor import DataDescriptor
 from xcube.core.store.descriptor import DatasetDescriptor
+from xcube.core.store.descriptor import GeoDataFrameDescriptor
 from xcube.core.store.descriptor import VariableDescriptor
 from xcube.core.store.typespecifier import TypeSpecifier
+
+
+class DataDescriptorTest(unittest.TestCase):
+
+    def test_from_dict_no_data_id(self):
+        with self.assertRaises(ValueError):
+            descriptor_dict = dict()
+            DataDescriptor.from_dict(descriptor_dict)
+
+    def test_from_dict_no_type_specifier(self):
+        with self.assertRaises(ValueError):
+            descriptor_dict = dict(data_id='id')
+            DataDescriptor.from_dict(descriptor_dict)
+
+    def test_from_dict_random_type_specifier(self):
+        descriptor_dict = dict(data_id='xyz', type_specifier='tsr')
+        descriptor = DataDescriptor.from_dict(descriptor_dict)
+        self.assertIsNotNone(descriptor)
+        self.assertEqual('xyz', descriptor.data_id)
+        self.assertEqual('tsr', descriptor.type_specifier)
+
+    def test_from_dict_dataset_type_specifier(self):
+        descriptor_dict = dict(data_id='xyz', type_specifier='dataset')
+        descriptor = DataDescriptor.from_dict(descriptor_dict)
+        self.assertIsNotNone(descriptor)
+        self.assertTrue(DatasetDescriptor, type(descriptor))
+        self.assertEqual('xyz', descriptor.data_id)
+        self.assertEqual('dataset', descriptor.type_specifier)
+
+    def test_from_dict_geodataframe_type_specifier(self):
+        descriptor_dict = dict(data_id='xyz', type_specifier='geodataframe')
+        descriptor = DataDescriptor.from_dict(descriptor_dict)
+        self.assertIsNotNone(descriptor)
+        self.assertTrue(GeoDataFrameDescriptor, type(descriptor))
+        self.assertEqual('xyz', descriptor.data_id)
+        self.assertEqual('geodataframe', descriptor.type_specifier)
+
+    def test_from_dict_full(self):
+        descriptor_dict = dict(data_id='xyz',
+                               type_specifier='tsr',
+                               crs='EPSG:9346',
+                               bbox=(10., 20., 30., 40.),
+                               spatial_res=20.,
+                               time_range=('2017-06-05', '2017-06-27'),
+                               time_period='daily',
+                               open_params_schema=dict(type="object",
+                                                       properties=dict(variable_names=
+                                                                       dict(type='array',
+                                                                            items=dict(
+                                                                                type='string')
+                                                                            )
+                                                                       )
+                                                       )
+                               )
+        descriptor = DataDescriptor.from_dict(descriptor_dict)
+        self.assertIsNotNone(descriptor)
+        self.assertEqual('xyz', descriptor.data_id)
+        self.assertEqual('tsr', descriptor.type_specifier)
+        self.assertEqual('EPSG:9346', descriptor.crs)
+        self.assertEqual((10., 20., 30., 40.), descriptor.bbox)
+        self.assertEqual(20., descriptor.spatial_res)
+        self.assertEqual(('2017-06-05', '2017-06-27'), descriptor.time_range)
+        self.assertEqual('daily', descriptor.time_period)
+        self.assertEqual('object', descriptor.open_params_schema.get('type', None))
+
+    def test_to_dict(self):
+        descriptor = DatasetDescriptor(data_id='xyz',
+                                       type_specifier=TypeSpecifier('dataset', flags={'cube'}),
+                                       crs='EPSG:9346',
+                                       bbox=(10., 20., 30., 40.),
+                                       spatial_res=20.,
+                                       time_range=('2017-06-05', '2017-06-27'),
+                                       time_period='daily'
+                                       )
+        descriptor_dict = descriptor.to_dict()
+        self.assertEqual(dict(data_id='xyz',
+                              type_specifier='dataset[cube]',
+                              crs='EPSG:9346',
+                              bbox=(10., 20., 30., 40.),
+                              spatial_res=20.,
+                              time_range=('2017-06-05', '2017-06-27'),
+                              time_period='daily',
+                              ),
+                         descriptor_dict)
 
 
 class DatasetDescriptorTest(unittest.TestCase):

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -88,10 +88,22 @@ class DataDescriptor:
         self.open_params_schema = open_params_schema
 
     @classmethod
-    def from_dict(cls, d: Mapping[str, Any]) -> 'DatasetDescriptor':
+    def from_dict(cls, d: Mapping[str, Any]) -> 'DataDescriptor':
         """Create new instance from a JSON-serializable dictionary"""
-        # TODO: implement me
-        raise NotImplementedError()
+        assert_in('data_id', d)
+        assert_in('type_specifier', d)
+        if TYPE_SPECIFIER_DATASET.is_satisfied_by(d['type_specifier']):
+            return DatasetDescriptor.from_dict(d)
+        elif TYPE_SPECIFIER_GEODATAFRAME.is_satisfied_by(d['type_specifier']):
+            return GeoDataFrameDescriptor.from_dict(d)
+        return DataDescriptor(data_id=d['data_id'],
+                              type_specifier=d['type_specifier'],
+                              crs=d.get('crs', None),
+                              bbox=d.get('bbox', None),
+                              spatial_res=d.get('spatial_res', None),
+                              time_range=d.get('time_range', None),
+                              time_period=d.get('time_period', None),
+                              open_params_schema=d.get('open_params_schema', None))
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert into a JSON-serializable dictionary"""

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -252,20 +252,24 @@ class GeoDataFrameDescriptor(DataDescriptor):
 
     def __init__(self,
                  data_id: str,
+                 type_specifier=TYPE_SPECIFIER_GEODATAFRAME,
                  feature_schema: Any = None,
                  open_params_schema: JsonObjectSchema = None,
                  **kwargs):
         super().__init__(data_id=data_id,
-                         type_specifier=TYPE_SPECIFIER_GEODATAFRAME,
+                         type_specifier=type_specifier,
                          open_params_schema=open_params_schema,
                          **kwargs)
         self.feature_schema = feature_schema
 
     @classmethod
-    def from_dict(cls, d: Mapping[str, Any]) -> 'MultiLevelDatasetDescriptor':
+    def from_dict(cls, d: Mapping[str, Any]) -> 'GeoDataFrameDescriptor':
         """Create new instance from a JSON-serializable dictionary"""
-        # TODO: implement me
-        raise NotImplementedError()
+        assert_in('data_id', d)
+        return GeoDataFrameDescriptor(data_id=d['data_id'],
+                                      type_specifier=d.get('type_specifier',
+                                                           TYPE_SPECIFIER_GEODATAFRAME),
+                                      open_params_schema=d.get('open_params_schema', None))
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert into a JSON-serializable dictionary"""

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -55,7 +55,7 @@ def new_data_descriptor(data_id: str, data: Any, require: bool = False) -> 'Data
         return MultiLevelDatasetDescriptor(data_id=data_id, num_levels=5)
     elif isinstance(data, gpd.GeoDataFrame):
         # TODO: implement me: data -> GeoDataFrameDescriptor
-        return GeoDataFrameDescriptor(data_id=data_id, num_levels=5)
+        return GeoDataFrameDescriptor(data_id=data_id)
     elif not require:
         return DataDescriptor(data_id=data_id, type_specifier=TYPE_SPECIFIER_ANY)
     raise NotImplementedError()


### PR DESCRIPTION
This PR contains outstanding implementations of from_dict in the descriptor module, along with a test for the datadescriptor. This is a necessary prerequisite for the integration of xcube into cate.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `docs/CHANGES.md`
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge