### PR TITLE
Toniof xcube397 threadsafe progress monitors dask

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,14 @@
   with observe_dask_progress('Writing dataset', 100):
       dataset.to_zarr(store)  
   ```
+* xcube progress monitoring can deal with multiple nested progress monitors. Progress from different threads are handled separately.
+* Added new context manager `xcube.util.observe_dask_nested_progress()` that can be used
+  to observe tasks that are known to be dominated by Dask computations with nested xcube progress monitoring: 
+   
+  ```python
+  with observe_nested_dask_progress('Writing dataset', num_measured_sub_processes=100):
+      dataset.to_zarr(store)  
+  ```
 
 ## Changes in 0.6.1
 

--- a/xcube/core/store/accessors/dataset.py
+++ b/xcube/core/store/accessors/dataset.py
@@ -33,6 +33,7 @@ from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
+from xcube.util.progress import observe_dask_progress
 
 
 class DatasetNetcdfPosixDataAccessor(PosixDataDeleterMixin, DataWriter, DataOpener):
@@ -151,7 +152,8 @@ class DatasetZarrPosixAccessor(ZarrOpenerParamsSchemaMixin,
 
     def write_data(self, data: xr.Dataset, data_id: str, replace=False, **write_params):
         assert_instance(data, xr.Dataset, 'data')
-        data.to_zarr(data_id, mode='w' if replace else None, **write_params)
+        with observe_dask_progress('Writing data', 100):
+            data.to_zarr(data_id, mode='w' if replace else None, **write_params)
 
 
 #######################################################

--- a/xcube/util/progress.py
+++ b/xcube/util/progress.py
@@ -201,7 +201,8 @@ class _ProgressContext:
     def _get_parent_state(self, traceback: List[str]) -> Optional[ProgressState]:
         parent_state = None
         max_match = 0
-        for state in self._states:
+        states = self._states.copy()
+        for state in states:
             max_match_candidate = len(state.traceback)
             if len(traceback) < max_match_candidate or max_match_candidate < max_match:
                 continue

--- a/xcube/util/progress.py
+++ b/xcube/util/progress.py
@@ -478,6 +478,9 @@ class observe_dask_progress(dask.callbacks.Callback):
 class observe_nested_dask_progress(dask.callbacks.Callback):
     """
     Observe progress made by Dask tasks that have nested progress monitors.
+
+    :param label: A label.
+    :param num_measured_sub_processes: The number of sub processes with progress monitors.
     """
 
     def __init__(self,


### PR DESCRIPTION
This is a follow-up pr to #398 . In this pr, parent states might be detected across threads. The principle is that dask allows to get the children threads of a thread. We can save them to a state, and when we look for a parent state, we can link a progress state from one thread to a parent progress state from another thread.
Issues with this:
- It forces us to check whether a private attribute '_children' exists for a thread, and, if not, to set it. This is because this attribute is not set for every thread that has a thread pool, but only for the one that first loads the module's __init__.py.
- It is not compatible with observe_dask_progress. There might be instances where it cannot be decided whether observe_dask_progress or observe_nested_dask_progress is the correct choice. We could try to harmonize, though.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `docs/CHANGES.md`
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge