### PR TITLE
Update timeslice.find_time_slice for xarray 0.18

### DIFF
--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -51,7 +51,10 @@ def find_time_slice(store: Union[str, MutableMapping],
         # ValueError raised if cube store does not exist
         try:
             cube = xr.open_dataset(store)
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
+            # If the zarr directory does not exist, open_dataset raises a
+            # FileNotFoundError (with xarray <= 0.17.0) or a ValueError
+            # (with xarray 0.18.0).
             return -1, 'create'
 
     # TODO (forman): optimise following naive search by bi-sectioning or so


### PR DESCRIPTION
Fixes #452.

timeslice.find_time_slice wasn't working correctly with xarray 0.18.0
and non-existent store directories, because open_dataset now throws
a ValueError rather than FileNotFoundError in this case. With this
commit, find_time_slice now catches both exceptions, which adds xarray
0.18.0 compatibility while retaining backward compatibility.

[Description of PR]

Checklist:

* [x] Add unit tests and/or doctests in docstrings (n/a -- there are existing unit tests)
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions (n/a)
* [x] New/modified features documented in `docs/source/*` (n/a)
* [x] Changes documented in `docs/CHANGES.md` (I assume this is n/a for a minor fix like this)
* [x] AppVeyor ~~and Travis~~ CI passes
* [x] Test coverage remains or increases (target 100%)
* [x] Associated issues closed after merge