### PR TITLE
Issue warning when accessing S3 without specifying anon=True

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@ Checklist:
 * [ ] Add unit tests and/or doctests in docstrings
 * [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
 * [ ] New/modified features documented in `docs/source/*`
-* [ ] Changes documented in `docs/CHANGES.md`
-* [ ] AppVeyor and Travis CI passes
+* [ ] Changes documented in `CHANGES.md`
+* [ ] AppVeyor CI passes
 * [ ] Test coverage remains or increases (target 100%)
-* [ ] Associated issues closed after merge
+
+Remember to close associated issues after merge!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
     `xcube.core.gen2.service.RemoteCubeGenerator`;
   2. Generator CLI `xcube gen2`.
 * xcube now issues a warning, if a data cube is opened from object 
-  storage, and credentials have been neither passed not can be found, 
+  storage, and credentials have neither been passed nor can be found, 
   and the object storage has been opened with the default `anon=False`. (#412)
 * xcube no longer internally caches directory listings, which prevents 
   the situation where a data cube that has recently been written into object 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,8 @@
   storage, and credentials have been neither passed not can be found, 
   and the object storage has been opened with the default `anon=False`. (#412)
 * xcube no longer internally caches directory listings, which prevents 
-  the situation where a data cube, that has recently been written into object 
-  storage, cannot be found. 
+  the situation where a data cube that has recently been written into object 
+  storage cannot be found. 
 * Added a new utility module `xcube.util.temp` that allows for creating 
   temporary files and directories that will be deleted when the current 
   process ends.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
 * xcube now issues a warning, if a data cube is opened from object 
   storage, and credentials have been neither passed not can be found, 
   and the object storage has been opened with the default `anon=False`. (#412)
+* xcube no longer internally caches directory listings, which prevents 
+  the situation where a data cube, that has recently been written into object 
+  storage, cannot be found. 
 * Added a new utility module `xcube.util.temp` that allows for creating 
   temporary files and directories that will be deleted when the current 
   process ends.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
   1. Generator API `xcube.core.gen2.LocalCubeGenerator` and
     `xcube.core.gen2.service.RemoteCubeGenerator`;
   2. Generator CLI `xcube gen2`.
+* xcube now issues a warning, if a data cube is opened from object 
+  storage, and credentials have been neither passed not can be found, 
+  and the object storage has been opened with the default `anon=False`. (#412)
 * Added a new utility module `xcube.util.temp` that allows for creating 
   temporary files and directories that will be deleted when the current 
   process ends.

--- a/test/webapi/test_s3buckethandlers.py
+++ b/test/webapi/test_s3buckethandlers.py
@@ -2,10 +2,12 @@ import unittest
 import urllib.request
 
 import numpy as np
+import xarray as xr
 
 from xcube.core.dsio import open_cube
 
-SKIP_HELP = 'Skipped, because server is not running: $ xcube serve --verbose -c examples/serve/demo/config.yml'
+SKIP_HELP = ('Skipped, because server is not running:'
+             ' $ xcube serve --verbose -c examples/serve/demo/config.yml')
 SERVER_URL = 'http://localhost:8080'
 ENDPOINT_URL = SERVER_URL + '/s3bucket'
 
@@ -26,17 +28,27 @@ XCUBE_SERVER_IS_RUNNING = is_server_running()
 class S3BucketHandlersTest(unittest.TestCase):
 
     @unittest.skipUnless(XCUBE_SERVER_IS_RUNNING, SKIP_HELP)
-    def test_open_cube_from_xube_server(self):
-        ds = open_cube('s3bucket/local', format_name='zarr', endpoint_url=SERVER_URL)
-        self.assertIsNotNone(ds)
+    def test_open_cube_from_xube_server_rel_path(self):
+        ds = open_cube('s3bucket/local',
+                       format_name='zarr',
+                       s3_client_kwargs=dict(endpoint_url=SERVER_URL))
+        self.assertCubeOk(ds)
+
+    @unittest.skipUnless(XCUBE_SERVER_IS_RUNNING, SKIP_HELP)
+    def test_open_cube_from_xube_server_abs_path(self):
+        ds = open_cube('http://localhost:8080/s3bucket/local',
+                       format_name='zarr')
+        self.assertCubeOk(ds)
+
+    def assertCubeOk(self, ds):
+        self.assertIsInstance(ds, xr.Dataset)
         self.assertEqual((5, 1000, 2000), ds.conc_chl.shape)
         self.assertEqual(('time', 'lat', 'lon'), ds.conc_chl.dims)
         conc_chl_values = ds.conc_chl.values
         self.assertEqual((5, 1000, 2000), conc_chl_values.shape)
-        self.assertAlmostEqual(0.00005656, float(np.nanmin(conc_chl_values)), delta=1e-6)
-        self.assertAlmostEqual(22.4421215, float(np.nanmax(conc_chl_values)), delta=1e-6)
-
-    # def test_open_cube_from_obs(self):
-    #     ds = open_cube('xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr', format_name='zarr',
-    #                    endpoint_url='https://s3.eu-central-1.amazonaws.com/')
-    #     self.assertIsNotNone(ds)
+        self.assertAlmostEqual(0.00005656,
+                               float(np.nanmin(conc_chl_values)),
+                               delta=1e-6)
+        self.assertAlmostEqual(22.4421215,
+                               float(np.nanmax(conc_chl_values)),
+                               delta=1e-6)

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -625,8 +625,10 @@ def new_s3_file_system(s3_kwargs: Mapping[str, Any] = None,
     client_kwargs = s3_kwargs.pop('client_kwargs', {})
     client_kwargs.update(s3_client_kwargs or {})
     try:
-        return s3fs.S3FileSystem(**s3_kwargs,
+        s3 = s3fs.S3FileSystem(**s3_kwargs,
                                  client_kwargs=client_kwargs)
+        s3.exists('')  # Force potential NoCredentialsError
+        return s3
     except botocore.exceptions.NoCredentialsError:
         if s3_kwargs.get('anon') is False:
             warnings.warn('No object storage credentials where'

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -618,6 +618,10 @@ def new_s3_file_system(s3_kwargs: Mapping[str, Any] = None,
     """
 
     s3_kwargs = s3_kwargs or {}
+    if 'use_listings_cache' not in s3_kwargs:
+        # The default is not to cache any directory listings
+        # because we want current contents
+        s3_kwargs['use_listings_cache'] = False
     client_kwargs = s3_kwargs.pop('client_kwargs', {})
     client_kwargs.update(s3_client_kwargs or {})
     try:

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -645,7 +645,7 @@ def new_s3_file_system(s3_kwargs: Mapping[str, Any] = None,
             s3.exists(check_path)
         return s3
     except botocore.exceptions.NoCredentialsError:
-        if s3_kwargs.get('anon') is False:
+        if not s3_kwargs.get('anon'):
             warnings.warn('No object storage credentials were'
                           ' passed or found.\n'
                           'If you intend to access a public object storage,'

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -631,7 +631,7 @@ def new_s3_file_system(s3_kwargs: Mapping[str, Any] = None,
         return s3
     except botocore.exceptions.NoCredentialsError:
         if s3_kwargs.get('anon') is False:
-            warnings.warn('No object storage credentials where'
+            warnings.warn('No object storage credentials were'
                           ' passed or found.\n'
                           'If you intend to access a public object storage,'
                           ' please pass '

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -15,7 +15,7 @@ from xcube.constants import FORMAT_NAME_SCRIPT
 from xcube.constants import FORMAT_NAME_ZARR
 from xcube.core.dsio import guess_dataset_format
 from xcube.core.dsio import is_s3_url
-from xcube.core.dsio import parse_s3_url_and_kwargs
+from xcube.core.dsio import parse_s3_fs_and_root
 from xcube.core.dsio import write_cube
 from xcube.core.geom import get_dataset_bounds
 from xcube.core.verify import assert_cube
@@ -652,10 +652,9 @@ def open_ml_dataset_from_object_storage(path: str,
                                         **kwargs) -> MultiLevelDataset:
     data_format = data_format or guess_ml_dataset_format(path)
 
-    root, s3_kwargs, s3_client_kwargs = parse_s3_url_and_kwargs(path,
-                                                                s3_kwargs=s3_kwargs,
-                                                                s3_client_kwargs=s3_client_kwargs)
-    s3 = s3fs.S3FileSystem(**s3_kwargs, client_kwargs=s3_client_kwargs)
+    s3, root = parse_s3_fs_and_root(path,
+                                    s3_kwargs=s3_kwargs,
+                                    s3_client_kwargs=s3_client_kwargs)
 
     if data_format == FORMAT_NAME_ZARR:
         store = s3fs.S3Map(root=root, s3=s3, check=False)

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -654,7 +654,8 @@ def open_ml_dataset_from_object_storage(path: str,
 
     s3, root = parse_s3_fs_and_root(path,
                                     s3_kwargs=s3_kwargs,
-                                    s3_client_kwargs=s3_client_kwargs)
+                                    s3_client_kwargs=s3_client_kwargs,
+                                    mode='r')
 
     if data_format == FORMAT_NAME_ZARR:
         store = s3fs.S3Map(root=root, s3=s3, check=False)

--- a/xcube/core/resample.py
+++ b/xcube/core/resample.py
@@ -85,7 +85,6 @@ def resample_in_time(cube: xr.Dataset,
     resampler = cube.resample(skipna=True,
                               closed='left',
                               label='left',
-                              keep_attrs=True,
                               time=frequency,
                               loffset=offset,
                               base=base)

--- a/xcube/core/store/accessors/dataset.py
+++ b/xcube/core/store/accessors/dataset.py
@@ -245,7 +245,7 @@ class S3Mixin:
         aws_secret_access_key = params.pop('aws_secret_access_key', None)
         aws_session_token = params.pop('aws_session_token', None)
         anon = params.pop('anon', False)
-        region_name = params.pop('region_name', None),
+        region_name = params.pop('region_name', None)
         endpoint_url = params.pop('endpoint_url', None)
         s3 = new_s3_file_system(
             s3_kwargs=dict(

--- a/xcube/core/store/stores/s3.py
+++ b/xcube/core/store/stores/s3.py
@@ -22,8 +22,8 @@
 import json
 import os.path
 import uuid
-from typing import Optional, Iterator, Any, Tuple, List, Dict, Union, Container
 import warnings
+from typing import Optional, Iterator, Any, Tuple, List, Dict, Union, Container
 
 import s3fs
 import xarray as xr
@@ -45,10 +45,10 @@ from xcube.core.store import new_data_descriptor
 from xcube.core.store import new_data_opener
 from xcube.core.store import new_data_writer
 from xcube.core.store.accessors.dataset import S3Mixin
-from xcube.util.assertions import assert_true
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_in
 from xcube.util.assertions import assert_instance
+from xcube.util.assertions import assert_true
 from xcube.util.extension import Extension
 from xcube.util.jsonschema import JsonObjectSchema
 
@@ -90,15 +90,20 @@ class S3DataStore(DefaultSearchMixin, MutableDataStore):
     """
 
     def __init__(self, **store_params):
-        self._s3, store_params = S3Mixin.consume_s3fs_params(store_params,
-                                                             params_name='store_params')
-        self._bucket_name, store_params = S3Mixin.consume_bucket_name_param(store_params)
+        self._bucket_name, store_params = \
+            S3Mixin.consume_bucket_name_param(store_params)
         assert_given(self._bucket_name, 'bucket_name')
+        self._s3, store_params = \
+            S3Mixin.consume_s3fs_params(store_params,
+                                        check_path=self._bucket_name,
+                                        params_name='store_params')
         assert_true(not store_params,
-                    f'Unknown keyword arguments: {", ".join(store_params.keys())}')
+                    'Unknown keyword arguments:'
+                    f' {", ".join(store_params.keys())}')
+        registry_path = f'{self._bucket_name}/{_REGISTRY_FILE}'
         self._registry = {}
-        if self._s3.exists(f'{self._bucket_name}/{_REGISTRY_FILE}'):
-            with self._s3.open(f'{self._bucket_name}/{_REGISTRY_FILE}', 'r') as registry_file:
+        if self._s3.exists(registry_path):
+            with self._s3.open(registry_path, 'r') as registry_file:
                 self._registry = json.load(registry_file)
 
     def close(self):
@@ -319,8 +324,9 @@ class S3DataStore(DefaultSearchMixin, MutableDataStore):
             self._maybe_update_json_registry()
 
     def _maybe_update_json_registry(self):
-        if self._s3.exists(f'{self._bucket_name}/{_REGISTRY_FILE}'):
-            with self._s3.open(f'{self._bucket_name}/{_REGISTRY_FILE}', 'w') as registry_file:
+        registry_path = f'{self._bucket_name}/{_REGISTRY_FILE}'
+        if self._s3.exists(registry_path):
+            with self._s3.open(registry_path, 'w') as registry_file:
                 json.dump(self._registry, registry_file)
 
     ###############################################################

--- a/xcube/core/store/stores/s3.py
+++ b/xcube/core/store/stores/s3.py
@@ -90,7 +90,8 @@ class S3DataStore(DefaultSearchMixin, MutableDataStore):
     """
 
     def __init__(self, **store_params):
-        self._s3, store_params = S3Mixin.consume_s3fs_params(store_params)
+        self._s3, store_params = S3Mixin.consume_s3fs_params(store_params,
+                                                             params_name='store_params')
         self._bucket_name, store_params = S3Mixin.consume_bucket_name_param(store_params)
         assert_given(self._bucket_name, 'bucket_name')
         assert_true(not store_params,


### PR DESCRIPTION
* xcube now issues a warning, if a data cube is opened from object 
  storage, and credentials have been neither passed not can be found, 
  and the object storage has been opened with the default `anon=False`. (#412)
* xcube no longer internally caches directory listings, which prevents 
  the situation where a data cube, that has recently been written into object 
  storage, cannot be found. 

This addresses issue #412 posted by @tiagoams.


Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~ (would require boto-core mock)
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `docs/CHANGES.md`
* [x] AppVeyor and Travis CI passes
* [x] Test coverage remains or increases (target 100%)
* [ ] Associated issues closed after merge