### PR TITLE
use consolidated parameter to open data when possible

### DIFF
--- a/test/core/store/stores/test_s3.py
+++ b/test/core/store/stores/test_s3.py
@@ -199,9 +199,11 @@ class WritingToS3DataStoreTest(S3Test):
         self.assertFalse(self.store.has_data('cube-1.zarr', type_specifier='geodataframe'))
         self.assertFalse(self.store.has_data('cube-2.zarr'))
 
-    def test_write_and_describe_data_from_zarr_describer(self):
+    def test_write_and_describe_data_without_registry(self):
         dataset_1 = new_cube(variables=dict(a=4.1, b=7.4))
         self.store.write_data(dataset_1, data_id='cube-1.zarr')
+
+        self.store.deregister_data(data_id='cube-1.zarr')
 
         data_descriptor = self.store.describe_data('cube-1.zarr')
         self.assertIsInstance(data_descriptor, DatasetDescriptor)

--- a/xcube/core/store/stores/s3.py
+++ b/xcube/core/store/stores/s3.py
@@ -173,7 +173,11 @@ class S3DataStore(DefaultSearchMixin, MutableDataStore):
         data_opener_ids = self.get_data_opener_ids(data_id, type_specifier=type_specifier)
         if len(data_opener_ids) == 0:
             raise DataStoreError(f'Cannot describe data {data_id}')
-        data = self.open_data(data_id, data_opener_ids[0])
+        open_params = {}
+        op_schema = self._new_s3_opener(data_opener_ids[0]).get_open_data_params_schema(data_id)
+        if 'consolidated' in op_schema.properties:
+            open_params['consolidated'] = True
+        data = self.open_data(data_id, data_opener_ids[0], **open_params)
         return new_data_descriptor(data_id, data)
 
     def get_data_opener_ids(self, data_id: str = None, type_specifier: Optional[str] = None) -> Tuple[str, ...]:


### PR DESCRIPTION
This PR ensures that consolidated is used in the s3 store's describe data method when possible. This can be a notable performance boost when the dataset is large.