### PR TITLE
Generator must rechunk before write

### DIFF
--- a/test/cli/test_gen2.py
+++ b/test/cli/test_gen2.py
@@ -22,6 +22,7 @@ class Gen2CliTest(CliTest):
         self.assertTrue(os.path.exists(result_file))
         with open(result_file) as fp:
             result_json = json.load(fp)
+        self.assertIsInstance(result_json, dict)
         return result_json
 
     def test_help(self):
@@ -122,10 +123,6 @@ class Gen2CliTest(CliTest):
         print(result.output)
         self.assertIsNotNone(result)
         result_json = self.read_result_json()
-        self.assertEqual(
-            {
-                'data_id': result_levels,
-                'status': 'ok'
-            },
-            result_json)
+        self.assertEqual('ok', result_json.get('status'))
+        self.assertEqual({'data_id': 'out.levels'}, result_json.get('result'))
         self.assertTrue(os.path.isdir(result_levels))

--- a/test/cli/test_gen2.py
+++ b/test/cli/test_gen2.py
@@ -113,6 +113,7 @@ class Gen2CliTest(CliTest):
         result = self.invoke_cli(['gen2',
                                   '-o', result_file,
                                   request_file])
+        print(result.output)
         self.assertIsNotNone(result)
         result_json = self.read_result_json()
         self.assertEqual(

--- a/test/cli/test_gen2.py
+++ b/test/cli/test_gen2.py
@@ -106,19 +106,19 @@ class Gen2CliTest(CliTest):
 
     # TODO (forman): zarr writing fails because of invalid chunking
     #   Make this test work in a subsequent PR.
-    #
-    # def test_copy_levels_gen(self):
-    #     request_file = os.path.join(os.path.dirname(__file__),
-    #                                 'gen2-requests', 'copy-levels.yml')
-    #     result = self.invoke_cli(['gen2',
-    #                               '-o', result_file,
-    #                               request_file])
-    #     self.assertIsNotNone(result)
-    #     result_json = self.read_result_json()
-    #     self.assertEqual(
-    #         {
-    #             'data_id': result_levels,
-    #             'status': 'ok'
-    #         },
-    #         result_json)
-    #     self.assertTrue(os.path.isdir(result_levels))
+
+    def test_copy_levels_gen(self):
+        request_file = os.path.join(os.path.dirname(__file__),
+                                    'gen2-requests', 'copy-levels.yml')
+        result = self.invoke_cli(['gen2',
+                                  '-o', result_file,
+                                  request_file])
+        self.assertIsNotNone(result)
+        result_json = self.read_result_json()
+        self.assertEqual(
+            {
+                'data_id': result_levels,
+                'status': 'ok'
+            },
+            result_json)
+        self.assertTrue(os.path.isdir(result_levels))

--- a/test/core/gen2/local/test_rechunker.py
+++ b/test/core/gen2/local/test_rechunker.py
@@ -33,14 +33,16 @@ class CubeRechunkerTest(unittest.TestCase):
         for k, v in cube2.coords.items():
             if v.chunks is not None:
                 self.assertIsInstance(v.chunks, tuple, msg=f'{k!r}={v!r}')
-                self.assertIn('chunks', v.encoding)
-                self.assertEqual([v.sizes[d] for d in v.dims],
-                                 v.encoding['chunks'])
+                self.assertNotIn('chunks', v.encoding)
+                # self.assertIn('chunks', v.encoding)
+                # self.assertEqual([v.sizes[d] for d in v.dims],
+                #                  v.encoding['chunks'])
         for k, v in cube2.data_vars.items():
             self.assertIsInstance(v.chunks, tuple, msg=f'{k!r}={v!r}')
             self.assertEqual(((2, 2, 1), (100, 80), (200, 160)), v.chunks)
-            self.assertIn('chunks', v.encoding)
-            self.assertEqual([2, 100, 200], v.encoding['chunks'])
+            self.assertNotIn('chunks', v.encoding)
+            # self.assertIn('chunks', v.encoding)
+            # self.assertEqual([2, 100, 200], v.encoding['chunks'])
 
     def test_chunks_are_larger_than_sizes(self):
         cube1 = new_cube(variables=dict(chl=0.6, tsm=0.9, flags=16))
@@ -64,11 +66,8 @@ class CubeRechunkerTest(unittest.TestCase):
         for k, v in cube2.coords.items():
             if v.chunks is not None:
                 self.assertIsInstance(v.chunks, tuple, msg=f'{k!r}={v!r}')
-                self.assertIn('chunks', v.encoding)
-                self.assertEqual([v.sizes[d] for d in v.dims],
-                                 v.encoding['chunks'])
+                self.assertNotIn('chunks', v.encoding)
         for k, v in cube2.data_vars.items():
             self.assertIsInstance(v.chunks, tuple, msg=f'{k!r}={v!r}')
             self.assertEqual(((5,), (180,), (360,)), v.chunks)
-            self.assertIn('chunks', v.encoding)
-            self.assertEqual([5, 180, 360], v.encoding['chunks'])
+            self.assertNotIn('chunks', v.encoding)

--- a/test/core/gridmapping/test_dataset.py
+++ b/test/core/gridmapping/test_dataset.py
@@ -39,13 +39,21 @@ class DatasetGridMappingTest(unittest.TestCase):
                                           crs='epsg:25832')
         gm1 = GridMapping.from_dataset(dataset)
         self.assertEqual(pyproj.CRS.from_string('epsg:25832'), gm1.crs)
-        dataset = dataset.drop('crs')
+        dataset = dataset.drop_vars('crs')
         gm2 = GridMapping.from_dataset(dataset)
         self.assertEqual(GEO_CRS, gm2.crs)
         gm3 = GridMapping.from_dataset(dataset, crs=gm1.crs)
         self.assertEqual(gm1.crs, gm3.crs)
         self.assertEqual(('x', 'y'), gm3.xy_var_names)
         self.assertEqual(('x', 'y'), gm3.xy_dim_names)
