### PR TITLE
assert_condition -> assert_true

### DIFF
--- a/test/util/test_assert.py
+++ b/test/util/test_assert.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+from xcube.util.assertions import assert_true
+from xcube.util.assertions import assert_false
+from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_not_none
+from xcube.util.assertions import assert_given
+from xcube.util.assertions import assert_instance
+from xcube.util.assertions import assert_in
+
+
+class AssertTest(TestCase):
+    def test_assert_not_none(self):
+        assert_not_none(10, 'x')
+        with self.assertRaises(ValueError) as e:
+            assert_not_none(None, 'x')
+        self.assertEqual(('x must not be None',), e.exception.args)
+
+    def test_assert_given(self):
+        assert_given('data.txt', 'x')
+        with self.assertRaises(ValueError) as e:
+            assert_given('', 'x')
+        self.assertEqual(('x must be given',), e.exception.args)
+
+    def test_assert_instance(self):
+        assert_instance(10, int, 'x')
+        assert_instance('data.txt', (int, str), 'x')
+        with self.assertRaises(TypeError) as e:
+            assert_instance(0.5, (int, str), 'x')
+        self.assertEqual(("x must be an instance of "
+                          "(<class 'int'>, <class 'str'>), "
+                          "was <class 'float'>",),
+                         e.exception.args)
+
+    def test_assert_in(self):
+        assert_in(2, (1, 2, 3), 'x')
+        with self.assertRaises(ValueError) as e:
+            assert_in(4, (1, 2, 3), 'x')
+        self.assertEqual(('x must be one of (1, 2, 3)',), e.exception.args)
+
+    def test_assert_true(self):
+        assert_true(True, 'Should be true')
+        with self.assertRaises(ValueError) as e:
+            assert_true(False, 'Should be true')
+        self.assertEqual(('Should be true',), e.exception.args)
+
+    def test_assert_false(self):
+        assert_false(False, 'Should be false')
+        with self.assertRaises(ValueError) as e:
+            assert_false(True, 'Should be false')
+        self.assertEqual(('Should be false',), e.exception.args)
+
+    def test_assert_condition(self):
+        assert_condition(True, 'Should be true')
+        with self.assertRaises(ValueError) as e:
+            assert_condition(False, 'Should be true')
+        self.assertEqual(('Should be true',), e.exception.args)

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -25,7 +25,7 @@ from typing import Optional, Any, Sequence, Mapping, Tuple, Union, Dict
 
 import pyproj
 
-from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonArraySchema
@@ -45,7 +45,8 @@ class InputConfig(JsonObject):
                  data_id: str = None,
                  store_params: Mapping[str, Any] = None,
                  open_params: Mapping[str, Any] = None):
-        assert_condition(store_id or opener_id, 'One of store_id and opener_id must be given')
+        assert_true(store_id or opener_id,
+                    'One of store_id and opener_id must be given')
         assert_given(data_id, 'data_id')
         self.store_id = store_id
         self.opener_id = opener_id
@@ -60,8 +61,10 @@ class InputConfig(JsonObject):
                 store_id=JsonStringSchema(min_length=1),
                 opener_id=JsonStringSchema(min_length=1),
                 data_id=JsonStringSchema(min_length=1),
-                store_params=JsonObjectSchema(additional_properties=True, nullable=True),
-                open_params=JsonObjectSchema(additional_properties=True, nullable=True)
+                store_params=JsonObjectSchema(additional_properties=True,
+                                              nullable=True),
+                open_params=JsonObjectSchema(additional_properties=True,
+                                             nullable=True)
             ),
             additional_properties=False,
             required=['data_id'],
@@ -73,7 +76,8 @@ class CallbackConfig(JsonObject):
     def __init__(self,
                  api_uri: str = None,
                  access_token: str = None):
-        assert_condition(api_uri and access_token, 'Both, api_uri and access_token must be given')
+        assert_true(api_uri and access_token,
+                    'Both, api_uri and access_token must be given')
         self.api_uri = api_uri
         self.access_token = access_token
 
