### PR TITLE
Harmonize JSON format of generator results

### DIFF
--- a/test/cli/test_gen2.py
+++ b/test/cli/test_gen2.py
@@ -36,12 +36,13 @@ class Gen2CliTest(CliTest):
                                   request_file])
         self.assertIsNotNone(result)
         result_json = self.read_result_json()
-        self.assertEqual(
-            {
-                'data_id': result_zarr,
-                'status': 'ok'
-            },
-            result_json)
+        self.assertEqual('ok', result_json.get('status'))
+        self.assertIsInstance(result_json.get('message'), str)
+        self.assertIn('Cube generated successfully after ',
+                      result_json.get('message'))
+        result = result_json.get('result')
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result_zarr, result.get('data_id'))
         self.assertTrue(os.path.isdir(result_zarr))
 
     def test_copy_zarr_info(self):
@@ -53,6 +54,11 @@ class Gen2CliTest(CliTest):
                                   request_file])
         self.assertIsNotNone(result)
         result_json = self.read_result_json()
+
+        self.assertEqual('ok', result_json.get('status'))
+        result = result_json.get('result')
+        self.assertIsInstance(result, dict)
+
         self.assertEqual(
             {
                 'dataset_descriptor': {
@@ -101,7 +107,7 @@ class Gen2CliTest(CliTest):
                     'tile_size': [2000, 1000]
                 }
             },
-            result_json)
+            result)
         self.assertFalse(os.path.isdir(result_zarr))
 
     # TODO (forman): zarr writing fails because of invalid chunking

--- a/test/core/gen2/local/test_generator.py
+++ b/test/core/gen2/local/test_generator.py
@@ -9,7 +9,9 @@ import yaml
 from xcube.core.dsio import rimraf
 from xcube.core.gen2.generator import CubeGenerator
 from xcube.core.gen2.local.generator import LocalCubeGenerator
-from xcube.core.gen2.response import CubeInfo, CubeInfoResult, CubeReference
+from xcube.core.gen2.response import CubeInfo
+from xcube.core.gen2.response import CubeInfoResult
+from xcube.core.gen2.response import CubeReference
 from xcube.core.new import new_cube
 from xcube.core.store import DatasetDescriptor
 from xcube.core.store import MutableDataStore

--- a/test/core/gen2/local/test_generator.py
+++ b/test/core/gen2/local/test_generator.py
@@ -9,7 +9,7 @@ import yaml
 from xcube.core.dsio import rimraf
 from xcube.core.gen2.generator import CubeGenerator
 from xcube.core.gen2.local.generator import LocalCubeGenerator
-from xcube.core.gen2.response import CubeInfo
+from xcube.core.gen2.response import CubeInfo, CubeInfoResult, CubeReference
 from xcube.core.new import new_cube
 from xcube.core.store import DatasetDescriptor
 from xcube.core.store import MutableDataStore
@@ -68,8 +68,9 @@ class LocalCubeGeneratorTest(unittest.TestCase):
         m.put(CALLBACK_MOCK_URL, json={})
         result = LocalCubeGenerator(verbosity=1).generate_cube(self.REQUEST)
         self.assertEqual('ok', result.status)
-        self.assertEqual('CHL.zarr', result.data_id)
-        self.assertIsInstance(self.data_store.open_data(result.data_id),
+        self.assertIsInstance(result.result, CubeReference)
+        self.assertEqual('CHL.zarr', result.result.data_id)
+        self.assertIsInstance(self.data_store.open_data(result.result.data_id),
                               xr.Dataset)
 
     @requests_mock.Mocker()
@@ -77,8 +78,9 @@ class LocalCubeGeneratorTest(unittest.TestCase):
         m.put(CALLBACK_MOCK_URL, json={})
         result = CubeGenerator.new(verbosity=1).generate_cube('_request.json')
         self.assertEqual('ok', result.status)
-        self.assertEqual('CHL.zarr', result.data_id)
-        self.assertIsInstance(self.data_store.open_data(result.data_id),
+        self.assertIsInstance(result.result, CubeReference)
+        self.assertEqual('CHL.zarr', result.result.data_id)
+        self.assertIsInstance(self.data_store.open_data(result.result.data_id),
                               xr.Dataset)
 
     @requests_mock.Mocker()
@@ -86,8 +88,9 @@ class LocalCubeGeneratorTest(unittest.TestCase):
         m.put(CALLBACK_MOCK_URL, json={})
         result = CubeGenerator.new(verbosity=1).generate_cube('_request.yaml')
         self.assertEqual('ok', result.status)
-        self.assertEqual('CHL.zarr', result.data_id)
-        self.assertIsInstance(self.data_store.open_data(result.data_id),
+        self.assertIsInstance(result.result, CubeReference)
+        self.assertEqual('CHL.zarr', result.result.data_id)
+        self.assertIsInstance(self.data_store.open_data(result.result.data_id),
                               xr.Dataset)
 
     @requests_mock.Mocker()
@@ -98,18 +101,21 @@ class LocalCubeGeneratorTest(unittest.TestCase):
 
         result = LocalCubeGenerator().generate_cube(request)
         self.assertEqual('warning', result.status)
-        self.assertEqual('CHL.zarr', result.data_id)
-        self.assertEqual('An empty cube has been generated,'
-                         ' hence it has not been written at all.',
-                         result.message)
+        self.assertEqual(None, result.result)
+        self.assertIsInstance(result.message, str)
+        self.assertIn('An empty cube has been generated', result.message)
 
     @requests_mock.Mocker()
     def test_get_cube_info_from_dict(self, m):
         m.put(CALLBACK_MOCK_URL, json={})
         cube_info = LocalCubeGenerator(verbosity=1).get_cube_info(self.REQUEST)
-        self.assertIsInstance(cube_info, CubeInfo)
-        self.assertIsInstance(cube_info.dataset_descriptor, DatasetDescriptor)
-        self.assertIsInstance(cube_info.size_estimation, dict)
+        self.assertIsInstance(cube_info, CubeInfoResult)
+        self.assertIsInstance(cube_info.result,
+                              CubeInfo)
+        self.assertIsInstance(cube_info.result.dataset_descriptor,
+                              DatasetDescriptor)
+        self.assertIsInstance(cube_info.result.size_estimation,
+                              dict)
         # JSON-serialisation smoke test
         cube_info_dict = cube_info.to_dict()
         json.dumps(cube_info_dict, indent=2)

--- a/test/core/gen2/remote/test_generator.py
+++ b/test/core/gen2/remote/test_generator.py
@@ -5,10 +5,10 @@ import requests_mock
 
 from test.util.test_progress import TestProgressObserver
 from xcube.core.gen2 import CostEstimation, CubeGenerator
-from xcube.core.gen2 import CubeGeneratorError
 from xcube.core.gen2 import CubeInfoWithCosts
 from xcube.core.gen2 import ServiceConfig
 from xcube.core.gen2.remote.generator import RemoteCubeGenerator
+from xcube.core.gen2.remote.response import CubeInfoWithCostsResult
 from xcube.core.store import DatasetDescriptor
 from xcube.util.progress import new_progress_observers
 
@@ -190,7 +190,9 @@ class RemoteCubeGeneratorTest(unittest.TestCase):
                    }
                })
 
-        cube_info = self.generator.get_cube_info(self.REQUEST)
+        result = self.generator.get_cube_info(self.REQUEST)
+        self.assertIsInstance(result, CubeInfoWithCostsResult)
+        cube_info = result.result
         self.assertIsInstance(cube_info, CubeInfoWithCosts)
         self.assertIsInstance(cube_info.dataset_descriptor, DatasetDescriptor)
         self.assertIsInstance(cube_info.size_estimation, dict)

--- a/test/core/gen2/remote/test_generator.py
+++ b/test/core/gen2/remote/test_generator.py
@@ -4,7 +4,8 @@ from typing import List
 import requests_mock
 
 from test.util.test_progress import TestProgressObserver
-from xcube.core.gen2 import CostEstimation, CubeGenerator
+from xcube.core.gen2 import CostEstimation
+from xcube.core.gen2 import CubeGenerator
 from xcube.core.gen2 import CubeInfoWithCosts
 from xcube.core.gen2 import ServiceConfig
 from xcube.core.gen2.remote.generator import RemoteCubeGenerator

--- a/test/core/gen2/remote/test_response.py
+++ b/test/core/gen2/remote/test_response.py
@@ -1,0 +1,46 @@
+import unittest
+
+from xcube.core.gen2.remote.response import CostEstimation
+from xcube.core.gen2.remote.response import CubeInfoWithCosts
+from xcube.core.gen2.remote.response import CubeInfoWithCostsResult
+from xcube.core.gen2.response import CubeInfoResult
+from xcube.core.store import DatasetDescriptor
+
+
+class CubeInfoWithCostsResultTest(unittest.TestCase):
+    def test_serialisation(self):
+        result = CubeInfoWithCostsResult(
+            status='ok',
+            message='Success!',
+            result=CubeInfoWithCosts(
+                dataset_descriptor=DatasetDescriptor(data_id='bibo.zarr'),
+                size_estimation={},
+                cost_estimation=CostEstimation(required=10,
+                                               available=20,
+                                               limit=100)
+            )
+        )
+
+        result_dict = result.to_dict()
+        self.assertIsInstance(result_dict, dict)
+        self.assertEqual(
+            {
+                'status': 'ok',
+                'message': 'Success!',
+                'result': {
+                    'dataset_descriptor': {
+                        'data_id': 'bibo.zarr',
+                        'data_type': 'dataset'
+                    },
+                    'size_estimation': {},
+                    'cost_estimation': {
+                        'available': 20,
+                        'limit': 100,
+                        'required': 10
+                    },
+                },
+            },
+            result_dict)
+
+        result2 = CubeInfoWithCostsResult.from_dict(result_dict)
+        self.assertIsInstance(result2, CubeInfoResult)

--- a/test/core/gen2/test_response.py
+++ b/test/core/gen2/test_response.py
@@ -1,0 +1,58 @@
+import unittest
+
+from xcube.core.gen2.response import CubeGeneratorResult
+from xcube.core.gen2.response import CubeInfo
+from xcube.core.gen2.response import CubeInfoResult
+from xcube.core.gen2.response import CubeReference
+from xcube.core.store import DatasetDescriptor
+
+
+class CubeGeneratorResultTest(unittest.TestCase):
+    def test_serialisation(self):
+        result = CubeGeneratorResult(status='ok',
+                                     message='Success!',
+                                     result=CubeReference(data_id='bibo.zarr'))
+
+        result_dict = result.to_dict()
+        self.assertIsInstance(result_dict, dict)
+        self.assertEqual(
+            {
+                'status': 'ok',
+                'message': 'Success!',
+                'result': {'data_id': 'bibo.zarr'},
+            },
+            result_dict)
+
+        result2 = CubeGeneratorResult.from_dict(result_dict)
+        self.assertIsInstance(result2, CubeGeneratorResult)
+
+
+class CubeInfoResultTest(unittest.TestCase):
+    def test_serialisation(self):
+        result = CubeInfoResult(
+            status='ok',
+            message='Success!',
+            result=CubeInfo(
+                dataset_descriptor=DatasetDescriptor(data_id='bibo.zarr'),
+                size_estimation={}
+            )
+        )
+
+        result_dict = result.to_dict()
+        self.assertIsInstance(result_dict, dict)
+        self.assertEqual(
+            {
+                'status': 'ok',
+                'message': 'Success!',
+                'result': {
+                    'dataset_descriptor': {
+                        'data_id': 'bibo.zarr',
+                        'data_type': 'dataset'
+                    },
+                    'size_estimation': {}
+                },
+            },
+            result_dict)
+
+        result2 = CubeInfoResult.from_dict(result_dict)
+        self.assertIsInstance(result2, CubeInfoResult)

--- a/xcube/core/gen2/generator.py
+++ b/xcube/core/gen2/generator.py
@@ -29,7 +29,7 @@ from xcube.util.assertions import assert_true
 from .remote.config import ServiceConfigLike
 from .request import CubeGeneratorRequestLike
 from .response import CubeGeneratorResult
-from .response import CubeInfo
+from .response import CubeInfoResult
 
 
 class CubeGenerator(ABC):
@@ -114,7 +114,8 @@ class CubeGenerator(ABC):
                                       verbosity=verbosity)
 
     @abstractmethod
-    def get_cube_info(self, request: CubeGeneratorRequestLike) -> CubeInfo:
+    def get_cube_info(self, request: CubeGeneratorRequestLike) \
+            -> CubeInfoResult:
         """
         Get data cube information for given *request*.
 
@@ -127,7 +128,8 @@ class CubeGenerator(ABC):
           parsed into a ``CubeGeneratorRequest``.
 
         :param request: Cube generator request.
-        :return: a cube information object
+        :return: a cube information result
+            of type :class:CubeInfoResult
         :raises CubeGeneratorError: if cube info generation failed
         :raises DataStoreError: if data store access failed
         """
@@ -151,7 +153,8 @@ class CubeGenerator(ABC):
         store configured in ``output_config`` of the cube generator request.
 
         :param request: Cube generator request.
-        :return: the cube reference
+        :return: the cube generation result
+            of type :class:CubeGeneratorResult
         :raises CubeGeneratorError: if cube generation failed
         :raises DataStoreError: if data store access failed
         """

--- a/xcube/core/gen2/local/generator.py
+++ b/xcube/core/gen2/local/generator.py
@@ -44,7 +44,8 @@ from ..progress import ConsoleProgressObserver
 from ..request import CubeGeneratorRequest
 from ..request import CubeGeneratorRequestLike
 from ..response import CubeGeneratorResult
-from ..response import CubeInfo
+from ..response import CubeInfoResult
+from ..response import CubeReference
 
 
 class LocalCubeGenerator(CubeGenerator):
@@ -163,24 +164,32 @@ class LocalCubeGenerator(CubeGenerator):
                 data_id, cube = cube_writer.write_cube(cube, gm)
                 self._generated_data_id = data_id
                 self._generated_cube = cube
-                status = 'ok'
-                message = None
             else:
-                data_id = request.output_config.data_id
-                status = 'warning'
-                message = 'An empty cube has been generated,' \
-                          ' hence it has not been written at all.'
+                self._generated_data_id = None
+                self._generated_cube = None
 
-        if self._verbosity:
-            print('Cube "{}" generated within {:.2f} seconds'
-                  .format(str(data_id), progress.state.total_time))
+        total_time = progress.state.total_time
 
-        return CubeGeneratorResult(data_id=data_id,
-                                   status=status,
-                                   message=message)
+        if self._generated_data_id is not None:
+            return CubeGeneratorResult(
+                status='ok',
+                result=CubeReference(data_id=data_id),
+                message=f'Cube generated successfully'
+                        f' after {total_time:.2f} seconds'
+            )
+        else:
+            return CubeGeneratorResult(
+                status='warning',
+                message=f'An empty cube has been generated'
+                        f' after {total_time:.2f} seconds.'
+                        f' No data has been written at all.'
+            )
 
-    def get_cube_info(self, request: CubeGeneratorRequestLike) -> CubeInfo:
+    def get_cube_info(self, request: CubeGeneratorRequestLike) \
+            -> CubeInfoResult:
         request = CubeGeneratorRequest.normalize(request)
         informant = CubeInformant(request=request.for_local(),
                                   store_pool=self._store_pool)
-        return informant.generate()
+        cube_info = informant.generate()
+
+        return CubeInfoResult(result=cube_info, status='ok')

--- a/xcube/core/gen2/remote/generator.py
+++ b/xcube/core/gen2/remote/generator.py
@@ -29,14 +29,17 @@ import requests
 from xcube.util.assertions import assert_instance
 from xcube.util.progress import observe_progress
 from .config import ServiceConfig
-from .response import CubeGeneratorState, CubeInfoWithCostsResult
+from .response import CubeGeneratorState
 from .response import CubeGeneratorToken
 from .response import CubeInfoWithCosts
+from .response import CubeInfoWithCostsResult
 from ..error import CubeGeneratorError
 from ..generator import CubeGenerator
 from ..request import CubeGeneratorRequest
 from ..request import CubeGeneratorRequestLike
-from ..response import CubeInfo, CubeGeneratorResult, CubeReference
+from ..response import CubeGeneratorResult
+from ..response import CubeInfo
+from ..response import CubeReference
 
 _BASE_HEADERS = {
     "Accept": "application/json",

--- a/xcube/core/gen2/remote/response.py
+++ b/xcube/core/gen2/remote/response.py
@@ -27,7 +27,8 @@ from xcube.util.jsonschema import JsonNumberSchema
 from xcube.util.jsonschema import JsonObject
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
-from ..response import CubeInfo, CubeInfoResult
+from ..response import CubeInfo
+from ..response import CubeInfoResult
 
 
 class CubeGeneratorToken(JsonObject):

--- a/xcube/core/gen2/remote/response.py
+++ b/xcube/core/gen2/remote/response.py
@@ -27,7 +27,7 @@ from xcube.util.jsonschema import JsonNumberSchema
 from xcube.util.jsonschema import JsonObject
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
-from ..response import CubeInfo
+from ..response import CubeInfo, CubeInfoResult
 
 
 class CubeGeneratorToken(JsonObject):
@@ -129,6 +129,7 @@ class CubeGeneratorProgressState(JsonObject):
 
 class CubeGeneratorProgress(JsonObject):
     """Current progress of the remote generator."""
+
     def __init__(self,
                  sender: str,
                  state: CubeGeneratorProgressState):
@@ -232,3 +233,10 @@ class CubeInfoWithCosts(CubeInfo):
         schema.required.add('cost_estimation')
         schema.factory = cls
         return schema
+
+
+class CubeInfoWithCostsResult(CubeInfoResult):
+
+    @classmethod
+    def get_result_schema(cls) -> JsonObjectSchema:
+        return CubeInfoWithCosts.get_schema()

--- a/xcube/core/gen2/response.py
+++ b/xcube/core/gen2/response.py
@@ -18,39 +18,86 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+from abc import abstractmethod, ABC
 from typing import Dict, Any, Optional, Sequence
 
 from xcube.core.store import DatasetDescriptor
+from xcube.util.assertions import assert_in
+from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
 from .config import JsonObject
 
+STATUS_IDS = ['ok', 'error', 'warning']
 
-class CubeGeneratorResult(JsonObject):
+
+class AbstractResult(JsonObject, ABC):
     def __init__(self,
-                 data_id: str,
                  status: str,
+                 result: Optional[Any] = None,
                  message: Optional[str] = None,
-                 output: Optional[Sequence[str]] = None):
-        self.data_id = data_id
+                 output: Optional[Sequence[str]] = None,
+                 traceback: Optional[Sequence[str]] = None):
+        assert_instance(status, str, name='status')
+        assert_in(status, STATUS_IDS, name='status')
+        self.result = result
         self.status = status
-        self.message = message
+        self.message = message if message else None
         self.output = list(output) if output else None
+        self.traceback = list(traceback) if traceback else None
+
+    @classmethod
+    @abstractmethod
+    def get_result_schema(cls) -> JsonObjectSchema:
+        """Get the JSON schema of the result object"""
+
+    @classmethod
+    def get_schema(cls) -> JsonObjectSchema:
+        return JsonObjectSchema(
+            properties=dict(
+                status=JsonStringSchema(enum=STATUS_IDS),
+                result=cls.get_result_schema(),
+                message=JsonStringSchema(),
+                output=JsonArraySchema(items=JsonStringSchema()),
+            ),
+            required=['status'],
+            additional_properties=True,
+            factory=cls,
+        )
+
+
+class CubeReference(JsonObject):
+    def __init__(self, data_id: str):
+        self.data_id = data_id
 
     @classmethod
     def get_schema(cls) -> JsonObjectSchema:
         return JsonObjectSchema(
             properties=dict(
                 data_id=JsonStringSchema(min_length=1),
-                status=JsonStringSchema(enum=['ok', 'error', 'warning']),
-                message=JsonStringSchema(),
-                output=JsonArraySchema(items=JsonStringSchema()),
             ),
-            required=['data_id', 'status'],
-            additional_properties=True,
+            required=['data_id'],
+            additional_properties=False,
         )
+
+
+class CubeGeneratorResult(AbstractResult):
+    def __init__(self,
+                 status: str,
+                 result: Optional[CubeReference] = None,
+                 message: Optional[str] = None,
+                 output: Optional[Sequence[str]] = None,
+                 traceback: Optional[Sequence[str]] = None):
+        super().__init__(status,
+                         result=result,
+                         message=message,
+                         output=output,
+                         traceback=traceback)
+
+    @classmethod
+    def get_result_schema(cls) -> JsonObjectSchema:
+        return CubeReference.get_schema()
 
     @classmethod
     def from_dict(cls, value: Dict) -> 'CubeGeneratorResult':
@@ -60,7 +107,8 @@ class CubeGeneratorResult(JsonObject):
 class CubeInfo(JsonObject):
     def __init__(self,
                  dataset_descriptor: DatasetDescriptor,
-                 size_estimation: Dict[str, Any]):
+                 size_estimation: Dict[str, Any],
+                 **kwargs):
         self.dataset_descriptor: DatasetDescriptor = dataset_descriptor
         self.size_estimation: dict = size_estimation
 
@@ -72,6 +120,28 @@ class CubeInfo(JsonObject):
                 size_estimation=JsonObjectSchema(additional_properties=True)
             ),
             required=['dataset_descriptor', 'size_estimation'],
-            additional_properties=False,
+            additional_properties=True,
             factory=cls
         )
+
+
+class CubeInfoResult(AbstractResult):
+    def __init__(self,
+                 status: str,
+                 result: Optional[CubeInfo] = None,
+                 message: Optional[str] = None,
+                 output: Optional[Sequence[str]] = None,
+                 traceback: Optional[Sequence[str]] = None):
+        super().__init__(status,
+                         result=result,
+                         message=message,
+                         output=output,
+                         traceback=traceback)
+
+    @classmethod
+    def get_result_schema(cls) -> JsonObjectSchema:
+        return CubeInfo.get_schema()
+
+    @classmethod
+    def from_dict(cls, value: Dict) -> 'CubeInfoResult':
+        return cls.get_schema().from_instance(value)

--- a/xcube/core/gen2/response.py
+++ b/xcube/core/gen2/response.py
@@ -25,9 +25,9 @@ from xcube.core.store import DatasetDescriptor
 from xcube.util.assertions import assert_in
 from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonArraySchema
+from xcube.util.jsonschema import JsonObject
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
-from .config import JsonObject
 
 STATUS_IDS = ['ok', 'error', 'warning']
 


### PR DESCRIPTION
`xcube gen2`nor outputs the same JSON format for `--info` and without.

@dzelge There are 3 TODOs in `xcube/core/gen2/remote/generator.py` of the form

        # TODO (forman): gen2 API change:
        #   get result from state and merge

which I need fix after xcube-hub changes. But in another PR.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!