+
+    def test_from_regular_cube_no_chunks_and_chunks(self):
+        dataset = xcube.core.new.new_cube(variables=dict(rad=0.5))
+        gm1 = GridMapping.from_dataset(dataset)
+        self.assertEqual((360, 180), gm1.tile_size)
+        dataset = dataset.chunk(dict(lon=10, lat=20))
+        gm2 = GridMapping.from_dataset(dataset)
+        self.assertEqual((10, 20), gm2.tile_size)
 
     def test_from_non_regular_cube(self):
         lon = np.array([[8, 9.3, 10.6, 11.9],

--- a/test/core/test_compute.py
+++ b/test/core/test_compute.py
@@ -109,13 +109,13 @@ class ComputeCubeTest(unittest.TestCase):
         self.assertIsInstance(output_dataset, xr.Dataset)
         self.assertIn('analysed_sst_max', output_dataset.data_vars)
         output_var = output_dataset.analysed_sst_max
-        self.assertEqual(1, len(calls))  # call from dask with 0-dim chunks
+        self.assertEqual(0, len(calls))  # call from dask with 0-dim chunks
         self.assertEqual(('lat', 'lon'), output_var.dims)
         self.assertEqual((180, 360), output_var.shape)
         self.assertEqual(((90, 90), (90, 90, 90, 90)), output_var.chunks)
 
         values = output_var.values
-        self.assertEqual(1 + 2 * 4, len(calls))
+        self.assertEqual(2 * 4, len(calls))
         self.assertEqual((180, 360), values.shape)
         self.assertAlmostEqual(275.3 + 2.1, values[0, 0])
         self.assertAlmostEqual(275.3 + 2.1, values[-1, -1])

--- a/test/core/test_compute.py
+++ b/test/core/test_compute.py
@@ -109,13 +109,13 @@ class ComputeCubeTest(unittest.TestCase):
         self.assertIsInstance(output_dataset, xr.Dataset)
         self.assertIn('analysed_sst_max', output_dataset.data_vars)
         output_var = output_dataset.analysed_sst_max
-        self.assertEqual(0, len(calls))
+        self.assertEqual(1, len(calls))  # call from dask with 0-dim chunks
         self.assertEqual(('lat', 'lon'), output_var.dims)
         self.assertEqual((180, 360), output_var.shape)
         self.assertEqual(((90, 90), (90, 90, 90, 90)), output_var.chunks)
 
         values = output_var.values
-        self.assertEqual(2 * 4, len(calls))
+        self.assertEqual(1 + 2 * 4, len(calls))
         self.assertEqual((180, 360), values.shape)
         self.assertAlmostEqual(275.3 + 2.1, values[0, 0])
         self.assertAlmostEqual(275.3 + 2.1, values[-1, -1])

--- a/test/core/test_mldataset.py
+++ b/test/core/test_mldataset.py
@@ -65,19 +65,24 @@ class BaseMultiLevelDatasetTest(unittest.TestCase):
         self.assertIsInstance(ml_ds.ds_id, str)
 
         self.assertEqual(3, ml_ds.num_levels)
-        self.assertEqual(TileGrid(3, 2, 1, 180, 180, (-180, -90, 180, 90), inv_y=False),
+        self.assertEqual(TileGrid(3, 2, 1, 180, 180, (-180, -90, 180, 90),
+                                  inv_y=False),
                          ml_ds.tile_grid)
 
         ds0 = ml_ds.get_dataset(0)
-        self.assertIs(ds, ds0)
+        self.assertIsNot(ds, ds0)
+        self.assertEqual({'time': 14, 'lat': 720, 'lon': 1440, 'bnds': 2},
+                         ds0.dims)
 
         ds1 = ml_ds.get_dataset(1)
         self.assertIsNot(ds, ds1)
-        self.assertEqual({'time': 14, 'lat': 360, 'lon': 720}, ds1.dims)
+        self.assertEqual({'time': 14, 'lat': 360, 'lon': 720},
+                         ds1.dims)
 
         ds2 = ml_ds.get_dataset(2)
         self.assertIsNot(ds, ds2)
-        self.assertEqual({'time': 14, 'lat': 180, 'lon': 360}, ds2.dims)
+        self.assertEqual({'time': 14, 'lat': 180, 'lon': 360},
+                         ds2.dims)
 
         self.assertEqual([ds0, ds1, ds2], ml_ds.datasets)
 
@@ -149,7 +154,7 @@ def _get_test_dataset(var_names=('noise',)):
                   lat_bnds=(("lat", "bnds"), lat_bnds),
                   lon_bnds=(("lon", "bnds"), lon_bnds))
 
-    return xr.Dataset(coords=coords, data_vars=data_vars)
+    return xr.Dataset(coords=coords, data_vars=data_vars).chunk(dict(lat=180, lon=180))
 
 
 class ObjectStorageMultiLevelDatasetTest(S3Test):

--- a/test/util/test_tilegrid2.py
+++ b/test/util/test_tilegrid2.py
@@ -1,0 +1,119 @@
+from abc import abstractmethod, ABC
+from typing import Tuple, Union
+from unittest import TestCase
+
+from xcube.util.assertions import assert_true
+
+
+class TileGrid2(ABC):
+    @abstractmethod
+    def get_tile_size(self) -> Tuple[int, int]:
+        """Get the tile size in pixels."""
+
+    @abstractmethod
+    def get_num_tiles(self, level: int) -> Tuple[int, int]:
+        """Get the number of tiles at *level*"""
+
+    @abstractmethod
+    def get_resolution(self, level: int) -> float:
+        """Get the spatial resolution at *level*."""
+
+    @abstractmethod
+    def get_rectangle(self, level: int) -> Tuple[float, float, float, float]:
+        """Get the spatial resolution at *level*."""
+
+
+class GlobalCrs84TileGrid(TileGrid2):
+    def __init__(self,
+                 tile_size: Union[int, Tuple[int, int]] = 256):
+        if not tile_size:
+            tile_size = 256
+        elif not isinstance(tile_size, int):
+            tile_with, tile_height = tile_size
+            assert_true(tile_with == tile_height,
+                        message='tile_with, tile_height must be equal')
+            tile_size = tile_with
+        assert_true(tile_size >= 2, message='tile_size must be >= 2')
+        self._tile_size: int = tile_size
+        self._res_0 = 180.0 / tile_size
+        self._rectangle = -180, -90, 180, 90
+
+    def get_tile_size(self) -> Tuple[int, int]:
+        ts = self._tile_size
+        return ts, ts
+
+    def get_num_tiles(self, level: int) -> Tuple[int, int]:
+        factor = 1 << level
+        return 2 * factor, factor
+
+    def get_resolution(self, level: int) -> float:
+        factor = 1 << level
+        return self._res_0 / factor
+
+    def get_rectangle(self, level: int) -> Tuple[float, float, float, float]:
+        return self._rectangle
+
+
+class ArbitraryTileGrid(TileGrid2):
+    def __init__(self,
+                 image_size: Tuple[int, int],
+                 tile_size: Tuple[int, int],
+                 xy_min: Tuple[float, float],
+                 xy_res: float):
+        image_width, image_height = image_size
+        assert_true(image_width >= 2 and image_height >= 2,
+                    message='image_width and image_height must be >= 2')
+        self._image_width = int(image_width)
+        self._image_height = int(image_height)
+
+        tile_width, tile_height = tile_size
+        assert_true(tile_width >= 2 and tile_height >= 2,
+                    message='tile_width and tile_height must be >= 2')
+        tile_width = min(image_width, tile_width)
+        tile_height = min(image_height, tile_height)
+        self._tile_width = int(tile_width)
+        self._tile_height = int(tile_height)
+
+        x_min, y_min = xy_min
+        self._xy_min = x_min, y_min
+        assert_true(xy_res > 0,
+                    message='xy_res must be > 0')
+
+        self._xy_res = xy_res
+
+        num_levels = 1
+        image_width_0 = image_width
+        image_height_0 = image_height
+        while True:
+            image_width_0 //= 2
+            image_height_0 //= 2
+            if image_width_0 <= tile_width or image_height_0 <= tile_height:
+                break
+            num_levels += 1
+        num_level_0_tiles_x = (image_width_0 + tile_width - 1) // tile_width
+        num_level_0_tiles_y = (image_height_0 + tile_height - 1) // tile_height
+
+    def get_tile_size(self) -> Tuple[int, int]:
+        return self._tile_width, self._tile_height
+
+    def get_num_tiles(self, level: int) -> Tuple[int, int]:
+        image_with, image_height = self._image_width, self._image_height
+        tile_width, tile_height = self._tile_width, self._tile_height
+        factor = 1 << level
+        image_width_level = (image_with + 1) // factor
+        image_height_level = (image_height + 1) // factor
+        num_tiles_x = (image_width_level + tile_width - 1) // tile_width
+        num_tiles_y = (image_height_level + tile_height - 1) // tile_height
+        return num_tiles_x, num_tiles_y
+
+    def get_resolution(self, level: int) -> float:
+        factor = 1 << level
+        return self._res_0 / factor
+
+    def get_rectangle(self, level: int) -> Tuple[float, float, float, float]:
+        return self._rectangle
+
+
+class TilingGrid2Test(TestCase):
+    def test_it(self):
+        pass

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -167,8 +167,8 @@ def gen2(request_path: str,
                              'Cube generation failed.'
                              if error is None else f'{error}')
         click_error = click.ClickException(message)
-        if error is not None:
-            raise click_error from error
+        # if error is not None:
+        #     raise click_error from error
         raise click_error
 
 

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -167,9 +167,7 @@ def gen2(request_path: str,
                              'Cube generation failed.'
                              if error is None else f'{error}')
         click_error = click.ClickException(message)
-        # if error is not None:
-        #     raise click_error from error
-        raise click_error
+        raise click_error from error
 
 
 if __name__ == '__main__':

--- a/xcube/core/gen2/local/combiner.py
+++ b/xcube/core/gen2/local/combiner.py
@@ -23,6 +23,7 @@ from typing import Sequence
 
 import xarray as xr
 
+from xcube.util.progress import observe_progress
 from .transformer import TransformedCube
 from ..config import CubeConfig
 
@@ -38,6 +39,8 @@ class CubesCombiner:
         if len(t_cubes) == 1:
             return cube, gm, self._cube_config
 
-        cube = xr.merge([t_cube[0] for t_cube in t_cubes])
+        with observe_progress('merging cubes', 1) as observer:
+            cube = xr.merge([t_cube[0] for t_cube in t_cubes])
+            observer.worked(1)
 
         return cube, gm, self._cube_config

--- a/xcube/core/gen2/local/generator.py
+++ b/xcube/core/gen2/local/generator.py
@@ -156,6 +156,9 @@ class LocalCubeGenerator(CubeGenerator):
             progress.will_work(executor_work)
             t_cube = transform_cube(t_cube, code_executor)
 
+            progress.will_work(rechunker_work)
+            t_cube = transform_cube(t_cube, cube_rechunker)
+
             progress.will_work(writer_work)
             cube, gm, _ = t_cube
             if not is_empty_cube(cube):

--- a/xcube/core/gen2/local/generator.py
+++ b/xcube/core/gen2/local/generator.py
@@ -131,7 +131,7 @@ class LocalCubeGenerator(CubeGenerator):
                      + writer_work
 
         t_cubes = []
-        with observe_progress('Processing input dataset(s)',
+        with observe_progress('Generating cube',
                               total_work) as progress:
             for input_config in request.input_configs:
                 progress.will_work(opener_work)

--- a/xcube/core/gen2/local/generator.py
+++ b/xcube/core/gen2/local/generator.py
@@ -103,15 +103,15 @@ class LocalCubeGenerator(CubeGenerator):
         cube_resampler_xy = CubeResamplerXY()
         cube_resampler_t = CubeResamplerT()
         cube_combiner = CubesCombiner(request.cube_config)
-        cube_rechunker_1 = CubeRechunker()
+        cube_rechunker = CubeRechunker()
 
         code_config = request.code_config
         if code_config is not None:
             code_executor = CubeUserCodeExecutor(code_config)
-            cube_rechunker_2 = CubeRechunker()
+            cube_post_rechunker = CubeRechunker()
         else:
             code_executor = CubeIdentity()
-            cube_rechunker_2 = CubeIdentity()
+            cube_post_rechunker = CubeIdentity()
 
         cube_writer = CubeWriter(request.output_config,
                                  store_pool=self._store_pool)
@@ -123,17 +123,18 @@ class LocalCubeGenerator(CubeGenerator):
         resampler_xy_work = 20
         subsetter_work = 1
         combiner_work = num_inputs
-        rechunker_1_work = 1
+        rechunker_work = 1
         executor_work = 1
-        rechunker_2_work = 1
+        post_rechunker_work = 1
         writer_work = 100  # this is where dask processing takes place
         total_work = (opener_work
                       + subsetter_work
                       + resampler_t_work
                       + resampler_xy_work) * num_inputs \
-                     + rechunker_1_work \
+                     + combiner_work \
+                     + rechunker_work \
                      + executor_work \
-                     + rechunker_2_work \
+                     + post_rechunker_work \
                      + writer_work
 
         t_cubes = []
@@ -160,17 +161,17 @@ class LocalCubeGenerator(CubeGenerator):
             progress.will_work(combiner_work)
             t_cube = cube_combiner.combine_cubes(t_cubes)
 
-            progress.will_work(rechunker_1_work)
-            t_cube = transform_cube(t_cube, cube_rechunker_1,
+            progress.will_work(rechunker_work)
+            t_cube = transform_cube(t_cube, cube_rechunker,
                                     'rechunking')
 
             progress.will_work(executor_work)
             t_cube = transform_cube(t_cube, code_executor,
                                     'executing user code')
 
-            progress.will_work(rechunker_2_work)
-            t_cube = transform_cube(t_cube, cube_rechunker_2,
-                                    'rechunking second time')
+            progress.will_work(post_rechunker_work)
+            t_cube = transform_cube(t_cube, cube_post_rechunker,
+                                    'post-rechunking')
 
             progress.will_work(writer_work)
             cube, gm, _ = t_cube

--- a/xcube/core/gen2/local/rechunker.py
+++ b/xcube/core/gen2/local/rechunker.py
@@ -18,12 +18,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from typing import Tuple, Optional
 
 import xarray as xr
 
 from xcube.core.gridmapping import GridMapping
-from xcube.core.schema import get_dataset_chunks
+from xcube.core.schema import rechunk_cube
 from .transformer import CubeTransformer
 from .transformer import TransformedCube
 from ..config import CubeConfig
@@ -36,81 +35,7 @@ class CubeRechunker(CubeTransformer):
                        cube: xr.Dataset,
                        gm: GridMapping,
                        cube_config: CubeConfig) -> TransformedCube:
-
-        # get initial cube chunks from existing dataset
-        cube_chunks = get_dataset_chunks(cube)
-
-        # Get potential tile size
-        tile_size: Optional[Tuple[int, int]] = None
-        if cube_config.tile_size is not None:
-            tile_size = cube_config.tile_size
-        elif gm.tile_size is not None:
-            tile_size = gm.tile_size
-
-        # if tile sizes are specified, use them to overwrite
-        # the spatial dimensions
-        x_dim_name, y_dim_name = gm.xy_dim_names
-        if tile_size is not None:
-            tile_width, tile_height = tile_size
-            for dim_name, size in ((x_dim_name, tile_width),
-                                   (y_dim_name, tile_height)):
-                if dim_name not in cube_chunks:
-                    cube_chunks[dim_name] = size
-
-        # cube_config.chunks will overwrite any defaults
-        if cube_config.chunks:
-            for dim_name, chunks in cube_config.chunks:
-                cube_chunks[dim_name] = chunks
-
-        # If there is no chunking, return identities
-        if not cube_chunks:
-            return cube, gm, cube_config
-
-        chunked_cube = xr.Dataset(attrs=cube.attrs)
-
-        # Coordinate variables are chunked automatically
-        chunked_cube = chunked_cube.assign_coords(
-            coords={
-                var_name: var.chunk({
-                    dim_name: 'auto'
-                    for dim_name in var.dims
-                })
-                for var_name, var in cube.coords.items()
-            }
-        )
-
-        # Data variables are chunked according to cube_chunks
-        chunked_cube = chunked_cube.assign(
-            variables={
-                var_name: var.chunk({
-                    dim_name: cube_chunks.get(dim_name, 'auto')
-                    for dim_name in var.dims
-                })
-                for var_name, var in cube.data_vars.items()
-            }
-        )
-
-        # Test whether tile size has changed after re-chunking.
-        # If so, we must change the grid mapping too.
-        tile_width = cube_chunks.get(x_dim_name)
-        tile_height = cube_chunks.get(y_dim_name)
-        assert tile_width is not None
-        assert tile_height is not None
-        tile_size = (tile_width, tile_height)
-        if tile_size != gm.tile_size:
-            # Note, changing grid mapping tile size may
-            # rechunk (2D) coordinates in chunked_cube too
-            gm = gm.derive(tile_size=tile_size)
-
-        # Update chunks encoding for Zarr
-        for var in chunked_cube.variables.values():
-            if var.chunks is not None:
-                # sizes[0] is the first of
-                # e.g. sizes = (512, 512, 71)
-                var.encoding.update(chunks=[
-                    sizes[0] for sizes in var.chunks
-                ])
-            elif 'chunks' in var.encoding:
-                del var.encoding['chunks']
-
-        return chunked_cube, gm, cube_config
+        cube, gm = rechunk_cube(cube, gm,
+                                chunks=cube_config.chunks,
+                                tile_size=cube_config.tile_size)
+        return cube, gm, cube_config

--- a/xcube/core/gen2/local/transformer.py
+++ b/xcube/core/gen2/local/transformer.py
@@ -25,7 +25,9 @@ from typing import Tuple
 import xarray as xr
 
 from xcube.core.gridmapping import GridMapping
-from .helpers import is_empty_cube, strip_cube
+from xcube.util.progress import observe_progress
+from .helpers import is_empty_cube
+from .helpers import strip_cube
 from ..config import CubeConfig
 
 TransformedCube = Tuple[xr.Dataset, GridMapping, CubeConfig]
@@ -54,12 +56,28 @@ class CubeIdentity(CubeTransformer):
                        cube: xr.Dataset,
                        gm: GridMapping,
                        cube_config: CubeConfig) -> TransformedCube:
-        """Return *cube*, grid mapping *gm*, and parameters without change."""
+        """
+        Return *cube*, grid mapping *gm*, and parameters without change.
+        """
         return cube, gm, cube_config
 
 
-def transform_cube(t_cube: TransformedCube, transformer: CubeTransformer) -> TransformedCube:
-    if is_empty_cube(t_cube[0]):
-        return t_cube
-    t_cube = transformer.transform_cube(*t_cube)
-    return strip_cube(t_cube[0]), t_cube[1], t_cube[2]
+def transform_cube(t_cube: TransformedCube,
+                   transformer: CubeTransformer,
+                   label: str = '') -> TransformedCube:
+    empty_cube = is_empty_cube(t_cube[0])
+    identity = isinstance(transformer, CubeIdentity)
+    if not label:
+        label = f'{type(transformer).__name__}'
+    if identity:
+        label += ' (step not applicable)'
+    elif empty_cube:
+        label += ' (step not applicable, empty cube)'
+
+    with observe_progress(label, 1) as progress:
+        if not (identity or empty_cube):
+            t_cube = transformer.transform_cube(*t_cube)
+            t_cube = strip_cube(t_cube[0]), t_cube[1], t_cube[2]
+        progress.worked(1)
+
+    return t_cube

--- a/xcube/core/gen2/local/usercode.py
+++ b/xcube/core/gen2/local/usercode.py
@@ -25,6 +25,7 @@ import jsonschema
 import xarray as xr
 
 from xcube.core.byoa import CodeConfig
+from xcube.core.gridmapping import GridMapping
 from xcube.util.jsonschema import JsonObjectSchema
 from .transformer import CubeTransformer
 from .transformer import TransformedCube
@@ -33,7 +34,6 @@ from ..error import CubeGeneratorError
 from ..processor import DatasetProcessor
 from ..processor import METHOD_NAME_DATASET_PROCESSOR
 from ..processor import METHOD_NAME_PARAMS_SCHEMA_GETTER
-from ...gridmapping import GridMapping
 
 
 class CubeUserCodeExecutor(CubeTransformer):

--- a/xcube/core/gen2/local/writer.py
+++ b/xcube/core/gen2/local/writer.py
@@ -18,7 +18,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import warnings
 from typing import Tuple
 
 import xarray as xr
@@ -29,8 +28,7 @@ from xcube.core.store import DataStorePool
 from xcube.core.store import get_data_store_instance
 from xcube.core.store import new_data_writer
 from xcube.util.progress import observe_dask_progress
-from .helpers import is_empty_cube
-from ..config import OutputConfig, CubeConfig
+from ..config import OutputConfig
 
 
 class CubeWriter:
@@ -45,7 +43,7 @@ class CubeWriter:
                    gm: GridMapping) -> Tuple[str, xr.Dataset]:
         output_config = self._output_config
         dataset = encode_cube(cube, grid_mapping=gm)
-        with observe_dask_progress('Writing output', 100):
+        with observe_dask_progress('writing cube', 100):
             write_params = output_config.write_params or {}
             store_params = output_config.store_params or {}
             if output_config.store_id:

--- a/xcube/core/gridmapping/cfconv.py
+++ b/xcube/core/gridmapping/cfconv.py
@@ -20,7 +20,7 @@
 # SOFTWARE.
 
 import warnings
-from typing import Optional, Dict, Any, Hashable, Union, Set, List
+from typing import Optional, Dict, Any, Hashable, Union, Set, List, Tuple
 
 import pyproj
 import xarray as xr
@@ -32,26 +32,25 @@ class GridCoords:
     type xarray.DataArray.
     """
 
-    def __init__(self,
-                 x: xr.DataArray = None,
-                 y: xr.DataArray = None):
-        self.x = x
-        self.y = y
+    def __init__(self):
+        self.x: Optional[xr.DataArray] = None
+        self.y: Optional[xr.DataArray] = None
 
 
 class GridMappingProxy:
     """
     Grid mapping comprising *crs* of type pyproj.crs.CRS,
-    grid coordinates and an optional name.
+    grid coordinates, an optional name, coordinates, and a
+    tile size (= spatial chunk sizes).
     """
 
     def __init__(self,
                  crs: pyproj.crs.CRS,
-                 name: str = None,
-                 coords: GridCoords = None):
-        self.crs = crs
-        self.name = name
-        self.coords = coords
+                 name: Optional[str] = None):
+        self.crs: pyproj.crs.CRS = crs
+        self.name: Optional[str] = name
+        self.coords: Optional[xr.DataArray] = None
+        self.tile_size: Optional[Tuple[int, int]] = None
 
 
 def get_dataset_grid_mapping_proxies(
@@ -76,26 +75,26 @@ def get_dataset_grid_mapping_proxies(
     """
     # Find any grid mapping variables
     #
-    grid_mappings = dict()
+    grid_mapping_proxies = dict()
     for var_name, var in dataset.variables.items():
-        grid_mapping = _parse_crs_from_attrs(var.attrs)
-        if grid_mapping is not None:
-            grid_mappings[var_name] = grid_mapping
+        gmp = _parse_crs_from_attrs(var.attrs)
+        if gmp is not None:
+            grid_mapping_proxies[var_name] = gmp
 
     # If no grid mapping variables found,
     # try if CRS is encoded in dataset attributes
     #
-    if not grid_mappings:
-        grid_mapping = _parse_crs_from_attrs(dataset.attrs)
-        if grid_mapping is not None:
-            grid_mappings[None] = grid_mapping
+    if not grid_mapping_proxies:
+        gmp = _parse_crs_from_attrs(dataset.attrs)
+        if gmp is not None:
+            grid_mapping_proxies[None] = gmp
 
     # Find coordinate variables.
     #
 
-    latitude_longitude_coords = GridCoords(x=None, y=None)
-    rotated_latitude_longitude_coords = GridCoords(x=None, y=None)
-    projected_coords = GridCoords(x=None, y=None)
+    latitude_longitude_coords = GridCoords()
+    rotated_latitude_longitude_coords = GridCoords()
+    projected_coords = GridCoords()
 
     potential_coord_vars = _find_potential_coord_vars(dataset)
 
@@ -142,42 +141,57 @@ def get_dataset_grid_mapping_proxies(
 
     # Assign found coordinates to grid mappings
     #
-    for grid_mapping in grid_mappings.values():
-        if grid_mapping.name == 'latitude_longitude':
-            grid_mapping.coords = latitude_longitude_coords
-        elif grid_mapping.name == 'rotated_latitude_longitude':
-            grid_mapping.coords = rotated_latitude_longitude_coords
+    for gmp in grid_mapping_proxies.values():
+        if gmp.name == 'latitude_longitude':
+            gmp.coords = latitude_longitude_coords
+        elif gmp.name == 'rotated_latitude_longitude':
+            gmp.coords = rotated_latitude_longitude_coords
         else:
-            grid_mapping.coords = projected_coords
+            gmp.coords = projected_coords
 
     _complement_grid_mapping_coords(latitude_longitude_coords,
                                     'latitude_longitude',
                                     missing_latitude_longitude_crs
                                     or pyproj.crs.CRS(4326),
-                                    grid_mappings)
+                                    grid_mapping_proxies)
     _complement_grid_mapping_coords(rotated_latitude_longitude_coords,
                                     'rotated_latitude_longitude',
                                     missing_rotated_latitude_longitude_crs,
-                                    grid_mappings)
+                                    grid_mapping_proxies)
     _complement_grid_mapping_coords(projected_coords,
                                     None,
                                     missing_projected_crs,
-                                    grid_mappings)
+                                    grid_mapping_proxies)
 
     # Collect complete grid mappings
     complete_grid_mappings = dict()
-    for var_name, grid_mapping in grid_mappings.items():
-        if grid_mapping.coords is not None \
-                and grid_mapping.coords.x is not None \
-                and grid_mapping.coords.y is not None:
-            # TODO: add more consistency checks,
-            #   e.g. both 1d or both 2d with same dims
-            complete_grid_mappings[var_name] = grid_mapping
+    for var_name, gmp in grid_mapping_proxies.items():
+        if gmp.coords is not None \
+                and gmp.coords.x is not None \
+                and gmp.coords.y is not None \
+                and gmp.coords.x.size >= 2 \
+                and gmp.coords.y.size >= 2 \
+                and gmp.coords.x.ndim == gmp.coords.y.ndim:
+            if gmp.coords.x.ndim == 1:
+                gmp.tile_size = _find_dataset_tile_sizes(
+                    dataset,
+                    gmp.coords.x.dims[0],
+                    gmp.coords.y.dims[0]
+                )
+                complete_grid_mappings[var_name] = gmp
+            elif gmp.coords.x.ndim == 2 \
+                    and gmp.coords.x.dims == gmp.coords.y.dims:
+                gmp.tile_size = _find_dataset_tile_sizes(
+                    dataset,
+                    gmp.coords.x.dims[1],
+                    gmp.coords.x.dims[0]
+                )
+                complete_grid_mappings[var_name] = gmp
         elif emit_warnings:
-            warnings.warn(f'CRS "{grid_mapping.name}": '
+            warnings.warn(f'CRS "{gmp.name}": '
                           f'missing x- and/or y-coordinates '
                           f'(grid mapping variable "{var_name}": '
-                          f'grid_mapping_name="{grid_mapping.name}")')
+                          f'grid_mapping_name="{gmp.name}")')
 
     return complete_grid_mappings
 
@@ -190,8 +204,7 @@ def _parse_crs_from_attrs(attrs: Dict[Hashable, Any]) \
     except pyproj.crs.CRSError:
         return None
     return GridMappingProxy(crs=crs,
-                            name=attrs.get('grid_mapping_name'),
-                            coords=None)
+                            name=attrs.get('grid_mapping_name'))
 
 
 def _complement_grid_mapping_coords(
@@ -208,8 +221,7 @@ def _complement_grid_mapping_coords(
             grid_mapping = grid_mappings.get(None)
             if grid_mapping is None and missing_crs is not None:
                 grid_mapping = GridMappingProxy(crs=missing_crs,
-                                                name=grid_mapping_name,
-                                                coords=None)
+                                                name=grid_mapping_name)
                 grid_mappings[None] = grid_mapping
 
         if grid_mapping is not None and grid_mapping.coords is None:
@@ -258,3 +270,35 @@ def _is_potential_coord_var(dataset: xr.Dataset,
         var = dataset[var_name]
         return var.ndim in (1, 2) and var_name not in bounds_var_names
     return False
+
+
+def _find_dataset_tile_sizes(dataset: xr.Dataset,
+                             x_dim_name: Hashable,
+                             y_dim_name: Hashable) \
+        -> Optional[Tuple[int, int]]:
+    """Find the most likely tile size in *dataset*"""
+    tile_sizes: Dict[Any, int] = {}
+    for var_name, var in dataset.variables.items():
+        if var.ndim >= 2 \
+                and var.dims[-1] == x_dim_name \
+                and var.dims[-2] == y_dim_name \
+                and var.chunks \
+                and len(var.chunks) == var.ndim:
+            x_chunks = var.chunks[-1]
+            y_chunks = var.chunks[-2]
+            tile_size = (
+                max(0, *x_chunks),
+                max(0, *y_chunks)
+            )
+            if tile_size in tile_sizes:
+                tile_sizes[tile_size] += 1
+            else:
+                tile_sizes[tile_size] = 1
+
+    common_tile_size = None
+    max_count = 0
+    for tile_size, count in tile_sizes.items():
+        if count > max_count:
+            max_count = count
+            common_tile_size = tile_size
+    return common_tile_size

--- a/xcube/core/gridmapping/dataset.py
+++ b/xcube/core/gridmapping/dataset.py
@@ -68,7 +68,7 @@ def new_grid_mapping_from_dataset(
         new_grid_mapping_from_coords(x_coords=gmp.coords.x,
                                      y_coords=gmp.coords.y,
                                      crs=gmp.crs,
-                                     tile_size=tile_size,
+                                     tile_size=tile_size or gmp.tile_size,
                                      tolerance=tolerance)
         for gmp in grid_mapping_proxies
     ]

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -13,7 +13,6 @@ from xcube.constants import FORMAT_NAME_LEVELS
 from xcube.constants import FORMAT_NAME_NETCDF4
 from xcube.constants import FORMAT_NAME_SCRIPT
 from xcube.constants import FORMAT_NAME_ZARR
-from xcube.core.chunk import chunk_dataset
 from xcube.core.dsio import guess_dataset_format
 from xcube.core.dsio import is_s3_url
 from xcube.core.dsio import parse_s3_fs_and_root
@@ -21,6 +20,7 @@ from xcube.core.dsio import write_cube
 from xcube.core.geom import get_dataset_bounds
 from xcube.core.gridmapping import GridMapping
 from xcube.core.normalize import decode_cube
+from xcube.core.schema import rechunk_cube
 from xcube.core.verify import assert_cube
 from xcube.util.assertions import assert_instance
 from xcube.util.perf import measure_time
@@ -487,13 +487,9 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
         # Tile each level according to grid mapping
         tile_size = self.grid_mapping.tile_size
         if tile_size is not None:
-            tile_width, tile_height = tile_size
-            x_dim_name, y_dim_name = self.grid_mapping.xy_dim_names
-            level_dataset = chunk_dataset(level_dataset, {
-                x_dim_name: tile_width,
-                y_dim_name: tile_height
-            })
-
+            level_dataset, _ = rechunk_cube(level_dataset,
+                                            self.grid_mapping,
+                                            tile_size=tile_size)
         return level_dataset
 
 

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -18,8 +18,10 @@ from xcube.core.dsio import is_s3_url
 from xcube.core.dsio import parse_s3_fs_and_root
 from xcube.core.dsio import write_cube
 from xcube.core.geom import get_dataset_bounds
+from xcube.core.gridmapping import GridMapping
 from xcube.core.normalize import decode_cube
 from xcube.core.verify import assert_cube
+from xcube.util.assertions import assert_instance
 from xcube.util.perf import measure_time
 from xcube.util.tilegrid import TileGrid
 
@@ -44,6 +46,13 @@ class MultiLevelDataset(metaclass=ABCMeta):
     def ds_id(self) -> str:
         """
         :return: the dataset identifier.
+        """
+
+    @property
+    @abstractmethod
+    def grid_mapping(self) -> GridMapping:
+        """
+        :return: the CF-conformal grid mapping
         """
 
     @property
@@ -111,9 +120,11 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
     """
 
     def __init__(self,
+                 grid_mapping: GridMapping = None,
                  tile_grid: TileGrid = None,
                  ds_id: str = None,
                  parameters: Mapping[str, Any] = None):
+        self._grid_mapping = grid_mapping
         self._tile_grid = tile_grid
         self._ds_id = ds_id
         self._level_datasets: Dict[int, xr.Dataset] = {}
@@ -126,6 +137,13 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
             with self._lock:
                 self._ds_id = str(uuid.uuid4())
         return self._ds_id
+
+    @property
+    def grid_mapping(self) -> GridMapping:
+        if self._grid_mapping is None:
+            with self._lock:
+                self._grid_mapping = self._get_grid_mapping_lazily()
+        return self._grid_mapping
 
     @property
     def tile_grid(self) -> TileGrid:
@@ -173,6 +191,14 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
         :param parameters: *parameters* keyword argument that was passed to constructor.
         :return: the dataset for the level at *index*.
         """
+
+    def _get_grid_mapping_lazily(self) -> GridMapping:
+        """
+        Retrieve, i.e. read or compute, the tile grid used by the multi-level dataset.
+
+        :return: the dataset for the level at *index*.
+        """
+        return GridMapping.for_dataset(self.get_dataset(0))
 
     def _get_tile_grid_lazily(self) -> TileGrid:
         """
@@ -422,14 +448,18 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
     :param ds_id: Optional dataset identifier.
     """
 
-    def __init__(self, base_dataset: xr.Dataset, tile_grid: TileGrid = None, ds_id: str = None):
-        super().__init__(tile_grid=tile_grid, ds_id=ds_id)
-        if base_dataset is None:
-            raise ValueError("base_dataset must be given")
-        self._base_dataset = base_dataset
-        self._base_cube, self._grid_mapping, _ = decode_cube(
-            base_dataset
+    def __init__(self,
+                 base_dataset: xr.Dataset,
+                 tile_grid: TileGrid = None,
+                 ds_id: str = None):
+        assert_instance(base_dataset, xr.Dataset, name='base_dataset')
+        self._base_cube, grid_mapping, _ = decode_cube(
+            base_dataset,
+            force_non_empty=True
         )
+        super().__init__(grid_mapping=grid_mapping,
+                         tile_grid=tile_grid,
+                         ds_id=ds_id)
 
     def _get_dataset_lazily(self, index: int, parameters: Dict[str, Any]) -> xr.Dataset:
         """
@@ -441,7 +471,7 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
         :return: the dataset for the level at *index*.
         """
         if index == 0:
-            level_dataset = self._base_dataset
+            level_dataset = self._base_cube
         else:
             base_dataset = self._base_cube
             step = 2 ** index
@@ -451,7 +481,7 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
                 var = var[..., ::step, ::step]
                 data_vars[var_name] = var
             level_dataset = xr.Dataset(data_vars,
-                                       attrs=self._base_dataset.attrs)
+                                       attrs=self._base_cube.attrs)
         return level_dataset
 
 

--- a/xcube/core/normalize.py
+++ b/xcube/core/normalize.py
@@ -232,7 +232,9 @@ def decode_cube(dataset: xr.Dataset,
         # Pure cube!
         return dataset, grid_mapping, xr.Dataset()
 
-    return (dataset.drop_vars(dropped_vars),
+    cube = dataset.drop_vars(dropped_vars).assign_attrs(dataset.attrs)
+
+    return (cube,
             grid_mapping,
             dataset.drop_vars(cube_vars))
 

--- a/xcube/util/tilegrid2.py
+++ b/xcube/util/tilegrid2.py
@@ -1,0 +1,295 @@
+from abc import abstractmethod, ABC
+from typing import Tuple, Optional, Union, Dict, Any
+
+import pyproj
+
+from xcube.util.assertions import assert_instance
+from xcube.util.assertions import assert_true
+
+
+class TileGrid2(ABC):
+    """
+    This interface defines a tile grid as used by the
+    OpenLayers or Cesium UI JavaScript libraries.
+    """
+
+    @property
+    @abstractmethod
+    def tile_size(self) -> Tuple[int, int]:
+        """Tile size in pixels."""
+
+    @property
+    def min_level(self) -> Optional[int]:
+        """The minimum level of detail."""
+        return None
+
+    @property
+    def max_level(self) -> Optional[int]:
+        """The maximum level of detail."""
+        return None
+
+    @abstractmethod
+    def get_image_size(self, level: int) -> Tuple[int, int]:
+        """Get the image size at given *level* of detail."""
+
+    @abstractmethod
+    def get_num_tiles(self, level: int) -> Tuple[int, int]:
+        """Get the number of tiles at given *level* of detail."""
+
+    @property
+    @abstractmethod
+    def crs(self) -> pyproj.CRS:
+        """Spatial CRS."""
+
+    @property
+    @abstractmethod
+    def extent(self) -> Tuple[float, float, float, float]:
+        """Spatial extent in units of the CRS."""
+
+    @property
+    @abstractmethod
+    def origin(self) -> Tuple[float, float]:
+        """Spatial origin in units of the CRS."""
+
+    @abstractmethod
+    def get_resolution(self, level: int) -> float:
+        """Get the spatial resolution at given *level* of detail."""
+
+
+class BaseTileGrid(TileGrid2):
+    """
+    The default implementation of the :class:`TileGrid2`
+    interface.
+
+    :param tile_size: Tile width and height,
+        given as a tuple of positive integers.
+    :param num_level_0_tiles: Number of tiles at level zero,
+        the lowest level of detail,
+        in x and y direction
+        given as a tuple of positive integers.
+    :param crs: The spatial coordinate reference system.
+    :param res_level_0: The spatial resolution at level zero,
+        the lowest level of detail
+        given as size in CRS units per pixel.
+    :param extent: The extent of the tile grid given as
+        (x_min, y_min, x_max, y_max) in units of the spatial CRS.
+    :param origin: The origin in units of the CRS units
+        where x,y axes of the tile grid meet.
+    :param min_level: Optional minimum level of detail.
+    :param max_level: Optional maximum level of detail.
+    """
+
+    def __init__(self,
+                 tile_size: Tuple[int, int],
+                 num_level_0_tiles: Tuple[int, int],
+                 crs: pyproj.CRS,
+                 res_level_0: float,
+                 extent: Tuple[float, float, float, float],
+                 origin: Optional[Tuple[float, float]] = None,
+                 min_level: Optional[int] = None,
+                 max_level: Optional[int] = None):
+        tile_width, tile_height = tile_size
+        assert_instance(tile_width, int, name='tile_width')
+        assert_instance(tile_height, int, name='tile_height')
+        num_level_0_tiles_x, num_level_0_tiles_y = num_level_0_tiles
+        assert_instance(num_level_0_tiles_x, int, name='num_level_0_tiles_x')
+        assert_instance(num_level_0_tiles_y, int, name='num_level_0_tiles_y')
+        if isinstance(crs, str):
+            crs = pyproj.CRS.from_string(crs)
+        assert_instance(crs, pyproj.CRS, name='crs')
+
+        self._tile_size = tile_width, tile_height
+        self._num_level_zero_tiles = num_level_0_tiles_x, num_level_0_tiles_y
+        self._min_level = min_level
+        self._max_level = max_level
+
+        self._crs = crs
+        self._res_level_0 = res_level_0
+        self._extent = tuple(extent)
+        self._origin = tuple(origin) if origin else (extent[0], extent[1])
+
+    @property
+    def crs(self) -> pyproj.CRS:
+        return self._crs
+
+    @property
+    def extent(self) -> Tuple[float, float, float, float]:
+        return tuple(self._extent)
+
+    @property
+    def origin(self) -> Tuple[float, float]:
+        return tuple(self._origin)
+
+    @property
+    def min_level(self) -> Optional[int]:
+        return self._min_level
+
+    @property
+    def max_level(self) -> Optional[int]:
+        return self._max_level
+
+    @property
+    def tile_size(self) -> Tuple[int, int]:
+        return tuple(self._tile_size)
+
+    def get_image_size(self, level: int) -> Tuple[int, int]:
+        tile_width, tile_height = self.tile_size
+        num_tiles_x, num_tiles_y = self.get_num_tiles(level)
+        return num_tiles_x * tile_width, num_tiles_y * tile_height
+
+    def get_num_tiles(self, level: int) -> Tuple[int, int]:
+        num_level_0_tiles_x, num_level_0_tiles_y = self._num_level_zero_tiles
+        factor = 1 << level
+        return num_level_0_tiles_x * factor, num_level_0_tiles_y * factor
+
+    def get_resolution(self, level: int) -> float:
+        factor = 1 << level
+        return self._res_level_0 / factor
+
+
+GEOGRAPHIC_CRS = pyproj.CRS.from_string('CRS84')
+WEB_MERCATOR_CRS = pyproj.CRS.from_string('EPSG:3857')
+
+
+class GeographicTileGrid(BaseTileGrid):
+    """
+    A global CRS-84 tile grid with 2 horizontal tiles and 1 vertical tile
+    at level zero.
+
+    :param tile_size: Tile size, defaults to 256.
+    :param min_level: Optional minimum level of detail.
+    :param max_level: Optional maximum level of detail.
+    """
+
+    def __init__(self,
+                 tile_size: int = 256,
+                 min_level: Optional[int] = None,
+                 max_level: Optional[int] = None):
+        """
+
+        :param tile_size:
+        :param min_level:
+        :param max_level:
+        """
+        assert_instance(tile_size, int, name='tile_size')
+        super().__init__(
+            tile_size=(tile_size, tile_size),
+            num_level_0_tiles=(2, 1),
+            crs=GEOGRAPHIC_CRS,
+            res_level_0=180 / tile_size,
+            extent=(-180., -90., 180., 90.),
+            min_level=min_level,
+            max_level=max_level
+        )
+
+
+class ImageTileGrid(BaseTileGrid):
+    """
+    A tile grid that is created from a base image of size *image_size*.
+
+    :param image_size: Size of the base image.
+    :param tile_size: Tile size of the base image.
+    :param crs: Spatial CRS.
+    :param image_res: Spatial resolution of the base image
+        in CRS units per pixel.
+    :param image_origin: Origin of the base image
+        in CRS units.
+    """
+
+    def __init__(self,
+                 image_size: Tuple[int, int],
+                 tile_size: Tuple[int, int],
+                 crs: Union[str, pyproj.CRS],
+                 image_res: float,
+                 image_origin: Tuple[float, float]):
+        image_width, image_height = image_size
+        assert_true(image_width >= 2 and image_height >= 2,
+                    message='image_width and image_height must be >= 2')
+        self._image_width = int(image_width)
+        self._image_height = int(image_height)
+
+        tile_width, tile_height = tile_size
+        assert_true(tile_width >= 2 and tile_height >= 2,
+                    message='tile_width and tile_height must be >= 2')
+        tile_width = min(image_width, tile_width)
+        tile_height = min(image_height, tile_height)
+
+        assert_true(image_res > 0,
+                    message='xy_res must be > 0')
+
+        num_levels = 1
+        image_level_width = image_width
+        image_level_height = image_height
+        while True:
+            num_level_0_tiles_x = (image_level_width + tile_width - 1) \
+                                  // tile_width
+            num_level_0_tiles_y = (image_level_height + tile_height - 1) \
+                                  // tile_height
+            if num_level_0_tiles_x == 1 or num_level_0_tiles_y == 1:
+                break
+            image_level_width = (image_level_width + 1) // 2
+            image_level_height = (image_level_height + 1) // 2
+            num_levels += 1
+
+        x_min, y_min = image_origin
+        extent = (x_min,
+                  y_min,
+                  x_min + image_width * image_res,
+                  y_min + image_height * image_res)
+
+        factor = 1 << (num_levels - 1)
+
+        super().__init__(tile_size=(tile_width, tile_height),
+                         num_level_0_tiles=(num_level_0_tiles_x,
+                                            num_level_0_tiles_y),
+                         crs=crs,
+                         res_level_0=image_res * factor,
+                         extent=extent,
+                         max_level=num_levels - 1)
+
+    def get_image_size(self, level: int) -> Tuple[int, int]:
+        factor = 1 << (self.max_level - level)
+        return self._image_width // factor, self._image_height // factor
+
+
+def tile_grid_to_ol_xyz_source_options(tile_grid: TileGrid2, url: str) \
+        -> Dict[str, Any]:
+    """
+    Convert :class:`TileGrid2` instance into options to be used with
+    ``ol.source.XYZ(options)`` of OpenLayers 4+.
+
+    See
+
+    * https://openlayers.org/en/latest/apidoc/module-ol_source_XYZ-XYZ.html
+    * https://openlayers.org/en/latest/apidoc/module-ol_tilegrid_TileGrid-TileGrid.html
+    * https://openlayers.org/en/latest/examples/xyz.html
+
+    :param tile_grid: tile grid
+    :param url: source url
+    :return: A JSON object that represents the ``options`` to be passed to
+        OpenLayers ``ol.source.XYZ(options)``.
+    """
+    options = {
+        'url': url,
+        'projection': tile_grid.crs.srs
+    }
+
+    if tile_grid.max_level is not None:
+        tile_grid_options = {
+            'extent': list(tile_grid.extent),
+            'origin': list(tile_grid.origin),
+            'tileSize': list(tile_grid.tile_size),
+            'sizes': [list(tile_grid.get_num_tiles(i))
+                      for i in range(tile_grid.max_level + 1)],
+            'resolutions': [tile_grid.get_resolution(i)
+                            for i in range(tile_grid.max_level + 1)]}
+        if tile_grid.min_level is not None:
+            tile_grid_options['minZoom'] = tile_grid.min_level
+        options['tileGrid'] = tile_grid_options
+    else:
+        if tile_grid.min_level is not None:
+            options['minZoom'] = tile_grid.min_level
+        options['tileSize'] = list(tile_grid.tile_size)
+        options['maxResolution'] = float(tile_grid.get_resolution(0))
+
+    return options


### PR DESCRIPTION
**This PR is based on PR #513 which should be merged first.**
 
Generator fails for some inputs for `zarr` and mostly for `levels` output formats due to invalid chunking. In case of  `levels`, chunking of level datasets changes after downsampling, which causes the issue in almost all cases.

This PR ensures, that cubes are always chunked and encoded correctly before they are written as `zarr` or `levels`. 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!