@@ -99,7 +103,8 @@ class OutputConfig(JsonObject):
                  store_params: Mapping[str, Any] = None,
                  write_params: Mapping[str, Any] = None,
                  replace: bool = None):
-        assert_condition(store_id or writer_id, 'One of store_id and writer_id must be given')
+        assert_true(store_id or writer_id,
+                    'One of store_id and writer_id must be given')
         self.store_id = store_id
         self.writer_id = writer_id
         self.data_id = data_id
@@ -114,8 +119,10 @@ class OutputConfig(JsonObject):
                 store_id=JsonStringSchema(min_length=1),
                 writer_id=JsonStringSchema(min_length=1),
                 data_id=JsonStringSchema(default=None),
-                store_params=JsonObjectSchema(additional_properties=True, nullable=True),
-                write_params=JsonObjectSchema(additional_properties=True, nullable=True),
+                store_params=JsonObjectSchema(additional_properties=True,
+                                              nullable=True),
+                write_params=JsonObjectSchema(additional_properties=True,
+                                              nullable=True),
                 replace=JsonBooleanSchema(default=False),
             ),
             additional_properties=False,
@@ -139,7 +146,7 @@ class CubeConfig(JsonObject):
 
         self.variable_names = None
         if variable_names is not None:
-            assert_condition(len(variable_names) > 0, 'variable_names is invalid')
+            assert_true(len(variable_names) > 0, 'variable_names is invalid')
             self.variable_names = tuple(map(str, variable_names))
 
         self.crs = None
@@ -153,7 +160,7 @@ class CubeConfig(JsonObject):
 
         self.bbox = None
         if bbox is not None:
-            assert_condition(len(bbox) == 4, 'bbox is invalid')
+            assert_true(len(bbox) == 4, 'bbox is invalid')
             self.bbox = tuple(map(float, bbox))
 
         self.spatial_res = None
@@ -169,14 +176,17 @@ class CubeConfig(JsonObject):
                 try:
                     tile_width, tile_height = tile_size
                 except (ValueError, TypeError):
-                    raise ValueError('tile_size must be an integer or a pair of integers')
-                assert_instance(tile_width, numbers.Number, 'tile_width of tile_size')
-                assert_instance(tile_height, numbers.Number, 'tile_height of tile_size')
+                    raise ValueError('tile_size must be an integer '
+                                     'or a pair of integers')
+                assert_instance(tile_width, numbers.Number,
+                                'tile_width of tile_size')
+                assert_instance(tile_height, numbers.Number,
+                                'tile_height of tile_size')
             self.tile_size = tile_width, tile_height
 
         self.time_range = None
         if time_range is not None:
-            assert_condition(len(time_range) == 2, 'time_range is invalid')
+            assert_true(len(time_range) == 2, 'time_range is invalid')
             self.time_range = tuple(time_range)
 
         self.time_period = None
@@ -228,7 +238,8 @@ class CubeConfig(JsonObject):
                 ),
                 chunks=JsonObjectSchema(
                     nullable=True,
-                    additional_properties=JsonIntegerSchema(nullable=True, minimum=1)
+                    additional_properties=JsonIntegerSchema(nullable=True,
+                                                            minimum=1)
                 ),
             ),
             additional_properties=False,

--- a/xcube/core/gen2/generator.py
+++ b/xcube/core/gen2/generator.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Any
 
 from xcube.core.store import DataStorePool
-from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_instance
 from xcube.util.progress import observe_progress
 from .combiner import CubesCombiner
@@ -62,24 +62,29 @@ class CubeGenerator(ABC):
         at the same time.
 
         :param gen_config_path: Cube generation configuration. It may be
-            provided as a JSON or YAML file (file extensions ".json" or ".yaml").
+            provided as a JSON or YAML file
+            (file extensions ".json" or ".yaml").
             If None is passed, it is expected that
             the cube generator configuration is piped as a JSON string.
