### PR TITLE
Rename "fs_params" into "storage_options"

### DIFF
--- a/docs/source/generator.rst
+++ b/docs/source/generator.rst
@@ -162,7 +162,8 @@ might look as follows:
      description: An S3 bucket for output data sets
      store_id: s3
      store_params:
-       fs_params:
+       root: cube-outputs
+       storage_options:
          key: qwerty12345
          secret: 7ff889c0aea254d5e00440858289b85c
          client_kwargs:

--- a/examples/notebooks/datastores/1_getting_started.ipynb
+++ b/examples/notebooks/datastores/1_getting_started.ipynb
@@ -147,7 +147,7 @@
       "application/json": {
        "additionalProperties": false,
        "properties": {
-        "fs_params": {
+        "storage_options": {
          "additionalProperties": true,
          "properties": {
           "anon": {
@@ -266,21 +266,21 @@
    "source": [
     "The field `properties` lists the available data store parameters. For the filesystem-based data stores `file`, `s3`, and `memory` the most important parameter is `root` which specifies the data store's root path into the filesystem. \n",
     "\n",
-    "For the filesystem-based data stores there is also a special parameter `fs_params` that can contain further filesystem-specific parameters. \n",
+    "For the filesystem-based data stores there is also a special parameter `storage_options` that can contain further filesystem-specific parameters. \n",
     "\n",
     "Here are some examples how to parameterize an `s3` data store that can access AWS S3 compatible object storage:\n",
     "\n",
     "Public bucket on AWS S3: \n",
     "```python\n",
-    "store = new_data_store('s3', root=\"<bucket_name>\", fs_params=dict(anon=True))\n",
+    "store = new_data_store('s3', root=\"<bucket_name>\", storage_options=dict(anon=True))\n",
     "```\n",
     "Private bucket on AWS S3: \n",
     "```python\n",
-    "store = new_data_store('s3', root=\"<bucket_name>\", fs_params=dict(anon=False, key=\"<AWS_ACCESS_KEY_ID>\", secret=\"<AWS_SECRET_ACCESS_KEY>\"))\n",
+    "store = new_data_store('s3', root=\"<bucket_name>\", storage_options=dict(anon=False, key=\"<AWS_ACCESS_KEY_ID>\", secret=\"<AWS_SECRET_ACCESS_KEY>\"))\n",
     "```\n",
     "Public object storage other than AWS S3: \n",
     "```python\n",
-    "store = new_data_store('s3', root=\"<bucket_name>\", fs_params=dict(anon=True, client_kwargs=dict(endpoint_url=\"<object_storage_api_endpoint_url>\")))\n",
+    "store = new_data_store('s3', root=\"<bucket_name>\", storage_options=dict(anon=True, client_kwargs=dict(endpoint_url=\"<object_storage_api_endpoint_url>\")))\n",
     "```\n",
     "\n",
     "Which parameters are accepted by `new_data_store()` when using the `file` data store?"
@@ -296,7 +296,7 @@
       "application/json": {
        "additionalProperties": false,
        "properties": {
-        "fs_params": {
+        "storage_options": {
          "additionalProperties": true,
          "properties": {
           "asynchronous": {

--- a/examples/serve/demo/config-with-stores.yml
+++ b/examples/serve/demo/config-with-stores.yml
@@ -31,7 +31,7 @@ DataStores:
       # root: eurodatacube-scratch/2021-09-09/SERVICE-DEV
       root: eurodatacube-scratch/2021-09-13/SERVICE-DEV
       max_depth: 4
-      fs_params:
+      storage_options:
         anon: true
         # client_kwargs:
         #  endpoint_url: https://s3.eu-central-1.amazonaws.com

--- a/test/core/store/fs/test_plugin.py
+++ b/test/core/store/fs/test_plugin.py
@@ -105,12 +105,12 @@ class FsDataStoreAndAccessorsPluginTest(unittest.TestCase):
         # print(params_schema.to_dict())
         self.assertIsInstance(params_schema, JsonObjectSchema)
         self.assertIsInstance(params_schema.properties, dict)
-        self.assertIn('fs_params', params_schema.properties)
-        self.assertIsInstance(params_schema.properties['fs_params'],
+        self.assertIn('storage_options', params_schema.properties)
+        self.assertIsInstance(params_schema.properties['storage_options'],
                               JsonObjectSchema)
 
     def assertParamsSchemaExcludesFsParams(self, params_schema):
         # print(params_schema.to_dict())
         self.assertIsInstance(params_schema, JsonObjectSchema)
         self.assertIsInstance(params_schema.properties, dict)
-        self.assertNotIn('fs_params', params_schema.properties)
+        self.assertNotIn('storage_options', params_schema.properties)

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -161,14 +161,14 @@ class S3FsDataStoresTest(FsDataStoresTestMixin, S3Test):
 
     def create_data_store(self) -> FsDataStore:
         root = ROOT_DIR
-        fs_params = dict(
+        storage_options = dict(
             anon=False,
             client_kwargs=dict(
                 endpoint_url=MOTO_SERVER_ENDPOINT_URL,
             )
         )
-        self.prepare_fs(fsspec.filesystem('s3', **fs_params), root)
+        self.prepare_fs(fsspec.filesystem('s3', **storage_options), root)
         return new_fs_data_store('s3',
                                  root=root,
                                  max_depth=3,
-                                 fs_params=fs_params)
+                                 storage_options=storage_options)

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -136,7 +136,7 @@ ZARR_WRITE_DATA_PARAMS_SCHEMA = JsonObjectSchema(
 
 class DatasetFsDataAccessor(FsDataAccessor, ABC):
     """
-    Opener/writer extension name: "dataset:<format>:<fs_protocol>"
+    Opener/writer extension name: "dataset:<format>:<protocol>"
     """
 
     @classmethod
@@ -146,7 +146,7 @@ class DatasetFsDataAccessor(FsDataAccessor, ABC):
 
 class DatasetZarrFsDataAccessor(DatasetFsDataAccessor, ABC):
     """
-    Opener/writer extension name: "dataset:zarr:<fs_protocol>"
+    Opener/writer extension name: "dataset:zarr:<protocol>"
     """
 
     @classmethod
@@ -156,7 +156,7 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor, ABC):
     # noinspection PyUnusedLocal,PyMethodMayBeStatic
     def get_open_data_params_schema(self, data_id: str = None) \
             -> JsonObjectSchema:
-        return self.add_fs_params_to_params_schema(
+        return self.add_storage_options_to_params_schema(
             ZARR_OPEN_DATA_PARAMS_SCHEMA
         )
 
@@ -183,7 +183,7 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor, ABC):
 
     # noinspection PyMethodMayBeStatic
     def get_write_data_params_schema(self) -> JsonObjectSchema:
-        return self.add_fs_params_to_params_schema(
+        return self.add_storage_options_to_params_schema(
             ZARR_WRITE_DATA_PARAMS_SCHEMA
         )
 
@@ -235,7 +235,7 @@ NETCDF_WRITE_DATA_PARAMS_SCHEMA = JsonObjectSchema(
 
 class DatasetNetcdfFsDataAccessor(DatasetFsDataAccessor, ABC):
     """
-    Opener/writer extension name: "dataset:netcdf:<fs_protocol>"
+    Opener/writer extension name: "dataset:netcdf:<protocol>"
     """
 
     @classmethod
@@ -244,7 +244,7 @@ class DatasetNetcdfFsDataAccessor(DatasetFsDataAccessor, ABC):
 
     def get_open_data_params_schema(self, data_id: str = None) \
             -> JsonObjectSchema:
-        return self.add_fs_params_to_params_schema(
+        return self.add_storage_options_to_params_schema(
             NETCDF_OPEN_DATA_PARAMS_SCHEMA
         )
 
@@ -269,7 +269,7 @@ class DatasetNetcdfFsDataAccessor(DatasetFsDataAccessor, ABC):
         return xr.open_dataset(file_path, engine=engine, **open_params)
 
     def get_write_data_params_schema(self) -> JsonObjectSchema:
-        return self.add_fs_params_to_params_schema(
+        return self.add_storage_options_to_params_schema(
             NETCDF_WRITE_DATA_PARAMS_SCHEMA
         )
 

--- a/xcube/core/store/fs/impl/fs.py
+++ b/xcube/core/store/fs/impl/fs.py
@@ -22,25 +22,25 @@
 from xcube.util.jsonschema import JsonBooleanSchema
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
-from ..accessor import COMMON_FS_PARAMS_SCHEMA_PROPERTIES
+from ..accessor import COMMON_STORAGE_OPTIONS_SCHEMA_PROPERTIES
 from ..accessor import FsAccessor
 
 
 class FileFsAccessor(FsAccessor):
 
     @classmethod
-    def get_fs_protocol(cls) -> str:
+    def get_protocol(cls) -> str:
         return 'file'
 
     @classmethod
-    def get_fs_params_schema(cls) -> JsonObjectSchema:
+    def get_storage_options_schema(cls) -> JsonObjectSchema:
         return JsonObjectSchema(
             properties=dict(
                 auto_mkdirs=JsonBooleanSchema(
                     description='Whether, when opening a file, the directory'
                                 ' containing it should be created (if it'
                                 ' doesn\'t already exist).'),
-                **COMMON_FS_PARAMS_SCHEMA_PROPERTIES
+                **COMMON_STORAGE_OPTIONS_SCHEMA_PROPERTIES
             ),
             additional_properties=True,
         )
@@ -49,18 +49,18 @@ class FileFsAccessor(FsAccessor):
 class MemoryFsAccessor(FsAccessor):
 
     @classmethod
-    def get_fs_protocol(cls) -> str:
+    def get_protocol(cls) -> str:
         return 'memory'
 
 
 class S3FsAccessor(FsAccessor):
 
     @classmethod
-    def get_fs_protocol(cls) -> str:
+    def get_protocol(cls) -> str:
         return 's3'
 
     @classmethod
-    def get_fs_params_schema(cls) -> JsonObjectSchema:
+    def get_storage_options_schema(cls) -> JsonObjectSchema:
         # We may use here AWS S3 defaults as described in
         #   https://boto3.amazonaws.com/v1/documentation/api/
         #   latest/guide/configuration.html
@@ -132,7 +132,7 @@ class S3FsAccessor(FsAccessor):
                     ),
                     additional_properties=True,
                 ),
-                **COMMON_FS_PARAMS_SCHEMA_PROPERTIES,
+                **COMMON_STORAGE_OPTIONS_SCHEMA_PROPERTIES,
             ),
             additional_properties=True,
         )

--- a/xcube/core/store/fs/impl/geodataframe.py
+++ b/xcube/core/store/fs/impl/geodataframe.py
@@ -36,7 +36,7 @@ from ...datatype import GEO_DATA_FRAME_TYPE
 
 class GeoDataFrameFsDataAccessor(FsDataAccessor, ABC):
     """
-    Extension name: "geodataframe:<format_id>:<fs_protocol>"
+    Extension name: "geodataframe:<format_id>:<protocol>"
     """
 
     @classmethod
@@ -52,7 +52,7 @@ class GeoDataFrameFsDataAccessor(FsDataAccessor, ABC):
             -> JsonObjectSchema:
         return JsonObjectSchema(
             properties=dict(
-                fs_params=self.get_fs_params_schema(),
+                storage_options=self.get_storage_options_schema(),
                 # TODO: add more, see https://geopandas.org/io.html
             ),
         )
@@ -74,7 +74,7 @@ class GeoDataFrameFsDataAccessor(FsDataAccessor, ABC):
     def get_write_data_params_schema(self) -> JsonObjectSchema:
         return JsonObjectSchema(
             properties=dict(
-                fs_params=self.get_fs_params_schema(),
+                storage_options=self.get_storage_options_schema(),
                 # TODO: add more, see https://geopandas.org/io.html
             ),
         )
@@ -96,7 +96,7 @@ class GeoDataFrameFsDataAccessor(FsDataAccessor, ABC):
 
 class GeoDataFrameShapefileFsDataAccessor(GeoDataFrameFsDataAccessor, ABC):
     """
-    Extension name: "geodataframe:shapefile:<fs_protocol>"
+    Extension name: "geodataframe:shapefile:<protocol>"
     """
 
     @classmethod
@@ -110,7 +110,7 @@ class GeoDataFrameShapefileFsDataAccessor(GeoDataFrameFsDataAccessor, ABC):
 
 class GeoDataFrameGeoJsonFsDataAccessor(GeoDataFrameFsDataAccessor, ABC):
     """
-    Extension name: "geodataframe:geojson:<fs_protocol>"
+    Extension name: "geodataframe:geojson:<protocol>"
     """
 
     @classmethod

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -40,8 +40,8 @@ from ...error import DataStoreError
 
 class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
     """
-    Opener/writer extension name: "mldataset:levels:<fs_protocol>"
-    and "dataset:levels:<fs_protocol>"
+    Opener/writer extension name: "mldataset:levels:<protocol>"
+    and "dataset:levels:<protocol>"
     """
 
     @classmethod

--- a/xcube/plugin.py
+++ b/xcube/plugin.py
@@ -134,34 +134,34 @@ def _register_data_accessors(ext_registry: extension.ExtensionRegistry):
     # noinspection PyShadowingNames
     def _add_fs_data_accessor_ext(point: str,
                                   ext_type: str,
-                                  fs_protocol: str,
+                                  protocol: str,
                                   data_type: str,
                                   format_id: str):
-        factory_args = (fs_protocol, data_type, format_id)
+        factory_args = (protocol, data_type, format_id)
         loader = extension.import_component(factory,
                                             call_args=factory_args)
         ext_registry.add_extension(
             point=point,
             loader=loader,
-            name=f'{data_type}:{format_id}:{fs_protocol}',
+            name=f'{data_type}:{format_id}:{protocol}',
             description=f'Data {ext_type} for'
                         f' a {data_accessor_description}'
                         f' in {storage_description}'
         )
 
-    for fs_protocol, storage_description in _FS_STORAGE_ITEMS:
+    for protocol, storage_description in _FS_STORAGE_ITEMS:
         for data_type, format_id, data_accessor_description \
                 in _FS_DATA_OPENER_ITEMS:
             _add_fs_data_accessor_ext(EXTENSION_POINT_DATA_OPENERS,
                                       'opener',
-                                      fs_protocol,
+                                      protocol,
                                       data_type,
                                       format_id)
         for data_type, format_id, data_accessor_description \
                 in _FS_DATA_WRITER_ITEMS:
             _add_fs_data_accessor_ext(EXTENSION_POINT_DATA_WRITERS,
                                       'writer',
-                                      fs_protocol,
+                                      protocol,
                                       data_type,
                                       format_id)
 


### PR DESCRIPTION
In this PR two properties used in the filesystem-based data stores have been renamed:

* `fs_protocol` into `protocol` 
* `fs_params` into `storage_options`

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!