### PR TITLE
use gridmapping in gen and gen2

### DIFF
--- a/test/cli/test_gen.py
+++ b/test/cli/test_gen.py
@@ -33,12 +33,18 @@ class GenCliTest(CliTest):
     def test_main_with_illegal_region_option(self):
         with self.assertRaises(ValueError) as cm:
             self.invoke_cli(['gen', '-R', '50,_2,55,21', 'input.nc'])
-        self.assertEqual("output_region must have the form <lon_min>,<lat_min>,<lon_max>,<lat_max>,"
-                         " where all four numbers must be floating point numbers in degrees", f'{cm.exception}')
+        self.assertEqual("output_region must have the form "
+                         "<x_min>,<y_min>,<x_max>,<y_max>,"
+                         " where all four numbers must be floating point "
+                         "numbers in the units of the output CRS",
+                         f'{cm.exception}')
         with self.assertRaises(ValueError) as cm:
             self.invoke_cli(['gen', '-R', '50,20,55', 'input.nc'])
-        self.assertEqual("output_region must have the form <lon_min>,<lat_min>,<lon_max>,<lat_max>,"
-                         " where all four numbers must be floating point numbers in degrees", f'{cm.exception}')
+        self.assertEqual("output_region must have the form "
+                         "<x_min>,<y_min>,<x_max>,<y_max>,"
+                         " where all four numbers must be floating point "
+                         "numbers in the units of the output CRS",
+                         f'{cm.exception}')
 
     def test_main_with_illegal_variable_option(self):
         with self.assertRaises(ValueError) as cm:

--- a/test/core/gen/test_config.py
+++ b/test/core/gen/test_config.py
@@ -113,15 +113,19 @@ class GetConfigDictTest(unittest.TestCase):
         config_obj = dict(output_region='50,_2,55,21')
         with self.assertRaises(ValueError) as cm:
             get_config_dict(**config_obj)
-        self.assertEqual("output_region must have the form <lon_min>,<lat_min>,<lon_max>,<lat_max>,"
-                         " where all four numbers must be floating point numbers in degrees",
+        self.assertEqual("output_region must have the form "
+                         "<x_min>,<y_min>,<x_max>,<y_max>,"
+                         " where all four numbers must be floating point "
+                         "numbers in the units of the output CRS",
                          f'{cm.exception}')
 
         config_obj = dict(output_region='50, 20, 55')
         with self.assertRaises(ValueError) as cm:
             get_config_dict(**config_obj)
-        self.assertEqual("output_region must have the form <lon_min>,<lat_min>,<lon_max>,<lat_max>,"
-                         " where all four numbers must be floating point numbers in degrees",
+        self.assertEqual("output_region must have the form "
+                         "<x_min>,<y_min>,<x_max>,<y_max>,"
+                         " where all four numbers must be floating point "
+                         "numbers in the units of the output CRS",
                          f'{cm.exception}')
 
     def test_output_variables_option(self):

--- a/test/core/gen/test_iproc.py
+++ b/test/core/gen/test_iproc.py
@@ -4,49 +4,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from xcube.core.gen.iproc import DefaultInputProcessor, ReprojectionInfo
+from xcube.core.gen.iproc import DefaultInputProcessor
 from xcube.core.timecoord import to_time_in_days_since_1970
-
-
-class ReprojectionInfoTest(unittest.TestCase):
-    def test_success(self):
-        # noinspection PyTypeChecker
-        ri = ReprojectionInfo(xy_names=['x', 'y'])
-        self.assertEqual(('x', 'y'), ri.xy_names)
-        self.assertEqual(None, ri.xy_tp_names)
-        self.assertEqual(None, ri.xy_crs)
-        self.assertEqual(None, ri.xy_gcp_step)
-        self.assertEqual(None, ri.xy_tp_gcp_step)
-
-        # noinspection PyTypeChecker
-        ri = ReprojectionInfo(xy_names=['x', 'y'], xy_gcp_step=[2, 1])
-        self.assertEqual(('x', 'y'), ri.xy_names)
-        self.assertEqual(None, ri.xy_tp_names)
-        self.assertEqual(None, ri.xy_crs)
-        self.assertEqual((2, 1), ri.xy_gcp_step)
-        self.assertEqual(None, ri.xy_tp_gcp_step)
-
-        # noinspection PyTypeChecker
-        ri = ReprojectionInfo(xy_gcp_step=4, xy_tp_gcp_step=2)
-        self.assertEqual(None, ri.xy_names)
-        self.assertEqual(None, ri.xy_tp_names)
-        self.assertEqual(None, ri.xy_crs)
-        self.assertEqual((4, 4), ri.xy_gcp_step)
-        self.assertEqual((2, 2), ri.xy_tp_gcp_step)
-
-    def test_fail(self):
-        with self.assertRaises(ValueError):
-            # noinspection PyTypeChecker
-            ReprojectionInfo(xy_names=['x', ''])
-        with self.assertRaises(ValueError):
-            # noinspection PyTypeChecker
-            ReprojectionInfo(xy_names=[0, 'y'])
-        with self.assertRaises(ValueError):
-            # noinspection PyTypeChecker
-            ReprojectionInfo(xy_gcp_step=[7, 'y'])
-        with self.assertRaises(ValueError):
-            # noinspection PyTypeChecker
-            ReprojectionInfo(xy_gcp_step=[7, 0])
 
 
 class DefaultInputProcessorTest(unittest.TestCase):
@@ -61,11 +20,6 @@ class DefaultInputProcessorTest(unittest.TestCase):
 
         processor = DefaultInputProcessor(input_reader="zarr")
         self.assertEqual('zarr', processor.input_reader)
-
-    def test_reprojection_info(self):
-        # noinspection PyNoneFunctionAssignment
-        reprojection_info = self.processor.get_reprojection_info(create_default_dataset())
-        self.assertIsNotNone(reprojection_info)
 
     def test_get_time_range(self):
         ds = create_default_dataset(time_mode="time")

--- a/xcube/cli/gen.py
+++ b/xcube/cli/gen.py
@@ -52,8 +52,15 @@ resampling_methods = sorted(RESAMPLING_METHOD_NAMES)
                    'xcube gen --info. If omitted, the format will be guessed from the given output path.')
 @click.option('--size', '-S', metavar='SIZE',
               help='Output size in pixels using format "<width>,<height>".')
+@click.option('--crs', metavar='CRS',
+              help='The target coordinate reference system. Must be given as'
+                   'either (a) a WKT-String decribing a CRS or (b) an EPSG-code'
+                   '(with or without leading "EPSG:". If not provided, the '
+                   'output cube will be resampled to the WGS84 CRS.')
 @click.option('--region', '-R', metavar='REGION',
-              help='Output region using format "<lon-min>,<lat-min>,<lon-max>,<lat-max>"')
+              help='Output region using format '
+                   '"<X-min>,<Y-min>,<X-max>,<y-max>". Output region '
+                   'must be given in coordinates of the output crs.')
 @click.option('--variables', '--vars', metavar='VARIABLES',
               help='Variables to be included in output. '
                    'Comma-separated list of names which may contain wildcard characters "*" and "?".')
@@ -81,6 +88,7 @@ def gen(input: Sequence[str],
         output: str,
         format: str,
         size: str,
+        crs: str,
         region: str,
         variables: str,
         resampling: str,
@@ -115,6 +123,7 @@ def gen(input: Sequence[str],
         output_path=output,
         output_writer_name=format,
         output_size=size,
+        output_crs=crs,
         output_region=region,
         output_variables=variables,
         output_resampling=resampling,

--- a/xcube/core/gen/config.py
+++ b/xcube/core/gen/config.py
@@ -29,6 +29,7 @@ def get_config_dict(config_files: Sequence[str] = None,
                     output_path: str = None,
                     output_writer_name: str = None,
                     output_size: str = None,
+                    output_crs: str = None,
                     output_region: str = None,
                     output_variables: str = None,
                     output_resampling: str = None,
@@ -68,6 +69,9 @@ def get_config_dict(config_files: Sequence[str] = None,
     if output_writer_name is not None and 'output_writer_name' not in config:
         config['output_writer_name'] = output_writer_name
 
+    if output_crs is not None and 'output_crs' not in config:
+        config['output_crs'] = output_crs
+
     if output_resampling is not None and 'output_resampling' not in config:
         config['output_resampling'] = output_resampling
 
@@ -87,8 +91,10 @@ def get_config_dict(config_files: Sequence[str] = None,
         except ValueError:
             output_region = None
         if output_region is None or len(output_region) != 4:
-            raise ValueError(f'output_region must have the form <lon_min>,<lat_min>,<lon_max>,<lat_max>,'
-                             f' where all four numbers must be floating point numbers in degrees')
+            raise ValueError(f'output_region must have the form '
+                             f'<x_min>,<y_min>,<x_max>,<y_max>, '
+                             f'where all four numbers must be floating point '
+                             f'numbers in the units of the output CRS')
         config['output_region'] = output_region
 
     if output_variables is not None:

--- a/xcube/core/gridmapping/__init__.py
+++ b/xcube/core/gridmapping/__init__.py
@@ -21,5 +21,6 @@
 
 from .base import CRS_CRS84
 from .base import CRS_WGS84
+from .base import DEFAULT_CRS
 from .base import DEFAULT_TOLERANCE
 from .base import GridMapping

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -44,6 +44,8 @@ from .helpers import _normalize_number_pair
 from .helpers import _to_affine
 from .helpers import scale_xy_res_and_size
 
+DEFAULT_CRS = 'EPSG:4326'
+
 # WGS84, axis order: lat, lon
 CRS_WGS84 = pyproj.crs.CRS(4326)
 


### PR DESCRIPTION
Uses the newly introduced GridMapping in xcube gen and gen2. In particular, there is now a parameter 'crs' that can be passed to the gen cli. The class ReprojectionInfo has been removed.


Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!