-        :param stores_config_path: A path to a JSON or YAML file that represents
-            mapping of store names to rized stores.
-        :param service_config_path: A path to a JSON or YAML file that configures an
-            xcube generator service.
+        :param stores_config_path: A path to a JSON or YAML file that
+            represents a mapping of store names to configured data stores.
+        :param service_config_path: A path to a JSON or YAML file
+            that configures an xcube generator service.
         :param verbosity: Level of verbosity, 0 means off.
         """
-        assert_instance(gen_config_path, (str, type(None)), 'gen_config_path')
-        assert_instance(stores_config_path, (str, type(None)), 'stores_config_path')
-        assert_instance(service_config_path, (str, type(None)), 'service_config_path')
-        assert_condition(not (stores_config_path is not None and
-                              service_config_path is not None),
-                         'stores_config_path and service_config_path cannot be'
-                         ' given at the same time.')
+        assert_instance(gen_config_path, (str, type(None)),
+                        'gen_config_path')
+        assert_instance(stores_config_path, (str, type(None)),
+                        'stores_config_path')
+        assert_instance(service_config_path, (str, type(None)),
+                        'service_config_path')
+        assert_true(not (stores_config_path is not None and
+                         service_config_path is not None),
+                    'stores_config_path and service_config_path cannot be'
+                    ' given at the same time.')
 
-        request = CubeGeneratorRequest.from_file(gen_config_path, verbosity=verbosity)
+        request = CubeGeneratorRequest.from_file(gen_config_path,
+                                                 verbosity=verbosity)
 
         if service_config_path is not None:
             from .service import ServiceConfig
@@ -183,5 +188,6 @@ class LocalCubeGenerator(CubeGenerator):
         return data_id
 
     def get_cube_info(self) -> CubeInfo:
-        informant = CubeInformant(request=self._request, store_pool=self._store_pool)
+        informant = CubeInformant(request=self._request,
+                                  store_pool=self._store_pool)
         return informant.generate()

--- a/xcube/core/gen2/informant.py
+++ b/xcube/core/gen2/informant.py
@@ -30,7 +30,7 @@ import pyproj
 from xcube.core.store import DataStorePool
 from xcube.core.store import DatasetDescriptor
 from xcube.core.store import VariableDescriptor
-from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_instance
 from .config import CubeConfig
 from .describer import DatasetsDescriber
@@ -185,7 +185,7 @@ class CubeInformant:
         if spatial_res is None:
             spatial_res = self.first_input_dataset_descriptor.spatial_res
         assert_instance(spatial_res, numbers.Number, 'spatial_res')
-        assert_condition(spatial_res > 0, 'spatial_res must be positive')
+        assert_true(spatial_res > 0, 'spatial_res must be positive')
 
         tile_size = cube_config.tile_size
         if tile_size is not None:

--- a/xcube/core/gen2/opener.py
+++ b/xcube/core/gen2/opener.py
@@ -31,7 +31,7 @@ from xcube.core.store import TYPE_SPECIFIER_CUBE
 from xcube.core.store import TYPE_SPECIFIER_DATASET
 from xcube.core.store import get_data_store_instance
 from xcube.core.store import new_data_opener
-from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_instance
 from xcube.util.progress import observe_progress
 from .config import CubeConfig
@@ -48,8 +48,8 @@ class CubesOpener:
                  input_configs: Sequence[InputConfig],
                  cube_config: CubeConfig,
                  store_pool: DataStorePool = None):
-        assert_condition(len(input_configs) > 0,
-                         'At least one input must be given')
+        assert_true(len(input_configs) > 0,
+                    'At least one input must be given')
         assert_instance(cube_config, CubeConfig, 'cube_config')
         if store_pool is not None:
             assert_instance(store_pool, DataStorePool, 'store_pool')

--- a/xcube/core/gen2/progress.py
+++ b/xcube/core/gen2/progress.py
@@ -27,8 +27,10 @@ from typing import Sequence
 import requests
 
 from xcube.core.gen2.config import CallbackConfig
-from xcube.util.assertions import assert_given, assert_condition
-from xcube.util.progress import ProgressState, ProgressObserver
+from xcube.util.assertions import assert_given
+from xcube.util.assertions import assert_true
+from xcube.util.progress import ProgressState
+from xcube.util.progress import ProgressObserver
 
 
 def _format_time(t):
@@ -65,8 +67,8 @@ class _ThreadedProgressObserver(ProgressObserver):
         :type minimum: float
         """
         super().__init__()
-        assert_condition(dt >= 0, "The timer's time step must be >=0")
-        assert_condition(minimum >= 0, "The timer's minimum must be >=0")
+        assert_true(dt >= 0, "The timer's time step must be >=0")
+        assert_true(minimum >= 0, "The timer's minimum must be >=0")
         self._running = False
         self._start_time = None
         self._minimum = minimum
@@ -136,7 +138,10 @@ class _ThreadedProgressObserver(ProgressObserver):
         if self._running and len(state_stack) == 1:
             self._stop_timer(False)
 
-    def callback(self, sender: str, elapsed: float, state_stack: Sequence[ProgressState]):
+    def callback(self,
+                 sender: str,
+                 elapsed: float,
+                 state_stack: Sequence[ProgressState]):
         """
 
         :param sender:
@@ -147,14 +152,21 @@ class _ThreadedProgressObserver(ProgressObserver):
 
 
 class ApiProgressCallbackObserver(_ThreadedProgressObserver):
-    def __init__(self, callback_config: CallbackConfig, minimum: float = 0, dt: float = 1, timeout: float = False):
+    def __init__(self,
+                 callback_config: CallbackConfig,
+                 minimum: float = 0,
+                 dt: float = 1,
+                 timeout: float = False):
         super().__init__(minimum=minimum, dt=dt, timeout=timeout)
-        assert_condition(callback_config.api_uri and callback_config.access_token,
-                         "Both, api_uri and access_token must be given.")
+        assert_true(callback_config.api_uri and callback_config.access_token,
+                    "Both, api_uri and access_token must be given.")
 
         self.callback_config = callback_config
 
-    def callback(self, sender: str, elapsed: float, state_stack: Sequence[ProgressState]):
+    def callback(self,
+                 sender: str,
+                 elapsed: float,
+                 state_stack: Sequence[ProgressState]):
         assert_given(state_stack, "ProgressStates")
         state = state_stack[0]
         callback = {
@@ -175,17 +187,17 @@ class ApiProgressCallbackObserver(_ThreadedProgressObserver):
 
 
 class TerminalProgressCallbackObserver(_ThreadedProgressObserver):
-    def __init__(self, minimum: float = 0, dt: float = 1, timeout: float = False):
+    def __init__(self,
+                 minimum: float = 0,
+                 dt: float = 1,
+                 timeout: float = False):
         super().__init__(minimum=minimum, dt=dt, timeout=timeout)
 
-    def callback(self, sender: str, elapsed: float, state_stack: [ProgressState], prt: bool = True):
-        """
-
-        :param state_stack:
-        :param sender:
-        :param elapsed:
-        """
-
+    def callback(self,
+                 sender: str,
+                 elapsed: float,
+                 state_stack: [ProgressState],
+                 prt: bool = True):
         state = state_stack[0]
 
         bar = "#" * int(state.total_work * state.progress)
@@ -216,16 +228,23 @@ class ConsoleProgressObserver(ProgressObserver):
             print(self._format_progress(state_stack, status_label='done.'))
 
     @classmethod
-    def _format_progress(cls, state_stack: Sequence[ProgressState], status_label=None) -> str:
+    def _format_progress(cls,
+                         state_stack: Sequence[ProgressState],
+                         status_label=None) -> str:
         if status_label:
             state_stack_part = cls._format_state_stack(state_stack[0:-1])
-            state_part = cls._format_state(state_stack[-1], marker=status_label)
-            return state_part if not state_stack_part else state_stack_part + ': ' + state_part
+            state_part = cls._format_state(state_stack[-1],
+                                           marker=status_label)
+            return state_part \
+                if not state_stack_part \
+                else state_stack_part + ': ' + state_part
         else:
             return cls._format_state_stack(state_stack)
 
     @classmethod
-    def _format_state_stack(cls, state_stack: Sequence[ProgressState], marker=None) -> str:
+    def _format_state_stack(cls,
+                            state_stack: Sequence[ProgressState],
+                            marker=None) -> str:
         return ': '.join([cls._format_state(s) for s in state_stack])
 
     @classmethod

--- a/xcube/core/gen2/request.py
+++ b/xcube/core/gen2/request.py
@@ -28,7 +28,7 @@ import jsonschema
 import yaml
 
 from xcube.core.gen2.error import CubeGeneratorError
-from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_given
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonObject
@@ -59,8 +59,10 @@ class CubeGeneratorRequest(JsonObject):
                  cube_config: CubeConfig = None,
                  output_config: OutputConfig = None,
                  callback_config: Optional[CallbackConfig] = None):
-        assert_condition(input_config or input_configs, 'one of input_config and input_configs must be given')
-        assert_condition(not (input_config and input_configs), 'input_config and input_configs cannot be given both')
+        assert_true(input_config or input_configs,
+                    'one of input_config and input_configs must be given')
+        assert_true(not (input_config and input_configs),
+                    'input_config and input_configs cannot be given both')
         if input_config:
             input_configs = [input_config]
         assert_given(input_configs, 'input_configs')
@@ -76,7 +78,9 @@ class CubeGeneratorRequest(JsonObject):
         return JsonObjectSchema(
             properties=dict(
                 input_config=InputConfig.get_schema(),
-                input_configs=JsonArraySchema(items=InputConfig.get_schema(), min_items=1),
+                input_configs=JsonArraySchema(
+                    items=InputConfig.get_schema(), min_items=1
+                ),
                 cube_config=CubeConfig.get_schema(),
                 output_config=OutputConfig.get_schema(),
                 callback_config=CallbackConfig.get_schema()
@@ -109,24 +113,34 @@ class CubeGeneratorRequest(JsonObject):
             raise CubeGeneratorError(f'{e}') from e
 
     @classmethod
-    def from_file(cls, request_file: Optional[str], verbosity: int = 0) -> 'CubeGeneratorRequest':
-        """Create new instance from a JSON file, or YAML file, or JSON passed via stdin."""
-        gen_config_dict = cls._load_gen_config_file(request_file, verbosity=verbosity)
+    def from_file(cls, request_file: Optional[str], verbosity: int = 0) \
+            -> 'CubeGeneratorRequest':
+        """
+        Create new instance from a JSON file, or YAML file,
+        or JSON passed via stdin.
+        """
+        gen_config_dict = cls._load_gen_config_file(request_file,
+                                                    verbosity=verbosity)
         if verbosity:
-            print(f'Cube generator configuration loaded from {request_file or "TTY"}.')
+            print(f'Cube generator configuration loaded '
+                  f'from {request_file or "TTY"}.')
         return cls.from_dict(gen_config_dict)
 
     @classmethod
-    def _load_gen_config_file(cls, gen_config_file: Optional[str], verbosity: int = 0) -> Dict:
+    def _load_gen_config_file(cls,
+                              gen_config_file: Optional[str],
+                              verbosity: int = 0) -> Dict:
 
         if gen_config_file is not None and not os.path.exists(gen_config_file):
-            raise CubeGeneratorError(f'Cube generator configuration "{gen_config_file}" not found.')
+            raise CubeGeneratorError(f'Cube generator configuration '
+                                     f'"{gen_config_file}" not found.')
 
         try:
             if gen_config_file is None:
                 if not sys.stdin.isatty():
                     if verbosity:
-                        print('Awaiting generator configuration JSON from TTY...')
+                        print('Awaiting generator'
+                              ' configuration JSON from TTY...')
                     return json.load(sys.stdin)
             else:
                 with open(gen_config_file, 'r') as fp:
@@ -135,6 +149,7 @@ class CubeGeneratorRequest(JsonObject):
                     else:
                         return yaml.safe_load(fp)
         except BaseException as e:
-            raise CubeGeneratorError(f'Error loading generator configuration "{gen_config_file}": {e}') from e
+            raise CubeGeneratorError(f'Error loading generator configuration'
+                                     f' "{gen_config_file}": {e}') from e
 
         raise CubeGeneratorError(f'Missing cube generator configuration.')

--- a/xcube/core/store/stores/s3.py
+++ b/xcube/core/store/stores/s3.py
@@ -45,7 +45,7 @@ from xcube.core.store import new_data_descriptor
 from xcube.core.store import new_data_opener
 from xcube.core.store import new_data_writer
 from xcube.core.store.accessors.dataset import S3Mixin
-from xcube.util.assertions import assert_condition
+from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_in
 from xcube.util.assertions import assert_instance
@@ -93,8 +93,8 @@ class S3DataStore(DefaultSearchMixin, MutableDataStore):
         self._s3, store_params = S3Mixin.consume_s3fs_params(store_params)
         self._bucket_name, store_params = S3Mixin.consume_bucket_name_param(store_params)
         assert_given(self._bucket_name, 'bucket_name')
-        assert_condition(not store_params,
-                         f'Unknown keyword arguments: {", ".join(store_params.keys())}')
+        assert_true(not store_params,
+                    f'Unknown keyword arguments: {", ".join(store_params.keys())}')
         self._registry = {}
         if self._s3.exists(f'{self._bucket_name}/{_REGISTRY_FILE}'):
             with self._s3.open(f'{self._bucket_name}/{_REGISTRY_FILE}', 'r') as registry_file:
@@ -194,7 +194,7 @@ class S3DataStore(DefaultSearchMixin, MutableDataStore):
                     type_specifier=type_specifier,
                     format_id=acc_format,
                     storage_id=acc_storage_id)
-        ))
+            ))
         return tuple(ext.name for ext in find_data_opener_extensions(
             predicate=get_data_accessor_predicate(type_specifier=type_specifier,
                                                   storage_id=_STORAGE_ID)

--- a/xcube/core/store/typespecifier.py
+++ b/xcube/core/store/typespecifier.py
@@ -29,15 +29,17 @@ import xarray as xr
 
 from xcube.core.mldataset import MultiLevelDataset
 from xcube.core.verify import verify_cube
-from xcube.util.assertions import assert_given, assert_condition
+from xcube.util.assertions import assert_given
+from xcube.util.assertions import assert_true
 from xcube.util.jsonschema import JsonStringSchema
 
 
 class TypeSpecifier:
     """
