### PR TITLE
Improve finding of dependency module versions

### DIFF
--- a/xcube/util/versions.py
+++ b/xcube/util/versions.py
@@ -78,7 +78,16 @@ def get_versions(dependency_names: List[str], plugin_names: List[str]) \
     dependencies = [(_maybe_add_dot_version(plugin_name),
                      lambda mod: mod.version)
                     for plugin_name in plugin_names]
-    dependencies += [(dependency_name, lambda mod: mod.__version__)
+
+    def _find_module_version(mod):
+        if hasattr(mod, '__version__'):
+            return mod.__version__
+        elif hasattr(mod, 'version'):
+            return mod.version
+        else:
+            return 'unknown'
+
+    dependencies += [(dependency_name, _find_module_version)
                      for dependency_name in dependency_names]
 
     dependencies_dict = {}


### PR DESCRIPTION
In util.versions.get_versions:

 - If a module doesn't have a __versions__ attribute,
   look for versions attribute instead.

 - If neither is present, give "unknown" as version

[Description of PR]

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!