### PR TITLE
xarray accessor for cube and grid_mapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@
     `xcube.core.gen2.service.RemoteCubeGenerator`;
   2. Generator CLI `xcube gen2`.
   
-* A data's cube subset and its grid mapping can now be accessed through
+* A dataset's cube subset and its grid mapping can now be accessed through
   the `xcube` property of `xarray.Dataset` instances. This feature requires 
   importing the `xcube.core.xarray`package. Let `dataset` be an 
   instance of `xarray.Dataset`, then

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,9 @@
   - `dataset.xcube.gm` is a `xcube.core.gridmapping.GridMapping` that 
      describes the CF-compliant grid mapping of `dataset`. 
      May be `None`, if `dataset` does not define a grid mapping.
+  - `dataset.xcube.non_cube` is a `xarray.Dataset` that contains all
+     variables of `dataset` that are not in `dataset.xcube.cube`.
+     May be same as `dataset`, if `dataset.xcube.cube` is empty.
   
 * Added a new utility module `xcube.util.temp` that allows for creating 
   temporary files and directories that will be deleted when the current 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,19 @@
     `xcube.core.gen2.service.RemoteCubeGenerator`;
   2. Generator CLI `xcube gen2`.
   
+* A data's cube subset and its grid mapping can now be accessed through
+  the `xcube` property of `xarray.Dataset` instances. This feature requires 
+  importing the `xcube.core.xarray`package. Let `dataset` be an 
+  instance of `xarray.Dataset`, then
+  - `dataset.xcube.cube` is a `xarray.Dataset` that contains all cube 
+     variables of `dataset`, namely the ones with dimensions 
+     `("time", [...,], y_dim_name, x_dim_name)`, where `y_dim_name`, 
+    `x_dim_name` are determined by the dataset's grid mapping.
+     May be empty, if `dataset` has no cube variables.
+  - `dataset.xcube.gm` is a `xcube.core.gridmapping.GridMapping` that 
+     describes the CF-compliant grid mapping of `dataset`. 
+     May be `None`, if `dataset` does not define a grid mapping.
+  
 * Added a new utility module `xcube.util.temp` that allows for creating 
   temporary files and directories that will be deleted when the current 
   process ends.

--- a/test/core/test_xarray.py
+++ b/test/core/test_xarray.py
@@ -3,6 +3,8 @@ import unittest
 import xarray as xr
 
 from test.sampledata import new_test_dataset
+from xcube.core.gridmapping import GridMapping
+from xcube.core.new import new_cube
 from xcube.core.xarray import DatasetAccessor
 
 
@@ -15,6 +17,37 @@ class XCubeDatasetAccessorTest(unittest.TestCase):
         self.assertTrue(hasattr(xr.Dataset, "xcube"))
         ds = xr.Dataset()
         self.assertTrue(hasattr(ds, "xcube"))
+
+    def test_non_empty_cube_subset(self):
+        dataset = new_cube(variables=dict(a=9, b=0.2))
+        cube = dataset.xcube.cube
+        self.assertIsInstance(cube, xr.Dataset)
+        self.assertEqual(set(dataset.data_vars), set(cube.data_vars))
+        gm = dataset.xcube.gm
+        self.assertIsInstance(gm, GridMapping)
+
+    def test_no_cube_subset(self):
+        dataset = xr.Dataset(dict(a=9, b=0.2))
+        cube = dataset.xcube.cube
+        self.assertIsInstance(cube, xr.Dataset)
+        self.assertEqual(set(), set(cube.data_vars))
+        self.assertIs(None, dataset.xcube.gm)
+        self.assertIs(dataset, dataset.xcube.non_cube)
+
+    ########################################################################
+    # Testing old API from here on.
+    #
+    # Let's quickly agree, if we should deprecate all this stuff. I guess,
+    # no one uses it.
+    #
+    # We should only add props and methods to this accessor
+    # that require a certain state to be hold.
+    # Such state could be props that are expensive to recompute,
+    # such as grid mappings.
+    #
+    # It causes too much overhead and maintenance work
+    # if we continue putting any xcube function here.
+    ########################################################################
 
     def test_new(self):
         self.assertIsInstance(xr.Dataset.xcube.new(), xr.Dataset)


### PR DESCRIPTION
**NOTE: this PR is based on PR #511**

Addresses both #112 and #391


A data's cube subset and its grid mapping can now be accessed through the `xcube` property of `xarray.Dataset` instances. This feature requires importing the `xcube.core.xarray`package. Let `dataset` be an instance of `xarray.Dataset`, then

* `dataset.xcube.cube` is a `xarray.Dataset` that contains all cube variables of `dataset`, namely the ones with dimensions `("time", [...,] y_dim_name, x_dim_name)`, where `y_dim_name`,  `x_dim_name` are determined by the dataset's grid mapping. May be empty, if `dataset` has no cube variables.
* `dataset.xcube.gm` is a `xcube.core.gridmapping.GridMapping` that describes the CF-compliant grid mapping of `dataset`. May be `None`, if `dataset` does not define a grid mapping.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!