### PR TITLE
`xcube gen2` can now have multiple `-v` options

### DIFF
--- a/test/core/gen2/service/test_generator.py
+++ b/test/core/gen2/service/test_generator.py
@@ -58,7 +58,7 @@ class CubeGeneratorServiceTest(unittest.TestCase):
                                                           client_id='itzibitzispider',
                                                           client_secret='g3ergd36fd2983457fhjder'),
                                             progress_period=0,
-                                            verbose=True)
+                                            verbosity=True)
 
     @requests_mock.Mocker()
     def test_generate_cube_success(self, m: requests_mock.Mocker):

--- a/test/core/gen2/test_generator.py
+++ b/test/core/gen2/test_generator.py
@@ -46,28 +46,28 @@ class LocalCubeGeneratorTest(unittest.TestCase):
     @requests_mock.Mocker()
     def test_generate_cube_from_dict(self, m):
         m.put('https://xcube-gen.test/api/v1/jobs/tomtom/iamajob/callback', json={})
-        LocalCubeGenerator(CubeGeneratorRequest.from_dict(self.REQUEST), verbose=True).generate_cube()
+        LocalCubeGenerator(CubeGeneratorRequest.from_dict(self.REQUEST), verbosity=True).generate_cube()
         self.assertIsInstance(MemoryDataStore.get_global_data_dict().get('CHL'),
                               xr.Dataset)
 
     @requests_mock.Mocker()
     def test_generate_cube_from_json(self, m):
         m.put('https://xcube-gen.test/api/v1/jobs/tomtom/iamajob/callback', json={})
-        CubeGenerator.from_file('_request.json', verbose=True).generate_cube()
+        CubeGenerator.from_file('_request.json', verbosity=True).generate_cube()
         self.assertIsInstance(MemoryDataStore.get_global_data_dict().get('CHL'),
                               xr.Dataset)
 
     @requests_mock.Mocker()
     def test_generate_cube_from_yaml(self, m):
         m.put('https://xcube-gen.test/api/v1/jobs/tomtom/iamajob/callback', json={})
-        CubeGenerator.from_file('_request.yaml', verbose=True).generate_cube()
+        CubeGenerator.from_file('_request.yaml', verbosity=True).generate_cube()
         self.assertIsInstance(MemoryDataStore.get_global_data_dict().get('CHL'),
                               xr.Dataset)
 
     @requests_mock.Mocker()
     def test_get_cube_info_from_dict(self, m):
         m.put('https://xcube-gen.test/api/v1/jobs/tomtom/iamajob/callback', json={})
-        cube_info = LocalCubeGenerator(CubeGeneratorRequest.from_dict(self.REQUEST), verbose=True).get_cube_info()
+        cube_info = LocalCubeGenerator(CubeGeneratorRequest.from_dict(self.REQUEST), verbosity=True).get_cube_info()
         self.assertIsInstance(cube_info, CubeInfo)
         self.assertIsInstance(cube_info.dataset_descriptor, DatasetDescriptor)
         self.assertIsInstance(cube_info.size_estimation, dict)

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 
 import sys
+from typing import Sequence
 
 import click
 
@@ -46,12 +47,13 @@ import click
 @click.option('--verbose', '-v',
               is_flag=True,
               multiple=True,
-              help='Control amount of information dumped to stdout. Multiple may be given.')
+              help='Control amount of information dumped to stdout.'
+                   ' May be given multiple time, e.g. "-vvv".')
 def gen2(request_path: str,
          stores_config_path: str = None,
          service_config_path: str = None,
          info: bool = False,
-         verbose: int = 0):
+         verbose: Sequence[bool] = None):
     """
     Generator tool for data cubes.
 
@@ -103,11 +105,14 @@ def gen2(request_path: str,
     from xcube.core.gen2 import CubeGeneratorError
     from xcube.core.gen2 import CubeInfo
     from xcube.core.store import DataStoreError
+
+    verbosity = len(verbose) if verbose else 0
+
     try:
         generator = CubeGenerator.from_file(request_path,
                                             stores_config_path=stores_config_path,
                                             service_config_path=service_config_path,
-                                            verbosity=verbose)
+                                            verbosity=verbosity)
         if info:
             def dump_cube_info(cube_info: CubeInfo):
                 import sys

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -45,12 +45,13 @@ import click
                    ' Does not generate the data cube.')
 @click.option('--verbose', '-v',
               is_flag=True,
-              help='Control amount of information dumped to stdout.')
+              multiple=True,
+              help='Control amount of information dumped to stdout. Multiple may be given.')
 def gen2(request_path: str,
          stores_config_path: str = None,
          service_config_path: str = None,
          info: bool = False,
-         verbose: bool = False):
+         verbose: int = 0):
     """
     Generator tool for data cubes.
 
