### PR TITLE
Forman 446 fs stores recursive scan

### DIFF
--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -32,22 +32,22 @@ class FsDataStoresTestMixin(ABC):
     @classmethod
     def prepare_fs(cls, fs: fsspec.AbstractFileSystem, root: str):
         if fs.isdir(root):
-            print(f'{fs.protocol}: deleting {root}')
+            # print(f'{fs.protocol}: deleting {root}')
             fs.delete(root, recursive=True)
 
-        print(f'{fs.protocol}: making root {root}')
+        # print(f'{fs.protocol}: making root {root}')
         fs.mkdirs(root)
 
         # Write a text file into each subdirectory so
         # we also test that store.get_data_ids() scans
         # recursively.
         dir_path = root
-        for d in DATA_PATH.split('/'):
-            dir_path += '/' + d
-            print(f'{fs.protocol}: making {dir_path}')
+        for subdir_name in DATA_PATH.split('/'):
+            dir_path += '/' + subdir_name
+            # print(f'{fs.protocol}: making {dir_path}')
             fs.mkdir(dir_path)
             file_path = dir_path + '/README.md'
-            print(f'{fs.protocol}: writing {file_path}')
+            # print(f'{fs.protocol}: writing {file_path}')
             with fs.open(file_path, 'w') as fp:
                 fp.write('\n')
 

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -2,6 +2,7 @@ import unittest
 from abc import ABC, abstractmethod
 from typing import Type, Union
 
+import fsspec
 import xarray as xr
 
 from test.s3test import MOTO_SERVER_ENDPOINT_URL
@@ -16,7 +17,7 @@ from xcube.core.store import MutableDataStore
 from xcube.core.store.fs.registry import new_fs_data_store
 from xcube.core.store.fs.store import FsDataStore
 from xcube.util.temp import new_temp_dir
-
+import fsspec
 
 # noinspection PyUnresolvedReferences,PyPep8Naming
 class FsDataStoresTestMixin(ABC):
@@ -124,8 +125,10 @@ class FileFsDataStoresTest(FsDataStoresTestMixin, unittest.TestCase):
 class MemoryFsDataStoresTest(FsDataStoresTestMixin, unittest.TestCase):
 
     def create_data_store(self) -> FsDataStore:
-        return new_fs_data_store('memory',
-                                 root='xcube-test')
+        fs: fsspec.AbstractFileSystem = fsspec.filesystem('memory')
+        for f in fs.find(''):
+            fs.delete(f)
+        return new_fs_data_store('memory', root='xcube-test')
 
 
 class S3FsDataStoresTest(FsDataStoresTestMixin, S3Test):

--- a/xcube/core/store/fs/accessor.py
+++ b/xcube/core/store/fs/accessor.py
@@ -108,8 +108,15 @@ class FsAccessor:
         fs_params = params.pop(FS_PARAMS_PARAM_NAME, None)
         if fs_params is not None:
             assert_instance(fs_params, dict, name=FS_PARAMS_PARAM_NAME)
+
+        # Note, by default, filesystem data stores are writable and hence
+        # SHALL NOT cache any directory listings!
+        use_listings_cache = bool(fs_params.pop('use_listings_cache', False)
+                                  if fs_params else False)
+
         try:
             return fsspec.filesystem(fs_protocol,
+                                     use_listings_cache=use_listings_cache,
                                      **(fs_params or {})), params
         except (ValueError, ImportError):
             raise DataStoreError(f"Cannot instantiate"

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -198,7 +198,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         data_type = DataType.normalize(data_type)
         # TODO: do not ignore names in include_attrs
         return_tuples = include_attrs is not None
-        yield from self._generate_data_ids('', data_type, return_tuples, 0)
+        yield from self._generate_data_ids('', data_type, return_tuples, 1)
 
     def has_data(self, data_id: str, data_type: DataTypeLike = None) -> bool:
         assert_given(data_id, 'data_id')

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -198,35 +198,30 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         data_type = DataType.normalize(data_type)
         # TODO: do not ignore names in include_attrs
         return_tuples = include_attrs is not None
-        for item in self._scan_dir('',
-                                   data_type,
-                                   return_tuples,
-                                   0):
-            yield item
+        yield from self._generate_data_ids('', data_type, return_tuples, 0)
 
-    def _scan_dir(self,
-                  dir_path: str,
-                  data_type: DataType,
-                  return_tuples: bool,
-                  current_depth: int):
+    def _generate_data_ids(self,
+                           dir_path: str,
+                           data_type: DataType,
+                           return_tuples: bool,
+                           current_depth: int):
         root = self.root + ('/' + dir_path if dir_path else '')
         # noinspection PyArgumentEqualDefault
-        if self.fs.isdir(root):
-            for file_info in self.fs.ls(root, detail=True):
-                file_path: str = file_info['name']
-                if file_path.startswith(self.root):
-                    file_path = file_path[len(self.root) + 1:]
-                elif file_path.startswith('/' + self.root):
-                    file_path = file_path[len(self.root) + 2:]
-                if self._is_data_specified(file_path, data_type):
-                    yield (file_path, {}) if return_tuples else file_path
-                elif file_info.get('type') == 'directory' \
-                        and current_depth < self._max_depth:
-                    for item in self._scan_dir(file_path,
-                                               data_type,
-                                               return_tuples,
-                                               current_depth + 1):
-                        yield item
+        for file_info in self.fs.ls(root, detail=True):
+            file_path: str = file_info['name']
+            if file_path.startswith(self.root):
+                file_path = file_path[len(self.root) + 1:]
+            elif file_path.startswith('/' + self.root):
+                file_path = file_path[len(self.root) + 2:]
+            if self._is_data_specified(file_path, data_type):
+                yield (file_path, {}) if return_tuples else file_path
+            elif file_info.get('type') == 'directory' \
+                    and (self._max_depth is None
+                         or current_depth < self._max_depth):
+                yield from self._generate_data_ids(file_path,
+                                                   data_type,
+                                                   return_tuples,
+                                                   current_depth + 1)
 
     def has_data(self, data_id: str, data_type: DataTypeLike = None) -> bool:
         assert_given(data_id, 'data_id')

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -200,29 +200,6 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         return_tuples = include_attrs is not None
         yield from self._generate_data_ids('', data_type, return_tuples, 0)
 
-    def _generate_data_ids(self,
-                           dir_path: str,
-                           data_type: DataType,
-                           return_tuples: bool,
-                           current_depth: int):
-        root = self.root + ('/' + dir_path if dir_path else '')
-        # noinspection PyArgumentEqualDefault
-        for file_info in self.fs.ls(root, detail=True):
-            file_path: str = file_info['name']
-            if file_path.startswith(self.root):
-                file_path = file_path[len(self.root) + 1:]
-            elif file_path.startswith('/' + self.root):
-                file_path = file_path[len(self.root) + 2:]
-            if self._is_data_specified(file_path, data_type):
-                yield (file_path, {}) if return_tuples else file_path
-            elif file_info.get('type') == 'directory' \
-                    and (self._max_depth is None
-                         or current_depth < self._max_depth):
-                yield from self._generate_data_ids(file_path,
-                                                   data_type,
-                                                   return_tuples,
-                                                   current_depth + 1)
-
     def has_data(self, data_id: str, data_type: DataTypeLike = None) -> bool:
         assert_given(data_id, 'data_id')
         if self._is_data_specified(data_id, data_type):
@@ -596,6 +573,29 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
             if dot_pos < sep_pos:
                 return ''
         return data_path[dot_pos:]
+
+    def _generate_data_ids(self,
+                           dir_path: str,
+                           data_type: DataType,
+                           return_tuples: bool,
+                           current_depth: int):
+        root = self.root + ('/' + dir_path if dir_path else '')
+        # noinspection PyArgumentEqualDefault
+        for file_info in self.fs.ls(root, detail=True):
+            file_path: str = file_info['name']
+            if file_path.startswith(self.root):
+                file_path = file_path[len(self.root) + 1:]
+            elif file_path.startswith('/' + self.root):
+                file_path = file_path[len(self.root) + 2:]
+            if self._is_data_specified(file_path, data_type):
+                yield (file_path, {}) if return_tuples else file_path
+            elif file_info.get('type') == 'directory' \
+                    and (self._max_depth is None
+                         or current_depth < self._max_depth):
+                yield from self._generate_data_ids(file_path,
+                                                   data_type,
+                                                   return_tuples,
+                                                   current_depth + 1)
 
 
 class FsDataStore(BaseFsDataStore, FsAccessor):


### PR DESCRIPTION
* The `get_data_ids()` method of our filesystem datastores will now scan directories recursively.
* By default, filesystems are now created using `use_listings_cache` which effectively avoids out-of-date results resturned by `get_data_ids()`.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!