### PR TITLE
Enhance xcube serve for use in containers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,12 @@
 * S3 Data Store will only recognise a `consolidated = True` parameter setting,
   if the file `{bucket}/{data_id}/.zmetadata` exists. 
 * `xcube gen2` will now ensure that temporal subsets can be created. (#430)
+* Enhance `xcube serve` for use in containers: (#437)
+  * In addition to option `--config` or `-c`, dataset configurations can now 
+    be passed via environment variable `XCUBE_SERVE_CONFIG_FILE`.
+  * Added new option `--base-dir` or `-b` to pass the base directory to
+    resolve relative paths in dataset configurations. In addition, the value
+    can be passed via environment variable `XCUBE_SERVE_BASE_DIR`.
 
 ## Changes in 0.7.2
 

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -31,36 +31,69 @@ Serve data cubes via web service.
       https://app.swaggerhub.com/apis/bcdev/xcube-server.
 
     Options:
-      -A, --address ADDRESS  Service address. Defaults to 'localhost'.
-      -P, --port PORT        Port number where the service will listen on.
-                             Defaults to 8080.
-      --prefix PREFIX        Service URL prefix. May contain template patterns
-                             such as "${version}" or "${name}". For example
-                             "${name}/api/${version}".
-      -u, --update PERIOD    Service will update after given seconds of
-                             inactivity. Zero or a negative value will disable
-                             update checks. Defaults to 2.0.
-      -S, --styles STYLES    Color mapping styles for variables. Used only, if one
-                             or more CUBE arguments are provided and CONFIG is not
-                             given. Comma-separated list with elements of the form
-                             <var>=(<vmin>,<vmax>) or
-                             <var>=(<vmin>,<vmax>,"<cmap>")
-      -c, --config CONFIG    Use datasets configuration file CONFIG. Cannot be
-                             used if CUBES are provided.
-      --tilecache SIZE       In-memory tile cache size in bytes. Unit suffixes
-                             'K', 'M', 'G' may be used. Defaults to '512M'. The
-                             special value 'OFF' disables tile caching.
-      --tilemode MODE        Tile computation mode. This is an internal option
-                             used to switch between different tile computation
-                             implementations. Defaults to 0.
-      -s, --show             Run viewer app. Requires setting the environment
-                             variable XCUBE_VIEWER_PATH to a valid xcube-viewer
-                             deployment or build directory. Refer to
-                             https://github.com/dcs4cop/xcube-viewer for more
-                             information.
-      -v, --verbose          Delegate logging to the console (stderr).
-      --traceperf            Print performance diagnostics (stdout).
-      --help                 Show this message and exit.
+      -A, --address ADDRESS    Service address. Defaults to 'localhost'.
+      -P, --port PORT          Port number where the service will listen on.
+                               Defaults to 8080.
+
+      --prefix PREFIX          Service URL prefix. May contain template patterns
+                               such as "${version}" or "${name}". For example
+                               "${name}/api/${version}". Will be used to prefix
+                               all API operation routes and in any URLs returned
+                               by the service.
+
+      --revprefix REVPREFIX    Service reverse URL prefix. May contain template
+                               patterns such as "${version}" or "${name}". For
+                               example "${name}/api/${version}". Defaults to
+                               PREFIX, if any. Will be used only in URLs returned
+                               by the service e.g. the tile URLs returned by the
+                               WMTS service.
+
+      -u, --update PERIOD      Service will update after given seconds of
+                               inactivity. Zero or a negative value will disable
+                               update checks. Defaults to 2.0.
+
+      -S, --styles STYLES      Color mapping styles for variables. Used only, if
+                               one or more CUBE arguments are provided and CONFIG
+                               is not given. Comma-separated list with elements of
+                               the form <var>=(<vmin>,<vmax>) or
+                               <var>=(<vmin>,<vmax>,"<cmap>")
+
+      -c, --config CONFIG      Use datasets configuration file CONFIG. Cannot be
+                               used if CUBES are provided. If not given and also
+                               CUBES are not provided, the configuration may be
+                               given by environment variable
+                               XCUBE_SERVE_CONFIG_FILE.
+
+      -b, --base-dir BASE_DIR  Base directory used to resolve relative dataset
+                               paths in CONFIG and relative CUBES paths. Defaults
+                               to value of environment variable
+                               XCUBE_SERVE_BASE_DIR, if given, otherwise defaults
+                               to the parent directory of CONFIG.
+
+      --tilecache SIZE         In-memory tile cache size in bytes. Unit suffixes
+                               'K', 'M', 'G' may be used. Defaults to '512M'. The
+                               special value 'OFF' disables tile caching.
+
+      --tilemode MODE          Tile computation mode. This is an internal option
+                               used to switch between different tile computation
+                               implementations. Defaults to 0.
+
+      -s, --show               Run viewer app. Requires setting the environment
+                               variable XCUBE_VIEWER_PATH to a valid xcube-viewer
+                               deployment or build directory. Refer to
+                               https://github.com/dcs4cop/xcube-viewer for more
+                               information.
+
+      -v, --verbose            Delegate logging to the console (stderr).
+      --traceperf              Print performance diagnostics (stdout).
+      --aws-prof PROFILE       To publish remote CUBEs, use AWS credentials from
+                               section [PROFILE] found in ~/.aws/credentials.
+
+      --aws-env                To publish remote CUBEs, use AWS credentials from
+                               environment variables AWS_ACCESS_KEY_ID and
+                               AWS_SECRET_ACCESS_KEY
+
+      --help                   Show this message and exit.
 
 
 Configuration File

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -1,5 +1,8 @@
-from test.cli.helpers import CliDataTest
+import os
 
+from test.cli.helpers import CliDataTest
+from xcube.cli.serve import BASE_ENV_VAR
+from xcube.cli.serve import CONFIG_ENV_VAR
 from xcube.cli.serve import VIEWER_ENV_VAR
 from xcube.cli.serve import main
 
@@ -11,19 +14,47 @@ class ServerCliTest(CliDataTest):
         self.assertEqual('Error: CONFIG and CUBES cannot be used at the same time.\n',
                          result.output[-58:])
 
-        result = self.invoke_cli(["serve", "--config", "x.yml", "pippo.zarr"])
+        old_value = os.environ.get(CONFIG_ENV_VAR)
+        os.environ[CONFIG_ENV_VAR] = "x.yml"
+        try:
+            result = self.invoke_cli(["serve"])
+            self.assertEqual(1, result.exit_code)
+            self.assertEqual('Error: Configuration file not found: x.yml\n',
+                             result.output[-44:])
+        finally:
+            if old_value is not None:
+                os.environ[CONFIG_ENV_VAR] = old_value
+
+    def test_base_dir(self):
+        config_path = os.path.join(os.path.dirname(__file__),
+                                   '..', '..', 'examples', 'serve', 'demo', 'config.yml')
+
+        result = self.invoke_cli(["serve", "--config", config_path, "--base-dir", "pippo/gnarz"])
         self.assertEqual(1, result.exit_code)
-        self.assertEqual('Error: CONFIG and CUBES cannot be used at the same time.\n',
-                         result.output[-58:])
+        self.assertEqual('Error: Base directory not found: pippo/gnarz\n',
+                         result.output[-45:])
+
+        old_value = os.environ.get(BASE_ENV_VAR)
+        os.environ[BASE_ENV_VAR] = 'pippo/curry'
+        try:
+            result = self.invoke_cli(["serve", "--config", config_path])
+            self.assertEqual(1, result.exit_code)
+            self.assertEqual('Error: Base directory not found: pippo/curry\n',
+                             result.output[-45:])
+        finally:
+            if old_value is not None:
+                os.environ[BASE_ENV_VAR] = old_value
 
     def test_show(self):
-        import os
+        config_path = os.path.join(os.path.dirname(__file__),
+                                   '..', '..', 'examples', 'serve', 'demo', 'config.yml')
+
         viewer_path = os.environ.get(VIEWER_ENV_VAR)
 
         if viewer_path is not None:
             del os.environ[VIEWER_ENV_VAR]
 
-        result = self.invoke_cli(["serve", "--show"])
+        result = self.invoke_cli(["serve", "--show", "--config", config_path])
         self.assertEqual(2, result.exit_code)
         self.assertEqual(f'Error: Option "--show": In order to run the viewer, '
                          f'set environment variable {VIEWER_ENV_VAR} to a valid '
@@ -31,7 +62,7 @@ class ServerCliTest(CliDataTest):
                          result.output[-150:])
 
         os.environ[VIEWER_ENV_VAR] = "pip/po"
-        result = self.invoke_cli(["serve", "--show"])
+        result = self.invoke_cli(["serve", "--show", "--config", config_path])
         self.assertEqual(2, result.exit_code)
         self.assertEqual(f'Error: Option "--show": Viewer path set by environment '
                          f'variable {VIEWER_ENV_VAR} '

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2019 by the xcube development team and contributors
+# Copyright (c) 2021 by the xcube development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -124,8 +124,12 @@ def serve(cube: List[str],
         styles = parse_cli_kwargs(styles, "STYLES")
     if (aws_prof or aws_env) and not cube:
         raise click.ClickException("AWS credentials are only valid in combination with given CUBE argument(s).")
+    if config_file and not os.path.isfile(config_file):
+        raise click.ClickException(f"Configuration file not found: {config_file}")
 
     base_dir = base_dir or os.environ.get(BASE_ENV_VAR, config_file and os.path.dirname(config_file)) or '.'
+    if not os.path.isdir(base_dir):
+        raise click.ClickException(f"Base directory not found: {base_dir}")
 
     from xcube.version import version
     from xcube.webapi.defaults import SERVER_NAME, SERVER_DESCRIPTION
@@ -145,6 +149,7 @@ def serve(cube: List[str],
                       cube_paths=cube,
                       styles=styles,
                       config_file=config_file,
+                      base_dir=base_dir,
                       tile_cache_size=tile_cache_size,
                       tile_comp_mode=tile_comp_mode,
                       update_period=update_period,

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2019 by the xcube development team and contributors
+# Copyright (c) 2021 by the xcube development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -71,6 +71,7 @@ class Service:
                  cube_paths: List[str] = None,
                  styles: Dict[str, Tuple] = None,
                  config_file: Optional[str] = None,
+                 base_dir: Optional[str] = None,
                  tile_cache_size: Optional[str] = DEFAULT_TILE_CACHE_SIZE,
                  tile_comp_mode: int = DEFAULT_TILE_COMP_MODE,
                  update_period: Optional[float] = DEFAULT_UPDATE_PERIOD,
@@ -94,6 +95,7 @@ class Service:
         :param port: the port number
         :param cube_paths: optional list of cube paths
         :param config_file: optional configuration file
+        :param base_dir: optional base directory
         :param update_period: if not-None, time of idleness in seconds before service is updated
         :param log_file_prefix: Log file prefix, default is "xcube-serve.log"
         :param log_to_stderr: Whether logging should be shown on stderr
@@ -136,7 +138,6 @@ class Service:
                                  started=datetime.now().isoformat(sep=' '),
                                  pid=os.getpid())
 
-        base_dir = os.path.dirname(self.config_file) if self.config_file else os.path.abspath('')
         self.context = ServiceContext(prefix=prefix,
                                       config=config,
                                       base_dir=base_dir,
@@ -443,7 +444,6 @@ def new_default_config(cube_paths: List[str],
         dataset_list.append(dataset_descriptor)
         index += 1
 
-
     config = dict(Datasets=dataset_list)
     if styles:
         color_mappings = {}
@@ -462,7 +462,9 @@ def new_default_config(cube_paths: List[str],
     return config
 
 
+# TODO (forman): fix this hack
 def _get_custom_color_list(config_file):
+    # global: too bad :(
     global SNAP_CPD_LIST
     config = load_configs(config_file) if config_file else {}
     styles = config.get('Styles')


### PR DESCRIPTION
Enhance `xcube serve` for use in containers: (#437)

* In addition to option `--config` or `-c`, dataset configurations can now be passed via environment variable `XCUBE_SERVE_CONFIG_FILE`.
* Added new option `--base-dir` or `-b` to pass the base directory to resolve relative paths in dataset configurations. In addition, the value can be passed via environment variable `XCUBE_SERVE_BASE_DIR`.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `docs/CHANGES.md`
* [x] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