@@ -106,7 +107,7 @@ def gen2(request_path: str,
         generator = CubeGenerator.from_file(request_path,
                                             stores_config_path=stores_config_path,
                                             service_config_path=service_config_path,
-                                            verbose=verbose)
+                                            verbosity=verbose)
         if info:
             def dump_cube_info(cube_info: CubeInfo):
                 import sys

--- a/xcube/core/gen2/request.py
+++ b/xcube/core/gen2/request.py
@@ -22,7 +22,7 @@
 import json
 import os.path
 import sys
-from typing import Optional, Dict, Any, Sequence, Mapping
+from typing import Optional, Dict, Any, Sequence
 
 import jsonschema
 import yaml
@@ -85,7 +85,7 @@ class CubeGeneratorRequest(JsonObject):
             factory=cls,
         )
 
-    def to_dict(self) -> Mapping[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """Convert into a JSON-serializable dictionary"""
         if len(self.input_configs) == 1:
             d = dict(input_config=self.input_configs[0].to_dict())
@@ -101,7 +101,7 @@ class CubeGeneratorRequest(JsonObject):
         return d
 
     @classmethod
-    def from_dict(cls, request_dict: Dict) -> 'CubeGeneratorRequest':
+    def from_dict(cls, request_dict: Dict[str, Any]) -> 'CubeGeneratorRequest':
         """Create new instance from a JSON-serializable dictionary"""
         try:
             return cls.get_schema().from_instance(request_dict)

--- a/xcube/core/gen2/request.py
+++ b/xcube/core/gen2/request.py
@@ -41,12 +41,16 @@ from .config import OutputConfig
 
 class CubeGeneratorRequest(JsonObject):
     """
+    A request used to generate data cubes using cube generators.
 
-    :param input_config:
-    :param input_configs:
-    :param cube_config:
-    :param output_config:
-    :param callback_config:
+    :param input_config: A configuration for a single input.
+        Must be omitted if *input_configs* is given.
+    :param input_configs: A sequence of one or more input configurations.
+        Must be omitted if *input_config* is given.
+    :param cube_config: The target cube configuration.
+    :param output_config: The output configuration for the target cube.
+    :param callback_config: A configuration that allows a cube generator
+        to publish progress information to a compatible endpoint.
     """
 
     def __init__(self,
@@ -105,15 +109,15 @@ class CubeGeneratorRequest(JsonObject):
             raise CubeGeneratorError(f'{e}') from e
 
     @classmethod
-    def from_file(cls, request_file: Optional[str], verbose=False) -> 'CubeGeneratorRequest':
+    def from_file(cls, request_file: Optional[str], verbosity: int = 0) -> 'CubeGeneratorRequest':
         """Create new instance from a JSON file, or YAML file, or JSON passed via stdin."""
-        gen_config_dict = cls._load_gen_config_file(request_file, verbose=verbose)
-        if verbose:
+        gen_config_dict = cls._load_gen_config_file(request_file, verbosity=verbosity)
+        if verbosity:
             print(f'Cube generator configuration loaded from {request_file or "TTY"}.')
         return cls.from_dict(gen_config_dict)
 
     @classmethod
-    def _load_gen_config_file(cls, gen_config_file: Optional[str], verbose=False) -> Dict:
+    def _load_gen_config_file(cls, gen_config_file: Optional[str], verbosity: int = 0) -> Dict:
 
         if gen_config_file is not None and not os.path.exists(gen_config_file):
             raise CubeGeneratorError(f'Cube generator configuration "{gen_config_file}" not found.')
@@ -121,7 +125,7 @@ class CubeGeneratorRequest(JsonObject):
         try:
             if gen_config_file is None:
                 if not sys.stdin.isatty():
-                    if verbose:
+                    if verbosity:
                         print('Awaiting generator configuration JSON from TTY...')
                     return json.load(sys.stdin)
             else:

--- a/xcube/core/gen2/service/generator.py
+++ b/xcube/core/gen2/service/generator.py
@@ -19,10 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import time
-from typing import Type, TypeVar, Dict
 import json
-import sys
+import time
+from typing import Type, TypeVar, Dict, Any
 
 import requests
 
@@ -47,20 +46,16 @@ R = TypeVar('R')
 
 class CubeGeneratorService(CubeGenerator):
     """
-    Generator tool for data cubes.
+    Service for generating data cubes.
 
     Creates cube views from one or more cube stores, resamples them to a
     common grid, optionally performs some cube transformation, and writes
     the resulting cube to some target cube store.
 
     :param request: Cube generation request.
-    :param store_pool: An optional pool of pre-configured data stores
-        referenced from *gen_config* input/output configurations.
+    :param service_config: An service configuration object.
     :param verbosity: Level of verbosity, 0 means off.
     """
-
-    # Allow dumping of JSON responses to stdout
-    _DEBUG = False
 
     def __init__(self,
                  request: CubeGeneratorRequest,
@@ -74,7 +69,7 @@ class CubeGeneratorService(CubeGenerator):
         self._service_config = service_config
         self._access_token = service_config.access_token
         self._progress_period = progress_period
-        self._verbosity = verbosity if not self._DEBUG else 10
+        self._verbosity = verbosity
 
     def endpoint_op(self, op_path: str) -> str:
         return f'{self._service_config.endpoint_url}{op_path}'
@@ -89,7 +84,7 @@ class CubeGeneratorService(CubeGenerator):
     @property
     def access_token(self) -> str:
         if self._access_token is None:
-            request = {
+            request_data = {
                 "audience": self._service_config.endpoint_url,
                 "client_id": self._service_config.client_id,
                 "client_secret": self._service_config.client_secret,
@@ -97,17 +92,18 @@ class CubeGeneratorService(CubeGenerator):
             }
             # self.__dump_json(request)
             response = requests.post(self.endpoint_op('oauth/token'),
-                                     json=request,
+                                     json=request_data,
                                      headers=_BASE_HEADERS)
-            token_response: Token = self._parse_response(response, Token)
+            token_response: Token = self._parse_response(response, Token, request_data=request_data)
             self._access_token = token_response.access_token
         return self._access_token
 
     def get_cube_info(self) -> CubeInfoWithCosts:
+        request_data = self._request.to_dict()
         response = requests.post(self.endpoint_op('cubegens/info'),
-                                 json=self._request.to_dict(),
+                                 json=request_data,
                                  headers=self.auth_headers)
-        return self._parse_response(response, CubeInfoWithCosts)
+        return self._parse_response(response, CubeInfoWithCosts, request_data=request_data)
 
     def generate_cube(self):
         request = self._request.to_dict()
@@ -139,9 +135,11 @@ class CubeGeneratorService(CubeGenerator):
                         cm.worked(work)
                         last_worked = worked
 
-    @classmethod
-    def _get_cube_generation_result(cls, response: requests.Response) -> Result:
-        response_instance: Response = cls._parse_response(response, Response)
+    def _get_cube_generation_result(self, response: requests.Response,
+                                    request_data: Dict[str, Any] = None) -> Result:
+        response_instance: Response = self._parse_response(response,
+                                                           Response,
+                                                           request_data=request_data)
         result = response_instance.result
         if result.status.failed:
             message = 'Cube generation failed'
@@ -154,30 +152,41 @@ class CubeGeneratorService(CubeGenerator):
                                      remote_traceback=response_instance.traceback)
         return result
 
-    def _parse_response(self, response: requests.Response, response_type: Type[R]) -> R:
+    def _parse_response(self,
+                        response: requests.Response,
+                        response_type: Type[R],
+                        request_data: Dict[str, Any] = None) -> R:
         CubeGeneratorError.maybe_raise_for_response(response)
-        data = response.json()
-
-        if self._verbosity > 3:
-            self.__dump_json(data, response.url)
+        response_data = response.json()
+        if self._verbosity >= 3:
+            self.__dump_json(response.request.method, response.url, request_data, response_data)
 
         # noinspection PyBroadException
         try:
-            return response_type.from_dict(data)
+            return response_type.from_dict(response_data)
         except Exception as e:
             raise RuntimeError(f'internal error: unexpected response'
                                f' from API call {response.url}: {e}') from e
 
     @classmethod
-    def __dump_json(cls, obj, url):
+    def __dump_json(cls, method, url, request_data, response_data):
         """
-        Dump *obj* as JSON to stdout.
+        Dump debug info as JSON to stdout.
 
         Used for debugging only.
         """
-        line = f'Response from {url}:'
-        print()
-        print(line)
-        print('=' * len(line))
-        json.dump(obj, sys.stdout, indent=2)
-        print()
+        url_line = f'{method} {url}:'
+        request_line = 'Request:'
+        response_line = 'Response:'
+
+        print('=' * len(url_line))
+        print(url_line)
+        print('=' * len(url_line))
+        print('-' * len(request_line))
+        print(request_line)
+        print('-' * len(request_line))
+        print(json.dumps(request_data, indent=2))
+        print('-' * len(response_line))
+        print(response_line)
+        print('-' * len(response_line))
+        print(json.dumps(response_data, indent=2))

--- a/xcube/util/jsonschema.py
+++ b/xcube/util/jsonschema.py
@@ -565,7 +565,7 @@ class JsonObject(ABC):
         """Get JSON object schema."""
 
     @classmethod
-    def from_dict(cls, value: Dict) -> 'JsonObject':
+    def from_dict(cls, value: Dict[str, Any]) -> 'JsonObject':
         """Create instance from JSON-serializable dictionary *value*."""
         return cls.get_schema().from_instance(value)
 


### PR DESCRIPTION
In this PR:

* `xcube gen2` can now have multiple `-v` options, e.g. `-vvv`
* `xcube gen2 -vvv --service SERVICE REQUEST` will now output detailed requests and responses
* `CubeGeneratorService(gen_config, ...)` --> `CubeGeneratorService(request, ...)`
* Docstring updates

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `docs/CHANGES.md`~
* [x] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] ~Associated issues closed after merge~