### PR TITLE
Versions follow-up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,9 +83,10 @@
 * Added a new utility module `xcube.util.temp` that allows for creating 
   temporary files and directories that will be deleted when the current 
   process ends.
-* Added `xcube.util.versions.XCUBE_VERSIONS` and function 
-  `xcube.util.versions.get_versions` to get mappings of package names to 
-  package versions. (#522)
+* Added function `xcube.util.versions.get_xcube_versions()`  
+  that outputs the versions of packages relevant for xcube.
+  Also added a new CLI `xcube versions` that outputs the result of the  
+  new function in JSON or YAML. (#522)
 
 ### Other
 

--- a/test/cli/test_versions.py
+++ b/test/cli/test_versions.py
@@ -1,0 +1,48 @@
+from test.cli.helpers import CliTest
+from xcube.util.temp import new_temp_file
+
+
+class VersionsTest(CliTest):
+
+    def test_help_option(self):
+        result = self.invoke_cli(['versions', '--help'])
+        self.assertEqual(0, result.exit_code)
+
+    def test_no_args(self):
+        result = self.invoke_cli(['versions'])
+        self.assertEqual(0, result.exit_code)
+        self.assertYaml(result.stdout)
+
+    def test_format(self):
+        result = self.invoke_cli(['versions', '-f', 'json'])
+        self.assertEqual(0, result.exit_code)
+        self.assertJson(result.stdout)
+
+        result = self.invoke_cli(['versions', '-f', 'yaml'])
+        self.assertEqual(0, result.exit_code)
+        self.assertYaml(result.stdout)
+
+    def test_output(self):
+        _, output_path = new_temp_file(suffix='.json')
+        result = self.invoke_cli(['versions', '-o', output_path])
+        self.assertEqual(0, result.exit_code)
+        with open(output_path) as fp:
+            text = fp.read()
+        self.assertJson(text)
+
+        _, output_path = new_temp_file(suffix='.yml')
+        result = self.invoke_cli(['versions', '-o', output_path])
+        self.assertEqual(0, result.exit_code)
+        with open(output_path) as fp:
+            text = fp.read()
+        self.assertYaml(text)
+
+    def assertJson(self, json_result: str):
+        self.assertIn('{', json_result)
+        self.assertIn(':', json_result)
+        self.assertIn('}', json_result)
+
+    def assertYaml(self, json_result: str):
+        self.assertNotIn('{', json_result)
+        self.assertIn(':', json_result)
+        self.assertNotIn('}', json_result)

--- a/test/util/test_versions.py
+++ b/test/util/test_versions.py
@@ -1,19 +1,26 @@
 import unittest
-from xcube.util.versions import XCUBE_VERSIONS
+
 import xcube.version as xcube_version
+from xcube.util.versions import get_xcube_versions
 
 
 class GetVersionsTest(unittest.TestCase):
 
-    def test_xcube_versions(self):
-        versions = XCUBE_VERSIONS
-        self.assertIsNotNone(versions)
-        self.assertTrue('xarray' in versions)
-        self.assertTrue('dask' in versions)
-        self.assertTrue('zarr' in versions)
-        self.assertTrue('tornado' in versions)
-        self.assertTrue('pandas' in versions)
-        self.assertTrue('numpy' in versions)
-        self.assertTrue('geopandas' in versions)
-        self.assertTrue('xcube' in versions)
+    def test_it_contains_what_is_expected(self):
+        versions = get_xcube_versions()
+        self.assertIsInstance(versions, dict)
+        self.assertTrue(all(isinstance(k, str) for k in versions.keys()))
+        self.assertTrue(all(isinstance(v, str) for v in versions.values()))
+        self.assertIn('xarray', versions)
+        self.assertIn('dask', versions)
+        self.assertIn('zarr', versions)
+        self.assertIn('tornado', versions)
+        self.assertIn('pandas', versions)
+        self.assertIn('numpy', versions)
+        self.assertIn('geopandas', versions)
+        self.assertIn('xcube', versions)
         self.assertEqual(xcube_version.version, versions['xcube'])
+
+    def test_it_is_cached(self):
+        versions = get_xcube_versions()
+        self.assertIs(versions, get_xcube_versions())

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -23,7 +23,6 @@ import json
 import sys
 import traceback
 from typing import Sequence
-from xcube.util.versions import XCUBE_VERSIONS
 
 import click
 
@@ -124,6 +123,7 @@ def gen2(request_path: str,
     from xcube.core.gen2 import CubeGenerator
     from xcube.core.gen2 import CubeGeneratorError
     from xcube.core.gen2 import CubeGeneratorRequest
+    from xcube.util.versions import get_xcube_versions
 
     verbosity = len(verbose) if verbose else 0
 
@@ -148,13 +148,15 @@ def gen2(request_path: str,
 
         result = dict(status='error',
                       message=f'{error}',
-                      versions=XCUBE_VERSIONS,
                       traceback=traceback.format_tb(error.__traceback__))
         if isinstance(error, CubeGeneratorError):
             if error.remote_output:
                 result.update(remote_output=error.remote_output)
             if error.remote_traceback:
                 result.update(remote_traceback=error.remote_traceback)
+
+    if result.get('status') == 'error':
+        result['versions'] = get_xcube_versions()
 
     if output_file is not None:
         with open(output_file, 'w') as fp:

--- a/xcube/cli/versions.py
+++ b/xcube/cli/versions.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2019 by the xcube development team and contributors
+# Copyright (c) 2021 by the xcube development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/xcube/cli/versions.py
+++ b/xcube/cli/versions.py
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+# Copyright (c) 2019 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Optional
+
+import os.path
+
+import click
+
+YAML_FORMAT = "yaml"
+JSON_FORMAT = "json"
+DEFAULT_FORMAT = YAML_FORMAT
+
+
+# noinspection PyShadowingBuiltins
+@click.command(name="versions")
+@click.option('--format', '-f', 'format_name',
+              metavar='FORMAT',
+              type=click.Choice([YAML_FORMAT, JSON_FORMAT],
+                                case_sensitive=False),
+              help=f'Output format. '
+                   f'Must be one of {YAML_FORMAT!r} or {JSON_FORMAT!r}. '
+                   f'If not given, derived from OUTPUT name extension.')
+@click.option('--output', '-o', 'output_path',
+              metavar='OUTPUT',
+              help=f'Output file path.')
+def versions(format_name: Optional[str], output_path: Optional[str]):
+    """
+    Get versions of important packages used by xcube.
+    """
+    from xcube.util.versions import get_xcube_versions
+    xcube_versions = get_xcube_versions()
+
+    if not format_name:
+        format_name = YAML_FORMAT
+        if output_path:
+            _, ext = os.path.splitext(output_path)
+            if ext.lower() == '.json':
+                format_name = JSON_FORMAT
+
+    if format_name.lower() == JSON_FORMAT:
+        import json
+        text = json.dumps(xcube_versions, indent=2)
+    else:
+        import yaml
+        text = yaml.dump(xcube_versions)
+
+    if output_path:
+        with open(output_path, 'w') as fp:
+            fp.write(text)
+    else:
+        print(text)

--- a/xcube/core/gen2/remote/generator.py
+++ b/xcube/core/gen2/remote/generator.py
@@ -27,7 +27,6 @@ from typing import Type, TypeVar, Dict, Any, Optional, List, Tuple, Union
 import requests
 
 from xcube.util.assertions import assert_instance
-from xcube.util.versions import XCUBE_VERSIONS
 from xcube.util.jsonschema import JsonObject
 from xcube.util.progress import observe_progress
 from .config import ServiceConfig
@@ -316,8 +315,7 @@ class RemoteCubeGenerator(CubeGenerator):
             status='error',
             status_code=422,
             message='missing cube generator result',
-            output=state.output,
-            versions=XCUBE_VERSIONS
+            output=state.output
         )
 
     @classmethod

--- a/xcube/plugin.py
+++ b/xcube/plugin.py
@@ -191,6 +191,7 @@ def _register_cli_commands(ext_registry: extension.ExtensionRegistry):
         'tile',
         'vars2dim',
         'verify',
+        'versions',
 
         # Experimental + Hidden
         'io',

--- a/xcube/webapi/handlers.py
+++ b/xcube/webapi/handlers.py
@@ -29,6 +29,7 @@ from tornado.ioloop import IOLoop
 from xcube.constants import LOG
 from xcube.core.timecoord import timestamp_to_iso_string
 from xcube.util.perf import measure_time
+from xcube.util.versions import get_xcube_versions
 from xcube.version import version
 from xcube.webapi.auth import AuthMixin
 from xcube.webapi.controllers.catalogue import get_datasets, get_dataset_coordinates, get_color_bars, get_dataset, \
@@ -438,6 +439,7 @@ class InfoHandler(ServiceRequestHandler):
         self.write(json.dumps(dict(name=SERVER_NAME,
                                    description=SERVER_DESCRIPTION,
                                    version=version,
+                                   versions=get_xcube_versions(),
                                    configTime=config_time,
                                    serverTime=server_time,
                                    serverPID=os.getpid()),

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -45,7 +45,6 @@ from xcube.core.mldataset import guess_ml_dataset_format
 from xcube.util.cache import parse_mem_size
 from xcube.util.caseless import caseless_dict
 from xcube.util.config import load_configs
-from xcube.util.versions import XCUBE_VERSIONS
 from xcube.util.undefined import UNDEFINED
 from xcube.version import version
 from xcube.webapi.context import ServiceContext
@@ -304,7 +303,6 @@ class ServiceRequestHandler(RequestHandler):
                 'error': {
                     'code': status_code,
                     'message': self._reason,
-                    'versions': XCUBE_VERSIONS,
                     'traceback': lines,
                 }
             }, indent=2))
@@ -313,7 +311,6 @@ class ServiceRequestHandler(RequestHandler):
                 'error': {
                     'code': status_code,
                     'message': self._reason,
-                    'versions': XCUBE_VERSIONS,
                 }
             }, indent=2))
 


### PR DESCRIPTION
* Added CLI "xcube versions"
* Adjusted usage of `get_xcube_versions()`
* `get_xcube_versions()` returns chached instance

[Description of PR]

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!