### PR TITLE
ChunkStore may return NaN-Chunks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
       dataset.to_zarr(store)  
   ```
 
+* Enanbled ChunkStore to deliver NaN-Chunks by calling `xcube.core.chunkstore.add_nan_array()`, this will be important 
+  once xcube-sh and xcube-cci will use the ChunkStore. This will allow to fill an xcube dataset with NaN-Chunks instead
+  of failing due to an API-Error.
+
 ## Changes in 0.6.1
 
 All changes relate to maintenance of xcube's Python environment requirements in `envrionment.yml`:

--- a/test/core/test_chunkstore.py
+++ b/test/core/test_chunkstore.py
@@ -84,7 +84,7 @@ def gen_index_var(dims, shape, chunks):
         return data.tobytes()
 
     store = ChunkStore(dims, shape, chunks)
-    store.add_lazy_array('__index_var__', '<f8', get_chunk=get_chunk)
+    store.add_lazy_array('__index_var__', '<u8', get_chunk=get_chunk)
 
     ds = xr.open_zarr(store)
     return ds.__index_var__

--- a/test/core/test_chunkstore.py
+++ b/test/core/test_chunkstore.py
@@ -62,7 +62,7 @@ class ChunkStoreTest(unittest.TestCase):
         self.assertEqual((4, 8, 16), index_var.shape)
         self.assertEqual(((2, 2), (4, 4), (8, 8)), index_var.chunks)
         self.assertEqual(('time', 'lat', 'lon'), index_var.dims)
-        self.assertEqual(9223372036854775808, index_var.encoding['_FillValue'])
+        self.assertEqual(99999, index_var.encoding['_FillValue'])
         self.assertEqual('uint64', index_var.encoding['dtype'])
         self.assertTrue(np.isnan(index_var.values).all())
 
@@ -92,7 +92,7 @@ def gen_index_var(dims, shape, chunks):
 
 def gen_index_var_nan(dims, shape, chunks):
     store = ChunkStore(dims, shape, chunks)
-    store.add_nan_array('__index_var__', dtype='<u8', fill_value=np.nan)
+    store.add_nan_array('__index_var__', dtype='<u8', fill_value=99999)
 
     ds = xr.open_zarr(store)
     return ds.__index_var__


### PR DESCRIPTION
[Description of PR]
Enanbled ChunkStore to deliver NaN-Chunks by calling `xcube.core.chunkstore.add_nan_array()`, this will be important once xcube-sh and xcube-cci will use the ChunkStore. This will allow to fill an xcube dataset with NaN-Chunks instead of failing due to an API-Error.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
~~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~~
~~* [ ] New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `docs/CHANGES.md`
* [ ] AppVeyor and Travis CI passes __COMMENT:__ one test fails, which is not connected to this PR (See Issue https://github.com/dcs4cop/xcube/issues/396)
* [ ] Test coverage remains or increases (target 100%)
~~* [ ] Associated issues closed after merge~~