-    A type specifier denotes a type of data. It is used to group similar types of data and
-    distinguish between different types of data. It can be used by stores to state what
-    types of data can be read from and/or written to them.
+    A type specifier denotes a type of data. It is used to group similar types
+    of data and distinguish between different types of data. It can be used
+    by stores to state what types of data can be read from and/or written
+    to them.
 
     A type specifier consists of a name and an arbitrary number of flags.
     Flags can be used to further refine a type specifier if needed.
@@ -84,14 +86,16 @@ class TypeSpecifier:
 
     def satisfies(self, other: Union[str, "TypeSpecifier"]) -> bool:
         """
-        Tests whether this type specifier satisfies (the requirements of) another type specifier.
+        Tests whether this type specifier satisfies (the requirements of)
+        another type specifier.
 
         This type specifier satisfies type specifier *other*
 
         1. if either this or *other* is "*" (= any) or
         2. if the type names of this and *other* are equal and
           - if *other* has no flags or
-          - if all the flags of *other* are a subset of the flags (if any) of this type specifier.
+          - if all the flags of *other* are a subset of the flags (if any)
+            of this type specifier.
 
         :param other: Another type specifier, as string or *TypeSpecifier*.
         :return: Whether this type specifier satisfies another type specifier.
@@ -107,10 +111,11 @@ class TypeSpecifier:
 
     def is_satisfied_by(self, other: Union[str, "TypeSpecifier"]) -> bool:
         """
-        Tests whether this type specifier is satisfied by another type specifier.
+        Tests whether this type specifier is satisfied by another
+        type specifier.
 
-        This is the inverse operation of :meth:satisfies and may be more handy
-        or intuitive in some situations. It is equivalent to:
+        This is the inverse operation of :meth:satisfies and may
+        be more handy or intuitive in some situations. It is equivalent to:
 
             self.normalize(other).satisfies(self)
 
@@ -120,19 +125,22 @@ class TypeSpecifier:
         return self.normalize(other).satisfies(self)
 
     @classmethod
-    def normalize(cls, type_specifier: Union[str, "TypeSpecifier"]) -> "TypeSpecifier":
+    def normalize(cls, type_specifier: Union[str, "TypeSpecifier"]) \
+            -> "TypeSpecifier":
         if isinstance(type_specifier, TypeSpecifier):
             return type_specifier
         if isinstance(type_specifier, str):
             return cls.parse(type_specifier)
-        raise TypeError('type_specifier must be of type "str" or "TypeSpecifier"')
+        raise TypeError('type_specifier must be of type '
+                        '"str" or "TypeSpecifier"')
 
     @classmethod
     def parse(cls, type_specifier: str) -> "TypeSpecifier":
         if '[' not in type_specifier:
             return TypeSpecifier(type_specifier)
         if not type_specifier.endswith(']'):
-            raise SyntaxError(f'"{type_specifier}" cannot be parsed: No end brackets found')
+            raise SyntaxError(f'"{type_specifier}" cannot be parsed: '
+                              f'No end brackets found')
         name = type_specifier.split('[')[0]
         flags = type_specifier.split('[')[1].split(']')[0].split(',')
         return TypeSpecifier(name, flags=set(flags))
@@ -145,17 +153,23 @@ class TypeSpecifier:
             serializer=str
         )
 
-    def assert_satisfies(self, other: Union[str, 'TypeSpecifier'], name: str = None):
-        assert_condition(self.satisfies(other),
-                         f'{name or "type_specifier"} must satisfy type specifier "{other}",'
-                         f' but was "{self}"')
+    def assert_satisfies(self,
+                         other: Union[str, 'TypeSpecifier'],
+                         name: str = None):
+        assert_true(self.satisfies(other),
+                    f'{name or "type_specifier"} must satisfy'
+                    f' type specifier "{other}",'
+                    f' but was "{self}"')
 
 
 TYPE_SPECIFIER_ANY = TypeSpecifier('*')
 TYPE_SPECIFIER_DATASET = TypeSpecifier('dataset')
-TYPE_SPECIFIER_CUBE = TypeSpecifier('dataset', flags={'cube'})
-TYPE_SPECIFIER_MULTILEVEL_DATASET = TypeSpecifier('dataset', flags={'multilevel'})
-TYPE_SPECIFIER_MULTILEVEL_CUBE = TypeSpecifier('dataset', flags={'multilevel', 'cube'})
+TYPE_SPECIFIER_CUBE = TypeSpecifier('dataset',
+                                    flags={'cube'})
+TYPE_SPECIFIER_MULTILEVEL_DATASET = TypeSpecifier('dataset',
+                                                  flags={'multilevel'})
+TYPE_SPECIFIER_MULTILEVEL_CUBE = TypeSpecifier('dataset',
+                                               flags={'multilevel', 'cube'})
 TYPE_SPECIFIER_GEODATAFRAME = TypeSpecifier('geodataframe')
 
 

--- a/xcube/util/assertions.py
+++ b/xcube/util/assertions.py
@@ -18,31 +18,115 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
 from typing import Any, Union, Tuple, Type, Container
+import warnings
 
 _DEFAULT_NAME = 'value'
 
 
-def assert_not_none(value: Any, name: str = None):
+def assert_not_none(value: Any, name: str = None,
+                    exception_type: Type[Exception] = ValueError):
+    """
+    Assert *value* is not None.
+    Otherwise raise *exception_type*.
+
+    :param value: The value to test.
+    :param name: Name of a variable that holds *value*.
+    :param exception_type: The exception type. Default is ```ValueError```.
+    """
     if value is None:
-        raise ValueError(f'{name or _DEFAULT_NAME} must not be None')
+        raise exception_type(f'{name or _DEFAULT_NAME} must not be None')
 
 
-def assert_given(value: Any, name: str = None):
+def assert_given(value: Any,
+                 name: str = None,
+                 exception_type: Type[Exception] = ValueError):
+    """
+    Assert *value* is not False when converted into a Boolean value.
+    Otherwise raise *exception_type*.
+
+    :param value: The value to test.
+    :param name: Name of a variable that holds *value*.
+    :param exception_type: The exception type. Default is ```ValueError```.
+    """
     if not value:
-        raise ValueError(f'{name or _DEFAULT_NAME} must be given')
+        raise exception_type(f'{name or _DEFAULT_NAME} must be given')
 
 
-def assert_instance(value: Any, dtype: Union[Type, Tuple[Type, ...]], name: str = None):
+def assert_instance(value: Any,
+                    dtype: Union[Type, Tuple[Type, ...]],
+                    name: str = None,
+                    exception_type: Type[Exception] = TypeError):
+    """
+    Assert *value* is an instance of data type *dtype*.
+    Otherwise raise *exception_type*.
+
+    :param value: The value to test.
+    :param dtype: A type or tuple of types.
+    :param name: Name of a variable that holds *value*.
+    :param exception_type: The exception type. Default is ```TypeError```.
+    """
     if not isinstance(value, dtype):
-        raise TypeError(f'{name or _DEFAULT_NAME} must be an instance of {dtype}, was {type(value)}')
+        raise exception_type(f'{name or _DEFAULT_NAME} '
+                             f'must be an instance of '
+                             f'{dtype}, was {type(value)}')
 
 
-def assert_in(value: Any, container: Container, name: str = None):
+def assert_in(value: Any,
+              container: Container,
+              name: str = None,
+              exception_type: Type[Exception] = ValueError):
+    """
+    Assert *value* is a member of *container*.
+    Otherwise raise *exception_type*.
+
+    :param value: The value to test for membership.
+    :param container: The container.
+    :param name: Name of a variable that holds *value*.
+    :param exception_type: The exception type. Default is ```ValueError```.
+    """
     if value not in container:
-        raise ValueError(f'{name or _DEFAULT_NAME} must be one of {container}')
+        raise exception_type(f'{name or _DEFAULT_NAME} '
+                             f'must be one of {container}')
 
 
-def assert_condition(condition: Any, message: str):
+def assert_true(value: Any,
+                message: str,
+                exception_type: Type[Exception] = ValueError):
+    """
+    Assert *value* is true after conversion into a Boolean value.
+    Otherwise raise *exception_type*.
+
+    :param value: The value to test.
+    :param message: The error message used if the assertion fails.
+    :param exception_type: The exception type. Default is ```ValueError```.
+    """
+    if not value:
+        raise exception_type(message)
+
+
+def assert_false(value: Any,
+                 message: str,
+                 exception_type: Type[Exception] = ValueError):
+    """
+    Assert *value* is false after conversion into a Boolean value.
+    Otherwise raise *exception_type*.
+
+    :param value: The value to test.
+    :param message: The error message used if the assertion fails.
+    :param exception_type: The exception type. Default is ```ValueError```.
+    """
+    if value:
+        raise exception_type(message)
+
+
+def assert_condition(condition: Any,
+                     message: str,
+                     exception_type: Type[Exception] = ValueError):
+    """Deprecated. Use assert_true()"""
+    warnings.warn('assert_condition() has been deprecated. '
+                  'Use assert_true() or assert_false() instead.',
+                  DeprecationWarning)
     if not condition:
-        raise ValueError(message)
+        raise exception_type(message)


### PR DESCRIPTION
Refactoring of the `xcube.util.assert` module:

* Added `assert_true()` and `assert_false()` assertions.
* Deprecated `assert_condition()` in favor of `assert_true()`.
* Replaced occurences of  `assert_condition()` by `assert_true()`.
* All assertions now have new kwarg `exception_type`.
* Added docstrings for all assertions.
* Added unit tests for all assertions.

FYI @AliceBalfanz @dzelge @pont-us 
@TonioF you should just focus on changes in `xcube/util/assert.py`. Other changes are mostly due to renaming.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `docs/CHANGES.md`~
* [ ] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] ~Associated issues closed after merge~