### PR TITLE
Toniof xxx descriptors from data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 * Added `coords` property to `DatasetDescriptor` class. 
   The `data_vars` property of the `DatasetDescriptor` class is now a dictionary. 
 
+* Added `chunks` property to `VariableDescriptor` class. 
+
 * Removed function `reproject_crs_to_wgs84()` and tests (#375) because  
   - it seemed to be no longer be working with GDAL 3.1+; 
   - there was no direct use in xcube itself;

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -170,6 +170,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                     name='xf',
                     dtype='rj',
                     dims=('dfjhrt', 'sg'),
+                    chunks=(2, 3),
                     ndim=2,
                     attrs=dict(
                         ssd=4,
@@ -222,6 +223,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                     name='xf',
                     dtype='rj',
                     dims=('dfjhrt', 'sg'),
+                    chunks=(2, 3),
                     ndim=2,
                     attrs=dict(
                         ssd=4,
@@ -244,6 +246,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                 name='rtdt',
                 dtype='rj',
                 dims=('rtdt',),
+                chunks=(2,),
                 attrs=dict(
                     ssd=6,
                     zjgrhgu='hgtr'
@@ -255,6 +258,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                 name='xf',
                 dtype='rj',
                 dims=('dfjhrt', 'sg'),
+                chunks=(2, 3),
                 attrs=dict(
                     ssd=4,
                     zjgrhgu='dgfrf'
@@ -295,6 +299,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                         name='rtdt',
                         dtype='rj',
                         dims=('rtdt',),
+                        chunks=(2,),
                         ndim=1,
                         attrs=dict(
                             ssd=6,
@@ -308,6 +313,7 @@ class DatasetDescriptorTest(unittest.TestCase):
                         name='xf',
                         dtype='rj',
                         dims=('dfjhrt', 'sg'),
+                        chunks=(2, 3),
                         ndim=2,
                         attrs=dict(
                             ssd=4,
@@ -328,27 +334,41 @@ class DatasetDescriptorTest(unittest.TestCase):
 class VariableDescriptorTest(unittest.TestCase):
 
     def test_variable_descriptor_basic(self):
-        vd1 = VariableDescriptor('gz', 'zughysz', ['rtdswgt', 'dref', 'zdrs5ge'])
+        vd1 = VariableDescriptor('gz',
+                                 'zughysz',
+                                 ['rtdswgt', 'dref', 'zdrs5ge'],
+                                 (3, 321, 4))
         self.assertEqual('gz', vd1.name)
         self.assertEqual('zughysz', vd1.dtype)
         self.assertEqual(('rtdswgt', 'dref', 'zdrs5ge'), vd1.dims)
+        self.assertEqual((3, 321, 4), vd1.chunks)
         self.assertEqual(3, vd1.ndim)
         self.assertEqual(None, vd1.attrs)
 
-        vd3 = VariableDescriptor('gz', 'zughysz', ['rtdswgt', 'dref', 'zdrs5ge'], {'d': 2, 'zjgu': ''})
+        vd3 = VariableDescriptor('gz',
+                                 'zughysz',
+                                 ['rtdswgt', 'dref', 'zdrs5ge'],
+                                 (3, 321, 4),
+                                 {'d': 2, 'zjgu': ''})
         self.assertEqual('gz', vd3.name)
         self.assertEqual('zughysz', vd3.dtype)
         self.assertEqual(('rtdswgt', 'dref', 'zdrs5ge'), vd3.dims)
+        self.assertEqual((3, 321, 4), vd3.chunks)
         self.assertEqual(3, vd3.ndim)
         self.assertEqual({'d': 2, 'zjgu': ''}, vd3.attrs)
 
     def test_variable_descriptor_to_dict(self):
-        vd = VariableDescriptor('xf', 'rj', ['dfjhrt', 'sg'], {'ssd': 4, 'zjgrhgu': 'dgfrf', 'fill_value': np.NaN})
+        vd = VariableDescriptor('xf',
+                                'rj',
+                                ['dfjhrt', 'sg'],
+                                (3, 2),
+                                {'ssd': 4, 'zjgrhgu': 'dgfrf', 'fill_value': np.NaN})
         expected = {
             'name': 'xf',
             'dtype': 'rj',
             'dims': ('dfjhrt', 'sg'),
             'ndim': 2,
+            'chunks': (3, 2),
             'attrs': {
                 'ssd': 4,
                 'zjgrhgu': 'dgfrf',
@@ -363,6 +383,7 @@ class VariableDescriptorTest(unittest.TestCase):
             'dtype': 'rj',
             'dims': ('dfjhrt', 'sg'),
             'ndim': 2,
+            'chunks':(3, 2),
             'attrs': {
                 'ssd': 4,
                 'zjgrhgu': 'dgfrf',
@@ -374,6 +395,7 @@ class VariableDescriptorTest(unittest.TestCase):
         self.assertEqual('rj', vd.dtype)
         self.assertEqual(('dfjhrt', 'sg'), vd.dims)
         self.assertEqual(2, vd.ndim)
+        self.assertEqual((3, 2), vd.chunks)
         self.assertEqual({'ssd': 4, 'zjgrhgu': 'dgfrf', 'fill_value': None}, vd.attrs)
 
         vd_fail = None

--- a/test/core/store/test_descriptor.py
+++ b/test/core/store/test_descriptor.py
@@ -20,7 +20,7 @@ class NewDataDescriptorTest(unittest.TestCase):
         self.assertTrue(isinstance(descriptor, DatasetDescriptor))
         self.assertEqual('cube', descriptor.data_id)
         self.assertEqual('dataset[cube]', descriptor.type_specifier)
-        self.assertEqual((-90, -180, 90, 180), descriptor.bbox)
+        self.assertEqual((-90.0, -180.0, 90.0, 180.0), descriptor.bbox)
         self.assertIsNone(descriptor.open_params_schema)
         self.assertEqual(('2010-01-01T00:00:00', '2010-01-06T00:00:00'), descriptor.time_range)
         self.assertEqual('1D', descriptor.time_period)

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -87,6 +87,7 @@ def _build_variable_descriptor_dict(variables) -> Mapping[str, 'VariableDescript
 
 
 def _determine_bbox(data: xr.Dataset, spatial_res: float = 0.0) -> (float, float, float, float):
+    # TODO get rid of these hard-coded coord names as soon as new resampling is available
     min_lat, max_lat, lat_bounds_ending = _determine_min_and_max(data, ['lat', 'latitude', 'y'])
     min_lon, max_lon, lon_bounds_ending = _determine_min_and_max(data, ['lon', 'longitude', 'x'])
     lat_spatial_res = 0.0 if lat_bounds_ending != '' else spatial_res
@@ -117,6 +118,7 @@ def _determine_min_and_max(data: xr.Dataset, dimensions: Sequence[str]) -> (floa
 
 
 def _determine_spatial_res(data: xr.Dataset):
+    # TODO get rid of these hard-coded coord names as soon as new resampling is available
     lat_dimensions = ['lat', 'latitude', 'y']
     for lat_dimension in lat_dimensions:
         if lat_dimension in data:

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -51,18 +51,9 @@ def new_data_descriptor(data_id: str, data: Any, require: bool = False) -> 'Data
     if isinstance(data, xr.Dataset):
         coords = _build_variable_descriptor_dict(data.coords)
         data_vars = _build_variable_descriptor_dict(data.data_vars)
-        bbox = None
-        if 'geospatial_lat_min' in data.attrs and 'geospatial_lon_min' in data.attrs \
-                and 'geospatial_lat_max' in data.attrs and 'geospatial_lon_max' in data.attrs:
-            bbox = (data.geospatial_lat_min, data.geospatial_lon_min,
-                    data.geospatial_lat_max, data.geospatial_lon_max)
         spatial_res = _determine_spatial_res(data)
-        time_coverage_start = None
-        time_coverage_end = None
-        if 'time_coverage_start' in data.attrs:
-            time_coverage_start = data.time_coverage_start
-        if 'time_coverage_end' in data.attrs:
-            time_coverage_end = data.time_coverage_end
+        bbox = _determine_bbox(data, spatial_res)
+        time_coverage_start, time_coverage_end = _determine_time_coverage(data)
         time_period = _determine_time_period(data)
         return DatasetDescriptor(data_id=data_id,
                                  type_specifier=get_type_specifier(data),
@@ -93,6 +84,36 @@ def _build_variable_descriptor_dict(variables) -> Mapping[str, 'VariableDescript
             for var_name, var in variables.items()}
 
 
+def _determine_bbox(data: xr.Dataset, spatial_res: float = 0.0) -> (float, float, float, float):
+    min_lat, max_lat, lat_bounds_ending = _determine_min_and_max(data, ['lat', 'latitude', 'y'])
+    min_lon, max_lon, lon_bounds_ending = _determine_min_and_max(data, ['lon', 'longitude', 'x'])
+    lat_spatial_res = 0.0 if lat_bounds_ending != '' else spatial_res
+    lon_spatial_res = 0.0 if lon_bounds_ending != '' else spatial_res
+    if min_lon is not None and min_lat is not None and max_lon is not None and max_lat is not None:
+        return (min_lat - lat_spatial_res / 2,
+                min_lon - lon_spatial_res / 2,
+                max_lat + lat_spatial_res / 2,
+                max_lon + lon_spatial_res / 2)
+    elif 'geospatial_lat_min' in data.attrs and \
+            'geospatial_lon_min' in data.attrs and \
+            'geospatial_lat_max' in data.attrs and \
+            'geospatial_lon_max' in data.attrs:
+        return (data.geospatial_lat_min, data.geospatial_lon_min,
+                data.geospatial_lat_max, data.geospatial_lon_max)
+    return None, None, None, None
+
+
+def _determine_min_and_max(data: xr.Dataset, dimensions: Sequence[str]) -> (float, float, str):
+    bounds_endings = ['bnds', 'bounds', '']
+    for bounds_ending in bounds_endings:
+        for dimension in dimensions:
+            dimension = f'{dimension}_{bounds_ending}'
+            if dimension in data:
+                dimension_data = data[dimension].values
+                return np.min(dimension_data), np.max(dimension_data), bounds_ending
+    return None, None, ''
+
+
 def _determine_spatial_res(data: xr.Dataset):
     lat_dimensions = ['lat', 'latitude', 'y']
     for lat_dimension in lat_dimensions:
@@ -101,7 +122,20 @@ def _determine_spatial_res(data: xr.Dataset):
             lat_res = lat_diff[0]
             lat_regular = np.allclose(lat_res, lat_diff, 1e-8)
             if lat_regular:
-                return lat_res
+                return abs(lat_res)
+
+
+def _determine_time_coverage(data: xr.Dataset):
+    start_time, end_time, _ = _determine_min_and_max(data, ['time'])
+    if start_time is not None:
+        start_time = pd.to_datetime(start_time).isoformat()
+    elif 'time_coverage_start' in data.attrs:
+        start_time = data.time_coverage_start
+    if end_time is not None:
+        end_time = pd.to_datetime(end_time).isoformat()
+    elif 'time_coverage_end' in data.attrs:
+        end_time = data.time_coverage_end
+    return start_time, end_time
 
 
 def _determine_time_period(data: xr.Dataset):


### PR DESCRIPTION
Contains two enhancements:
1. The new_data_descriptor method determines bbox and time range from data. Metadata attributes are now only used as fallback solution
2. Chunks have been added as a parameter to the VariableDescriptor class

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
~~[ ] New/modified features documented in `docs/source/*~~
* [x] Changes documented in `docs/CHANGES.md`
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage remains or increases (target 100%)
~~[ ] Associated issues closed after merge~~