### PR TITLE
Toniof xcube397 threadsafe progress monitors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
   with observe_dask_progress('Writing dataset', 100):
       dataset.to_zarr(store)  
   ```
+* xcube progress monitoring can deal with multiple nested progress monitors. Progress from different threads are handled separately.   
 
 ## Changes in 0.6.1
 

--- a/test/util/test_progress.py
+++ b/test/util/test_progress.py
@@ -271,6 +271,11 @@ class ProgressStateTest(unittest.TestCase):
 class AsyncProgressTest(unittest.TestCase):
 
     def test_asynchronous_progress(self):
+        """
+        This test ensures that progress can be monitored across processes that are run
+        asynchronously by asyncio. It runs three tasks that report progress simultaneously and
+        ensures that in the end the observer finishes with the correct total work.
+        """
         import asyncio
 
         async def do_something_async(i):

--- a/xcube/core/store/accessors/dataset.py
+++ b/xcube/core/store/accessors/dataset.py
@@ -33,6 +33,7 @@ from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
+from xcube.util.progress import observe_dask_progress
 
 
 class DatasetNetcdfPosixDataAccessor(PosixDataDeleterMixin, DataWriter, DataOpener):
@@ -151,7 +152,8 @@ class DatasetZarrPosixAccessor(ZarrOpenerParamsSchemaMixin,
 
     def write_data(self, data: xr.Dataset, data_id: str, replace=False, **write_params):
         assert_instance(data, xr.Dataset, 'data')
-        data.to_zarr(data_id, mode='w' if replace else None, **write_params)
+        with observe_dask_progress('Writing data', 100):
+            data.to_zarr(data_id, mode='w' if replace else None, **write_params)
 
 
 #######################################################

--- a/xcube/util/progress.py
+++ b/xcube/util/progress.py
@@ -201,7 +201,8 @@ class _ProgressContext:
     def _get_parent_state(self, traceback: List[str]) -> Optional[ProgressState]:
         parent_state = None
         max_match = 0
-        for state in self._states:
+        states = self._states.copy()
+        for state in states:
             max_match_candidate = len(state.traceback)
             if len(traceback) < max_match_candidate or max_match_candidate < max_match:
                 continue


### PR DESCRIPTION
There is no central progress state stack anymore. Instead, every progress state knows its parent state. A state may be the parent of more than one other state. To determine the parent, the traceback is considered. This works for progresses happening within the same thread, including tasks started with asyncio. Progresses started from another thread will have no parent (unless there is already another progress from the same thread).

Related issue: #397 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
~~* Add docstrings and API docs for any new/modified user-facing classes and functions~~
~~*New/modified features documented in `docs/source/*~~
* [x] Changes documented in `docs/CHANGES.md`
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge