### PR TITLE
Fix broken build and #434

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,21 @@
 ## Changes in 0.8.2 (in development)
 
-* Fixed the issue that xcube gen2 would not print tracebacks to stderr when raising
-  CubeGeneratorErrors (#448).
-* Enhanced `xcube.core.normalize.normalize_dataset()` function to also normalize datasets with latitudes given as 
+* Fixed the issue that xcube gen2 would not print tracebacks to stderr 
+  when raising errors of type `CubeGeneratorError` (#448).
+* Enhanced `xcube.core.normalize.normalize_dataset()` function to also 
+  normalize datasets with latitudes given as 
   `latitude_centers` and to invert decreasing latitude coordinate values.
-* Introduced `xcube.core.normalize.cubify_dataset()` function to normalize a dataset 
-  and finally assert the result complies to the [xcube dataset conventions](https://github.com/dcs4cop/xcube/blob/master/docs/source/cubespec.md).
-* Fixed that data stores `directory` and `s3` were not able to handle data identifiers that they
-  had assigned themselves during `write_data()`.  (#450)
+* Introduced `xcube.core.normalize.cubify_dataset()` function to normalize 
+  a dataset and finally assert the result complies to the 
+  [xcube dataset conventions](https://github.com/dcs4cop/xcube/blob/master/docs/source/cubespec.md).
+* Fixed that data stores `directory` and `s3` were not able to handle data 
+  identifiers that they had assigned themselves during `write_data()`.  
+  (#450)
+* The `xcube.core.extract.get_cube_values_for_points()` function has been 
+  enhanced to also accept lists or tuples in the item values of 
+  the `points` arguments. (#431)   
+* Fixed exception raised in `xcube extract` CLI tool when called with the 
+  `--ref` option. This issue occurred with `xarray 0.18.2+`.
 
 ## Changes in 0.8.1
 

--- a/test/core/test_extract.py
+++ b/test/core/test_extract.py
@@ -4,7 +4,9 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from xcube.core.extract import get_cube_point_indexes, get_cube_values_for_points, get_dataset_indexes
+from xcube.core.extract import get_cube_point_indexes
+from xcube.core.extract import get_cube_values_for_points
+from xcube.core.extract import get_dataset_indexes
 from xcube.core.new import new_cube
 
 
@@ -26,9 +28,8 @@ class GetCubeValuesForPointsTest(unittest.TestCase):
                                    "2010-01-20", "2010-01-01",
                                    "2010-01-05", "2010-01-03",
                                    ], dtype="datetime64[ns]"),
-                    lat=np.array([50.0, 51.3, 49.7, 50.1, 51.9, 50.8, 50.2, 52.0]),
-                    lon=np.array([0.0, 0.1, 0.4, 2.9, 1.6, 0.7, -0.5, 4.0]),
-                    )
+                    lat=[50.0, 51.3, 49.7, 50.1, 51.9, 50.8, 50.2, 52.0],
+                    lon=np.array([0.0, 0.1, 0.4, 2.9, 1.6, 0.7, -0.5, 4.0]))
 
     def test_get_cube_point_values_from_data_frame(self):
         self._test_get_cube_point_values(pd.DataFrame(self._new_test_points()))
@@ -42,8 +43,10 @@ class GetCubeValuesForPointsTest(unittest.TestCase):
     def _test_get_cube_point_values(self, points):
         cube = self._new_test_cube()
 
-        expected_prec_values = [0.6, np.nan, np.nan, 0.6, 0.6, 0.6, np.nan, 0.6]
-        expected_temp_values = [276.2, np.nan, np.nan, 276.2, 276.2, 276.2, np.nan, 276.2]
+        expected_prec_values = [0.6, np.nan, np.nan,
+                                0.6, 0.6, 0.6, np.nan, 0.6]
+        expected_temp_values = [276.2, np.nan, np.nan,
+                                276.2, 276.2, 276.2, np.nan, 276.2]
         expected_time_index = [3, -1, 7, 5, 19, 0, 4, 2]
         expected_lat_index = [0, 650, -1, 50, 950, 400, 100, 999]
         expected_lon_index = [0, 50, 200, 1450, 800, 349, -1, 1999]
@@ -57,33 +60,45 @@ class GetCubeValuesForPointsTest(unittest.TestCase):
             'lon_index',
             'time_index'},
             set(values.data_vars))
-        np.testing.assert_array_almost_equal(np.array(expected_prec_values, dtype=np.float64),
+        np.testing.assert_array_almost_equal(np.array(expected_prec_values,
+                                                      dtype=np.float64),
                                              values["precipitation"].values)
-        np.testing.assert_array_almost_equal(np.array(expected_temp_values, dtype=np.float64),
+        np.testing.assert_array_almost_equal(np.array(expected_temp_values,
+                                                      dtype=np.float64),
                                              values["temperature"].values)
-        np.testing.assert_array_equal(np.array(expected_time_index, dtype=np.int64),
+        np.testing.assert_array_equal(np.array(expected_time_index,
+                                               dtype=np.int64),
                                       values["time_index"].values)
-        np.testing.assert_array_equal(np.array(expected_lat_index, dtype=np.int64),
+        np.testing.assert_array_equal(np.array(expected_lat_index,
+                                               dtype=np.int64),
                                       values["lat_index"].values)
-        np.testing.assert_array_equal(np.array(expected_lon_index, dtype=np.int64),
+        np.testing.assert_array_equal(np.array(expected_lon_index,
+                                               dtype=np.int64),
                                       values["lon_index"].values)
 
     def test_get_cube_point_indexes(self):
         cube = self._new_test_cube()
 
-        expected_time_index = [3., np.nan, 7., 5., 19., 0., 4., 2.]
-        expected_lat_index = [0., 650., np.nan, 50., 950, 400., 100., 1000. - 1e-9]
-        expected_lon_index = [0., 50., 200., 1450., 800., 350., np.nan, 2000. - 1e-9]
+        expected_time_index = [3., np.nan, 7.,
+                               5., 19., 0., 4., 2.]
+        expected_lat_index = [0., 650., np.nan,
+                              50., 950, 400., 100., 1000. - 1e-9]
+        expected_lon_index = [0., 50., 200.,
+                              1450., 800., 350., np.nan, 2000. - 1e-9]
 
         indexes = get_cube_point_indexes(cube, self._new_test_points())
         self.assertIsInstance(indexes, xr.Dataset)
         self.assertEqual(3, len(indexes.data_vars))
-        self.assertEqual({'time_index', 'lat_index', 'lon_index'}, set(indexes.data_vars))
-        np.testing.assert_array_almost_equal(np.array(expected_time_index, dtype=np.float64),
+        self.assertEqual({'time_index', 'lat_index', 'lon_index'},
+                         set(indexes.data_vars))
+        np.testing.assert_array_almost_equal(np.array(expected_time_index,
+                                                      dtype=np.float64),
                                              indexes["time_index"].values)
-        np.testing.assert_array_almost_equal(np.array(expected_lat_index, dtype=np.float64),
+        np.testing.assert_array_almost_equal(np.array(expected_lat_index,
+                                                      dtype=np.float64),
                                              indexes["lat_index"].values)
-        np.testing.assert_array_almost_equal(np.array(expected_lon_index, dtype=np.float64),
+        np.testing.assert_array_almost_equal(np.array(expected_lon_index,
+                                                      dtype=np.float64),
                                              indexes["lon_index"].values)
 
 
@@ -95,49 +110,72 @@ class GetDatasetIndexesTest(unittest.TestCase):
         cell = dataset.isel(time=2, lat=20, lon=30)
         with self.assertRaises(ValueError) as cm:
             get_dataset_indexes(cell, "lon", np.array([-149.5]))
-        self.assertEqual("cannot determine cell boundaries for coordinate variable 'lon' of size 1",
+        self.assertEqual("cannot determine cell boundaries"
+                         " for coordinate variable 'lon' of size 1",
                          f"{cm.exception}")
 
     def test_get_dataset_indexes_with_bounds(self):
-        dataset = new_cube(width=360, height=180, drop_bounds=False)
+        dataset = new_cube(width=360, height=180,
+                           drop_bounds=False)
         self._assert_get_dataset_indexes_works(dataset)
 
     def test_get_dataset_indexes_without_bounds(self):
-        dataset = new_cube(width=360, height=180, drop_bounds=True)
+        dataset = new_cube(width=360, height=180,
+                           drop_bounds=True)
         self._assert_get_dataset_indexes_works(dataset)
 
     def test_get_dataset_indexes_with_bounds_inverse_lat(self):
-        dataset = new_cube(width=360, height=180, inverse_y=True, drop_bounds=False)
+        dataset = new_cube(width=360, height=180,
+                           inverse_y=True, drop_bounds=False)
         self._assert_get_dataset_indexes_works(dataset, inverse_lat=True)
 
     def test_get_dataset_indexes_without_bounds_inverse_lat(self):
-        dataset = new_cube(width=360, height=180, inverse_y=True, drop_bounds=True)
+        dataset = new_cube(width=360, height=180,
+                           inverse_y=True, drop_bounds=True)
         self._assert_get_dataset_indexes_works(dataset, inverse_lat=True)
 
     def _assert_get_dataset_indexes_works(self, dataset, inverse_lat=False):
         # - lon -------------------------------------
 
-        lon_coords = np.array([-190, -180., -179, -10.4, 0., 10.4, 179., 180.0, 190])
-        expected_lon_int64 = np.array([-1, 0, 1, 169, 180, 190, 359, 359, -1], dtype=np.int64)
-        expected_lon_float64 = np.array([np.nan, 0., 1., 169.6, 180., 190.4, 359., 360., np.nan], dtype=np.float64)
+        lon_coords = np.array([-190, -180., -179,
+                               -10.4, 0., 10.4, 179., 180.0, 190])
+        expected_lon_int64 = np.array([-1, 0, 1,
+                                       169, 180, 190,
+                                       359, 359, -1],
+                                      dtype=np.int64)
+        expected_lon_float64 = np.array([np.nan, 0., 1.,
+                                         169.6, 180., 190.4,
+                                         359., 360., np.nan],
+                                        dtype=np.float64)
 
-        indexes = get_dataset_indexes(dataset, "lon", lon_coords, index_dtype=np.int32)
+        indexes = get_dataset_indexes(dataset, "lon", lon_coords,
+                                      index_dtype=np.int32)
         np.testing.assert_array_equal(indexes, expected_lon_int64)
         indexes = get_dataset_indexes(dataset, "lon", lon_coords)
         np.testing.assert_array_almost_equal(indexes, expected_lon_float64)
 
         # - lat -------------------------------------
 
-        lat_coords = np.array([-100, -90., -89, -10.4, 0., 10.4, 89., 90.0, 100])
+        lat_coords = np.array([-100, -90., -89,
+                               -10.4, 0., 10.4, 89., 90.0, 100])
         if not inverse_lat:
-            expected_lat_int64 = np.array([-1, 0, 1, 79, 90, 100, 179, 179, -1], dtype=np.int64)
-            expected_lat_float64 = np.array([np.nan, 0., 1., 79.6, 90., 100.4, 179., 180., np.nan], dtype=np.float64)
+            expected_lat_int64 = np.array([-1, 0, 1,
+                                           79, 90, 100, 179, 179, -1],
+                                          dtype=np.int64)
+            expected_lat_float64 = np.array([np.nan, 0., 1., 79.6,
+                                             90., 100.4, 179.,
+                                             180., np.nan],
+                                            dtype=np.float64)
         else:
-            expected_lat_int64 = np.array([-1, 179, 179, 100, 90, 79, 1, 0, -1], dtype=np.int64)
-            expected_lat_float64 = np.array([np.nan, 180., 179., 100.4, 90., 79.6, 1., 0., np.nan],
+            expected_lat_int64 = np.array([-1, 179, 179,
+                                           100, 90, 79, 1, 0, -1],
+                                          dtype=np.int64)
+            expected_lat_float64 = np.array([np.nan, 180., 179.,
+                                             100.4, 90., 79.6, 1., 0., np.nan],
                                             dtype=np.float64)
 
-        indexes = get_dataset_indexes(dataset, "lat", lat_coords, index_dtype=np.int32)
+        indexes = get_dataset_indexes(dataset, "lat", lat_coords,
+                                      index_dtype=np.int32)
         np.testing.assert_array_equal(indexes, expected_lat_int64)
         indexes = get_dataset_indexes(dataset, "lat", lat_coords)
         np.testing.assert_array_almost_equal(indexes, expected_lat_float64)
@@ -145,12 +183,17 @@ class GetDatasetIndexesTest(unittest.TestCase):
         # - time ------------------------------------
 
         time_coords = np.array(
-            ["2010-01-03", "2010-01-02T23:15", "2010-05-15", "2010-01-01T12:00", "2010-01-05", "2009-12-07"],
+            ["2010-01-03", "2010-01-02T23:15", "2010-05-15",
+             "2010-01-01T12:00", "2010-01-05", "2009-12-07"],
             dtype="datetime64[ns]")
-        expected_time_int64 = np.array([2, 1, -1, 0, 4, -1], dtype=np.int64)
-        expected_time_float64 = np.array([2., 1.96875, np.nan, 0.5, 4., np.nan], dtype=np.float64)
+        expected_time_int64 = np.array([2, 1, -1, 0, 4, -1],
+                                       dtype=np.int64)
+        expected_time_float64 = np.array([2., 1.96875, np.nan,
+                                          0.5, 4., np.nan],
+                                         dtype=np.float64)
 
-        indexes = get_dataset_indexes(dataset, "time", time_coords, index_dtype=np.int32)
+        indexes = get_dataset_indexes(dataset, "time", time_coords,
+                                      index_dtype=np.int32)
         np.testing.assert_array_equal(indexes, expected_time_int64)
         indexes = get_dataset_indexes(dataset, "time", time_coords)
         np.testing.assert_array_almost_equal(indexes, expected_time_float64)

--- a/test/core/test_extract.py
+++ b/test/core/test_extract.py
@@ -28,6 +28,7 @@ class GetCubeValuesForPointsTest(unittest.TestCase):
                                    "2010-01-20", "2010-01-01",
                                    "2010-01-05", "2010-01-03",
                                    ], dtype="datetime64[ns]"),
+                    # Note "lat" is a list (see issue #434)
                     lat=[50.0, 51.3, 49.7, 50.1, 51.9, 50.8, 50.2, 52.0],
                     lon=np.array([0.0, 0.1, 0.4, 2.9, 1.6, 0.7, -0.5, 4.0]))
 

--- a/xcube/core/extract.py
+++ b/xcube/core/extract.py
@@ -425,11 +425,9 @@ def _normalize_series(
         for col_name in col_names:
             if col_name in points:
                 col = points[col_name]
-                if not isinstance(col, (np.ndarray,
-                                        da.Array,
-                                        xr.DataArray,
-                                        pd.Series)):
-                    new_points[col_name] = xr.DataArray(col)
+                if not isinstance(col, xr.DataArray):
+                    col = xr.DataArray(col)
+                new_points[col_name] = col
         points = new_points
 
     num_points = None

--- a/xcube/core/extract.py
+++ b/xcube/core/extract.py
@@ -1,5 +1,7 @@
-from typing import Dict, Union, Tuple, Any, Optional, Mapping, Sequence, Hashable
+from typing import Dict, Union, Tuple, Any, Optional, \
+    Mapping, Sequence, Hashable
 
+import dask.array as da
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -14,89 +16,144 @@ POINT_INTERP_METHOD_NEAREST = "nearest"
 POINT_INTERP_METHOD_LINEAR = "linear"
 DEFAULT_INTERP_POINT_METHOD = POINT_INTERP_METHOD_NEAREST
 
+SeriesLike = Union[
+    np.ndarray,
+    da.Array,
+    xr.DataArray,
+    pd.Series,
+    Sequence[Union[int, float]]
+]
 
-def get_cube_values_for_points(cube: xr.Dataset,
-                               points: Union[xr.Dataset, pd.DataFrame, Mapping[str, Any]],
-                               var_names: Sequence[str] = None,
-                               include_coords: bool = False,
-                               include_bounds: bool = False,
-                               include_indexes: bool = False,
-                               index_name_pattern: str = DEFAULT_INDEX_NAME_PATTERN,
-                               include_refs: bool = False,
-                               ref_name_pattern: str = DEFAULT_REF_NAME_PATTERN,
-                               method: str = DEFAULT_INTERP_POINT_METHOD,
-                               cube_asserted: bool = False) -> xr.Dataset:
+PointsLike = Union[
+    xr.Dataset,
+    pd.DataFrame,
+    Mapping[str, SeriesLike]
+]
+
+
+def get_cube_values_for_points(
+        cube: xr.Dataset,
+        points: PointsLike,
+        var_names: Sequence[str] = None,
+        include_coords: bool = False,
+        include_bounds: bool = False,
+        include_indexes: bool = False,
+        index_name_pattern: str = DEFAULT_INDEX_NAME_PATTERN,
+        include_refs: bool = False,
+        ref_name_pattern: str = DEFAULT_REF_NAME_PATTERN,
+        method: str = DEFAULT_INTERP_POINT_METHOD,
+        cube_asserted: bool = False
+) -> xr.Dataset:
     """
-    Extract values from *cube* variables at given coordinates in *points*.
+    Extract values from *cube* variables at given
+    coordinates in *points*.
 
-    Returns a new dataset with values of variables from *cube* selected by the coordinate columns
-    provided in *points*. All variables will be 1-D and have the same order as the rows in points.
+    Returns a new dataset with values of variables from *cube* selected
+    by the coordinate columns
+    provided in *points*. All variables will be 1-D and have the same order
+    as the rows in points.
 
     :param cube: The cube dataset.
     :param points: Dictionary that maps dimension name to coordinate arrays.
-    :param var_names: An optional list of names of data variables in *cube* whose values shall be extracted.
-    :param include_coords: Whether to include the cube coordinates for each point in return value.
-    :param include_bounds: Whether to include the cube coordinate boundaries (if any) for each point in return value.
-    :param include_indexes: Whether to include computed indexes into the cube for each point in return value.
+    :param var_names: An optional list of names of data variables in *cube*
+        whose values shall be extracted.
+    :param include_coords: Whether to include the cube coordinates for each
+        point in return value.
+    :param include_bounds: Whether to include the cube coordinate boundaries
+        (if any) for each point in return value.
+    :param include_indexes: Whether to include computed indexes into the cube
+        for each point in return value.
     :param index_name_pattern: A naming pattern for the computed index columns.
-           Must include "{name}" which will be replaced by the index' dimension name.
-    :param include_refs: Whether to include point (reference) values from *points* in return value.
-    :param ref_name_pattern: A naming pattern for the computed point data columns.
-           Must include "{name}" which will be replaced by the point's attribute name.
+        Must include "{name}" which will be replaced by the index'
+        dimension name.
+    :param include_refs: Whether to include point (reference) values from
+    *points* in return value.
+    :param ref_name_pattern: A naming pattern for the computed point data
+        columns. Must include "{name}" which will be replaced by the point's
+        attribute name.
     :param method: "nearest" or "linear".
-    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-    :return: A new data frame whose columns are values from *cube* variables at given *points*.
+    :param cube_asserted: If False, *cube* will be verified, otherwise it
+        is expected to be a valid cube.
+    :return: A new data frame whose columns are values from *cube* variables
+        at given *points*.
     """
     if not cube_asserted:
         assert_cube(cube)
 
-    point_indexes = get_cube_point_indexes(cube,
-                                           points,
-                                           index_name_pattern=index_name_pattern,
-                                           index_dtype=np.int64 if method == POINT_INTERP_METHOD_NEAREST else np.float64,
-                                           cube_asserted=True)
+    index_dtype = np.int64 \
+        if method == POINT_INTERP_METHOD_NEAREST else np.float64
 
-    cube_values = get_cube_values_for_indexes(cube,
-                                              point_indexes,
-                                              include_coords,
-                                              include_bounds,
-                                              data_var_names=var_names,
-                                              index_name_pattern=index_name_pattern,
-                                              method=method,
-                                              cube_asserted=True)
+    point_indexes = get_cube_point_indexes(
+        cube,
+        points,
+        index_name_pattern=index_name_pattern,
+        index_dtype=index_dtype,
+        cube_asserted=True
+    )
+
+    cube_values = get_cube_values_for_indexes(
+        cube,
+        point_indexes,
+        include_coords,
+        include_bounds,
+        data_var_names=var_names,
+        index_name_pattern=index_name_pattern,
+        method=method,
+        cube_asserted=True
+    )
 
     if include_indexes:
         cube_values.update(point_indexes)
 
     if include_refs:
-        point_refs = xr.Dataset({ref_name_pattern.format(name=name): xr.DataArray(points[name], dims=[INDEX_DIM_NAME])
-                                 for name in points.keys()})
+        point_refs = xr.Dataset({
+            ref_name_pattern.format(name=name):
+                xr.DataArray(points[name], dims=[INDEX_DIM_NAME])
+            for name in points.keys()
+        })
+
         cube_values.update(point_refs)
+
+    # The (coordinate) variable named INDEX_DIM_NAME should not exist,
+    # otherwise cube_values.to_dataframe() will use an empty string
+    # to name that series "" in the output DataFrame instance.
+    # This seems to be an issue of xarray 0.18.2+.
+    if INDEX_DIM_NAME in cube_values:
+        cube_values = cube_values.drop_vars(INDEX_DIM_NAME)
 
     return cube_values
 
 
-def get_cube_values_for_indexes(cube: xr.Dataset,
-                                indexes: Union[xr.Dataset, pd.DataFrame, Mapping[str, Any]],
-                                include_coords: bool = False,
-                                include_bounds: bool = False,
-                                data_var_names: Sequence[str] = None,
-                                index_name_pattern: str = DEFAULT_INDEX_NAME_PATTERN,
-                                method: str = DEFAULT_INTERP_POINT_METHOD,
-                                cube_asserted: bool = False) -> xr.Dataset:
+def get_cube_values_for_indexes(
+        cube: xr.Dataset,
+        indexes: Union[xr.Dataset, pd.DataFrame, Mapping[str, Any]],
+        include_coords: bool = False,
+        include_bounds: bool = False,
+        data_var_names: Sequence[str] = None,
+        index_name_pattern: str = DEFAULT_INDEX_NAME_PATTERN,
+        method: str = DEFAULT_INTERP_POINT_METHOD,
+        cube_asserted: bool = False
+) -> xr.Dataset:
     """
     Get values from the *cube* at given *indexes*.
 
     :param cube: A cube dataset.
-    :param indexes: A mapping from column names to index and fraction arrays for all cube dimensions.
-    :param include_coords: Whether to include the cube coordinates for each point in return value.
-    :param include_bounds: Whether to include the cube coordinate boundaries (if any) for each point in return value.
-    :param data_var_names: An optional list of names of data variables in *cube* whose values shall be extracted.
-    :param index_name_pattern: A naming pattern for the computed indexes columns.
-           Must include "{name}" which will be replaced by the dimension name.
+    :param indexes: A mapping from column names to index and fraction arrays
+        for all cube dimensions.
+    :param include_coords: Whether to include the cube coordinates for each
+        point in return value.
+    :param include_bounds: Whether to include the cube coordinate boundaries
+        (if any) for each point in return value.
+    :param data_var_names: An optional list of names of data variables in
+        *cube* whose values shall be extracted.
+    :param index_name_pattern: A naming pattern for the computed
+        indexes columns. Must include "{name}" which will be replaced by
+        the dimension name.
     :param method: "nearest" or "linear".
-    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
-    :return: A new data frame whose columns are values from *cube* variables at given *indexes*.
+    :param cube_asserted: If False, *cube* will be verified, otherwise it
+        is expected to be a valid cube.
+    :return: A new data frame whose columns are values from *cube* variables
+        at given *indexes*.
     """
     if not cube_asserted:
         assert_cube(cube)
@@ -112,7 +169,7 @@ def get_cube_values_for_indexes(cube: xr.Dataset,
 
     if data_var_names is not None:
         if len(data_var_names) == 0:
-            return xr.Dataset(coords=indexes.coords if hasattr(indexes, "coords") else None)
+            return _empty_dataset_from_points(indexes)
         for var_name in data_var_names:
             if var_name not in cube.data_vars:
                 raise ValueError(f"variable {var_name!r} not found in cube")
@@ -121,11 +178,16 @@ def get_cube_values_for_indexes(cube: xr.Dataset,
 
     dim_names = cube[data_var_names[0]].dims
     num_dims = len(dim_names)
-    index_names = [index_name_pattern.format(name=dim_name) for dim_name in dim_names]
-    num_points = _validate_points(indexes, index_names, param_name="indexes")
-    indexes = _normalize_points(indexes)
-
-    cube = xr.Dataset({var_name: cube[var_name] for var_name in data_var_names}, coords=cube.coords)
+    index_names = [index_name_pattern.format(name=dim_name)
+                   for dim_name in dim_names]
+    indexes, num_points = _normalize_series(indexes,
+                                            index_names,
+                                            force_dataset=True,
+                                            param_name="indexes")
+    if num_points == 0:
+        return _empty_dataset_from_points(indexes)
+    cube = xr.Dataset({var_name: cube[var_name]
+                       for var_name in data_var_names}, coords=cube.coords)
 
     new_bounds_vars = {}
     bounds_var_names = _get_coord_bounds_var_names(cube)
@@ -145,11 +207,13 @@ def get_cube_values_for_indexes(cube: xr.Dataset,
         if not include_coords:
             drop_coords = set(cube.coords)
 
-    # Generate a validation condition so we can filter out invalid rows (where any index == -1)
+    # Generate a validation condition so we can
+    # filter out invalid rows (where any index == -1)
     is_valid_point = None
     for index_name in index_names:
         col = indexes[index_name]
-        condition = col >= 0 if np.issubdtype(col.dtype, np.integer) else np.isnan(col)
+        condition = col >= 0 \
+            if np.issubdtype(col.dtype, np.integer) else np.isnan(col)
         if is_valid_point is None:
             is_valid_point = condition
         else:
@@ -158,13 +222,15 @@ def get_cube_values_for_indexes(cube: xr.Dataset,
     num_valid_points = np.count_nonzero(is_valid_point)
     if num_valid_points == num_points:
         # All indexes valid
-        cube_selector = {dim_names[i]: indexes[index_names[i]] for i in range(num_dims)}
+        cube_selector = {dim_names[i]: indexes[index_names[i]]
+                         for i in range(num_dims)}
         cube_values = cube.isel(cube_selector)
     elif num_valid_points == 0:
         # All indexes are invalid
         new_bounds_vars = {}
         for var_name in cube.variables:
-            new_bounds_vars[var_name] = _empty_points_var(cube[var_name], num_points)
+            new_bounds_vars[var_name] = _empty_points_var(cube[var_name],
+                                                          num_points)
         cube_values = xr.Dataset(new_bounds_vars)
     else:
         # Some invalid indexes
@@ -173,7 +239,8 @@ def get_cube_values_for_indexes(cube: xr.Dataset,
         idx_dim_name = indexes[index_names[0]].dims[0]
         good_indexes = indexes.isel({idx_dim_name: good_idx})
 
-        cube_selector = {dim_names[i]: good_indexes[index_names[i]] for i in range(num_dims)}
+        cube_selector = {dim_names[i]: good_indexes[index_names[i]]
+                         for i in range(num_dims)}
         cube_values = cube.isel(cube_selector)
 
         new_bounds_vars = {}
@@ -191,25 +258,34 @@ def get_cube_values_for_indexes(cube: xr.Dataset,
     return cube_values
 
 
-def get_cube_point_indexes(cube: xr.Dataset,
-                           points: Union[xr.Dataset, pd.DataFrame, Mapping[str, Any]],
-                           dim_name_mapping: Mapping[str, str] = None,
-                           index_name_pattern: str = DEFAULT_INDEX_NAME_PATTERN,
-                           index_dtype=np.float64,
-                           cube_asserted: bool = False) -> xr.Dataset:
+def get_cube_point_indexes(
+        cube: xr.Dataset,
+        points: PointsLike,
+        dim_name_mapping: Mapping[str, str] = None,
+        index_name_pattern: str = DEFAULT_INDEX_NAME_PATTERN,
+        index_dtype=np.float64,
+        cube_asserted: bool = False
+) -> xr.Dataset:
     """
     Get indexes of given point coordinates *points* into the given *dataset*.
 
     :param cube: The cube dataset.
-    :param points: A mapping from column names to column data arrays, which must all have the same length.
-    :param dim_name_mapping: A mapping from dimension names in *cube* to column names in *points*.
-    :param index_name_pattern: A naming pattern for the computed indexes columns.
-           Must include "{name}" which will be replaced by the dimension name.
-    :param index_dtype: Numpy data type for the indexes. If it is a floating point type (default),
-           then *indexes* will contain fractions, which may be used for interpolation.
-           For out-of-range coordinates in *points*, indexes will be -1 if *index_dtype* is an integer type, and NaN,
-           if *index_dtype* is a floating point types.
-    :param cube_asserted: If False, *cube* will be verified, otherwise it is expected to be a valid cube.
+    :param points: A mapping from column names to column data arrays, which
+        must all have the same length.
+    :param dim_name_mapping: A mapping from dimension names in *cube* to
+        column names in *points*.
+    :param index_name_pattern: A naming pattern for the computed
+        indexes columns. Must include "{name}" which will be replaced by
+        the dimension name.
+    :param index_dtype: Numpy data type for the indexes. If it is a
+        floating point type (default),
+        then *indexes* will contain fractions, which may be
+        used for interpolation.
+        For out-of-range coordinates in *points*, indexes will be -1
+        if *index_dtype* is an integer type, and NaN,
+        if *index_dtype* is a floating point types.
+    :param cube_asserted: If False, *cube* will be verified, otherwise
+        it is expected to be a valid cube.
     :return: A dataset containing the index columns.
     """
     if not cube_asserted:
@@ -217,44 +293,60 @@ def get_cube_point_indexes(cube: xr.Dataset,
 
     dim_name_mapping = dim_name_mapping if dim_name_mapping is not None else {}
     dim_names = _get_cube_data_var_dims(cube)
-    col_names = [dim_name_mapping.get(dim_name, dim_name) for dim_name in dim_names]
+    col_names = [dim_name_mapping.get(str(dim_name), dim_name)
+                 for dim_name in dim_names]
 
-    _validate_points(points, col_names, param_name="points")
+    points, _ = _normalize_series(points,
+                                  col_names,
+                                  force_dataset=False,
+                                  param_name="points")
 
     indexes = []
     for dim_name, col_name in zip(dim_names, col_names):
         col = points[col_name]
-        coord_indexes = get_dataset_indexes(cube, str(dim_name), col, index_dtype=index_dtype)
+        coord_indexes = get_dataset_indexes(cube,
+                                            str(dim_name),
+                                            col,
+                                            index_dtype=index_dtype)
         indexes.append((index_name_pattern.format(name=dim_name),
                         xr.DataArray(coord_indexes, dims=[INDEX_DIM_NAME])))
 
     return xr.Dataset(dict(indexes))
 
 
-def get_dataset_indexes(dataset: xr.Dataset,
-                        coord_var_name: str,
-                        coord_values: Union[xr.DataArray, np.ndarray],
-                        index_dtype=np.float64) -> Union[xr.DataArray, np.ndarray]:
+def get_dataset_indexes(
+        dataset: xr.Dataset,
+        coord_var_name: str,
+        coord_values: SeriesLike,
+        index_dtype=np.float64
+) -> Union[xr.DataArray, np.ndarray]:
     """
-    Compute the indexes and their fractions into a coordinate variable *coord_var_name* of a *dataset*
-    for the given coordinate values *coord_values*.
+    Compute the indexes and their fractions into a coordinate variable
+    *coord_var_name* of a *dataset* for the given coordinate values
+    *coord_values*.
 
-    The coordinate variable's labels must be monotonic increasing or decreasing,
-    otherwise the result will be nonsense.
+    The coordinate variable's labels must be monotonic increasing or
+    decreasing, otherwise the result will be nonsense.
 
-    For any value in *coord_values* that is out of the bounds of the coordinate variable's values,
-    the index depends on the value of *index_dtype*. If *index_dtype* is an integer type, invalid indexes are
-    encoded as -1 while for floating point types, NaN will be used.
+    For any value in *coord_values* that is out of the bounds of the
+    coordinate variable's values, the index depends on the value of
+    *index_dtype*. If *index_dtype* is an integer type, invalid indexes
+    are encoded as -1 while for floating point types, NaN will be used.
 
-    Returns a tuple of indexes as int64 array and fractions as float64 array.
+    Returns a tuple of indexes as int64 array and fractions as
+    float64 array.
 
     :param dataset: A cube dataset.
     :param coord_var_name: Name of a coordinate variable.
     :param coord_values: Array-like coordinate values.
-    :param index_dtype: Numpy data type for the indexes. If it is floating point type (default),
-           then *indexes* contain fractions, which may be used for interpolation. If *dtype* is an integer
-           type out-of-range coordinates are indicated by index -1, and NaN if it is is a floating point type.
-    :return: The indexes and their fractions as a tuple of numpy int64 and float64 arrays.
+    :param index_dtype: Numpy data type for the indexes.
+        If it is floating point type (default), then *indexes*
+        contain fractions, which may be used for interpolation.
+        If *dtype* is an integer type out-of-range coordinates
+        are indicated by index -1, and NaN if it is is a
+        floating point type.
+    :return: The indexes and their fractions as a tuple of
+        numpy int64 and float64 arrays.
     """
     coord_var = dataset[coord_var_name]
     n1 = coord_var.size
@@ -291,7 +383,8 @@ def get_dataset_indexes(dataset: xr.Dataset,
             coords -= 0.5 * deltas
     else:
         raise ValueError(f"cannot determine cell boundaries for"
-                         f" coordinate variable {coord_var_name!r} of size {coord_var.size}")
+                         f" coordinate variable {coord_var_name!r}"
+                         f" of size {coord_var.size}")
 
     if np.issubdtype(coord_values.dtype, np.datetime64):
         try:
@@ -301,7 +394,8 @@ def get_dataset_indexes(dataset: xr.Dataset,
             coord_values = coord_values.values.astype(np.uint64)
 
     indexes = np.linspace(0.0, n1, n2, dtype=np.float64)
-    interp_indexes = np.interp(coord_values, coords, indexes, left=-1, right=-1)
+    interp_indexes = np.interp(coord_values, coords, indexes,
+                               left=-1, right=-1)
     if is_inverse:
         i = interp_indexes >= 0
         interp_indexes[i] = n1 - interp_indexes[i]
@@ -314,38 +408,56 @@ def get_dataset_indexes(dataset: xr.Dataset,
     return interp_indexes
 
 
-def _empty_points_var(var: xr.DataArray, num_points):
+def _empty_points_var(var: xr.DataArray, num_points: int):
     fill_value = 0 if np.issubdtype(var.dtype, np.integer) else np.nan
     return xr.DataArray(np.full(num_points, fill_value, dtype=var.dtype),
                         dims=[INDEX_DIM_NAME], attrs=var.attrs)
 
 
-def _normalize_points(points: Union[xr.Dataset, pd.DataFrame, Mapping[str, Any]]) -> xr.Dataset:
-    if isinstance(points, pd.DataFrame):
-        points = xr.Dataset.from_dataframe(points)
-    elif not isinstance(points, xr.DataArray):
-        points = xr.Dataset(points)
-    return points
+def _normalize_series(
+        points: PointsLike,
+        col_names: Sequence[str],
+        force_dataset: bool = False,
+        param_name: str = "points"
+) -> Tuple[PointsLike, int]:
+    if not isinstance(points, (xr.Dataset, pd.DataFrame)):
+        new_points = {}
+        for col_name in col_names:
+            if col_name in points:
+                col = points[col_name]
+                if not isinstance(col, (np.ndarray,
+                                        da.Array,
+                                        xr.DataArray,
+                                        pd.Series)):
+                    new_points[col_name] = xr.DataArray(col)
+        points = new_points
 
-
-def _validate_points(points: Union[xr.Dataset, pd.DataFrame, Mapping[str, Any]],
-                     col_names: Sequence[str],
-                     param_name="points") -> Optional[int]:
     num_points = None
     for col_name in col_names:
         if col_name not in points:
             raise ValueError(f"column {col_name!r} not found in {param_name}")
         col = points[col_name]
         if len(col.shape) != 1:
-            raise ValueError(
-                f"column {col_name!r} in {param_name} must be one-dimensional, but has shape {col.shape!r}")
+            raise ValueError(f"column {col_name!r} in {param_name} must be"
+                             f" one-dimensional, but has shape {col.shape!r}")
         if num_points is None:
             num_points = len(col)
         elif num_points != len(col):
-            raise ValueError(f"column sizes in {param_name} must be all the same,"
-                             f" but found {len(points[col_names[0]])} for column {col_names[0]!r}"
-                             f" and {num_points} for column {col_name!r}")
-    return num_points
+            raise ValueError(f"column sizes in {param_name} must be all the"
+                             f" same, but found {len(points[col_names[0]])}"
+                             f" for column {col_names[0]!r} and {num_points}"
+                             f" for column {col_name!r}")
+
+    if num_points is None:
+        raise ValueError(f"{param_name} has no valid columns")
+
+    if force_dataset:
+        if isinstance(points, pd.DataFrame):
+            points = xr.Dataset.from_dataframe(points)
+        elif not isinstance(points, xr.DataArray):
+            points = xr.Dataset(points)
+
+    return points, num_points
 
 
 def _get_coord_bounds_var_names(dataset: xr.Dataset) -> Dict[Hashable, Any]:
@@ -366,12 +478,20 @@ def _get_cube_data_var_dims(cube: xr.Dataset) -> Tuple[Hashable, ...]:
     raise ValueError("cube dataset is empty")
 
 
-def _get_bounds_var(dataset: xr.Dataset, var_name: str) -> Optional[xr.DataArray]:
+def _get_bounds_var(dataset: xr.Dataset,
+                    var_name: str) -> Optional[xr.DataArray]:
     var = dataset[var_name]
     if len(var.shape) == 1:
         bounds_var_name = var.attrs.get("bounds", f"{var_name}_bnds")
         if bounds_var_name in dataset:
             bounds_var = dataset[bounds_var_name]
-            if bounds_var.dtype == var.dtype and bounds_var.shape == (var.size, 2):
+            if bounds_var.dtype == var.dtype \
+                    and bounds_var.shape == (var.size, 2):
                 return bounds_var
     return None
+
+
+def _empty_dataset_from_points(data: Any) -> xr.Dataset:
+    return xr.Dataset(
+        coords=data.coords if hasattr(data, "coords") else None
+    )


### PR DESCRIPTION
* This PR should fix the broken build due new test failures for `xcube extract --ref ...`. The actual fix is [here](https://github.com/dcs4cop/xcube/pull/474/files#diff-2a630afcb3e2c7ecff04e5868e071f9de65953c5ff4c8f32e4f1934cddb38e34R117-R122)
* Also fixes #434

FYI @AliceBalfanz @dzelge @pont-us 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `docs/CHANGES.md`
* [ ] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge