### PR TITLE
Increased snapping tolerance

### DIFF
--- a/xcube/core/gridmapping/helpers.py
+++ b/xcube/core/gridmapping/helpers.py
@@ -50,7 +50,7 @@ def _to_int_or_float(x: Number) -> Number:
         return x
     xi = int(x)
     xf = float(x)
-    return xi if math.isclose(xi, xf, abs_tol=1e-10) else xf
+    return xi if math.isclose(xi, xf, abs_tol=1e-5) else xf
 
 
 def _from_affine(matrix: affine.Affine) -> AffineTransformMatrix:


### PR DESCRIPTION
Adresses https://github.com/bcdev/service-eurodatacube/issues/197 .

While this solves the issue at hand, I do not feel that it is the optimal solution. The problem is that within pandas / xarray castings from float32 to float64 and back are performed, which may introduce significant rounding errors. The optimal way would be to avoid such unnecessary castings and stick to the data type, but this seems to be out of scope. 
Also, my understanding is that major changes lie ahead with respect to the spatial resampling, so this fix might likely be obsolete soon. Still, I create this PR because it (a) solves the isse and (b) serves to document a problem.