### PR TITLE
Fix tests for xarray >= 0.19

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
-  - pandas >=1.2,<1.3.0  # tests fail with 1.3.0, see xarray #5581
+  - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7
   - pyproj >=3.0
@@ -37,9 +37,7 @@ dependencies:
   - strict-rfc3339 >=0.7  # for python-jsonschema date-time format validation
   - tornado >=6.0
   - urllib3 >=1.26
-  # TODO: a lot of tests fail with 0.19
-  # Therefore pin to 0.18.2
-  - xarray =0.18.2
+  - xarray >=0.19
   - zarr >=2.8
   # Testing
   - flake8 >=3.7

--- a/test/cli/test_dump.py
+++ b/test/cli/test_dump.py
@@ -15,7 +15,7 @@ class DumpTest(CliDataTest):
         # post-change behaviour.
         output_template = (
             "<xarray.Dataset>\n"
-            "Dimensions:        (bnds: 2, lat: 180, lon: 360, time: 5)\n"
+            "Dimensions:        (time: 5, lat: 180, lon: 360, bnds: 2)\n"
             "Coordinates:\n"
             "  * lon            (lon) float64 -179.5 -178.5 -177.5 ... 177.5 178.5 179.5\n"
             "  * lat            (lat) float64 -89.5 -88.5 -87.5 -86.5 ... 86.5 87.5 88.5 89.5\n"
@@ -45,6 +45,6 @@ class DumpTest(CliDataTest):
             output_template % '2:00:00',  # for xarray v0.15.1 and below
             output_template % '...'  # for xarray v0.16.0 and above
         ]
-
+        print(result.output)
         self.assertIn(result.output, possible_outputs)
         self.assertEqual(0, result.exit_code)

--- a/test/cli/test_edit.py
+++ b/test/cli/test_edit.py
@@ -81,13 +81,12 @@ class EditMetadaDataTest(CliDataTest):
         self.assertEqual(ds1.__len__(), ds2.__len__())
         self.assertIn('geospatial_lat_max', ds2.attrs.keys())
         self.assertIn('geospatial_lat_min', ds2.attrs.keys())
-        self.assertIn('geospatial_lat_resolution', ds2.attrs.keys())
         self.assertIn('geospatial_lat_units', ds2.attrs.keys())
         self.assertIn('geospatial_lon_max', ds2.attrs.keys())
         self.assertEqual(180.0, ds2.attrs.__getitem__('geospatial_lon_max'))
         self.assertEqual(-180.0, ds2.attrs.__getitem__('geospatial_lon_min'))
-        self.assertEqual('2010-01-04T00:00:00.000000000', ds2.attrs.__getitem__('time_coverage_end'))
-        self.assertEqual('2010-01-01T00:00:00.000000000', ds2.attrs.__getitem__('time_coverage_start'))
+        self.assertEqual('2010-01-04T00:00:00', ds2.attrs.__getitem__('time_coverage_end'))
+        self.assertEqual('2010-01-01T00:00:00', ds2.attrs.__getitem__('time_coverage_start'))
         self.assertEqual('degrees_east', ds2.attrs.__getitem__('geospatial_lon_units'))
 
 

--- a/test/core/test_dump.py
+++ b/test/core/test_dump.py
@@ -15,7 +15,7 @@ class DumpDatasetTest(unittest.TestCase):
 
         text = dump_dataset(dataset)
         self.assertIn("<xarray.Dataset>", text)
-        self.assertIn("Dimensions:        (lat: 180, lon: 360, time: 5)\n", text)
+        self.assertIn("Dimensions:        (time: 5, lat: 180, lon: 360)\n", text)
         self.assertIn("Coordinates:\n", text)
         self.assertIn("  * lon            (lon) float64 ", text)
         self.assertIn("Data variables:\n", text)
@@ -26,7 +26,7 @@ class DumpDatasetTest(unittest.TestCase):
 
         text = dump_dataset(dataset, show_var_encoding=True)
         self.assertIn("<xarray.Dataset>", text)
-        self.assertIn("Dimensions:        (lat: 180, lon: 360, time: 5)\n", text)
+        self.assertIn("Dimensions:        (time: 5, lat: 180, lon: 360)\n", text)
         self.assertIn("Coordinates:\n", text)
         self.assertIn("  * lon            (lon) float64 ", text)
         self.assertIn("Data variables:\n", text)

--- a/test/core/test_edit.py
+++ b/test/core/test_edit.py
@@ -98,13 +98,12 @@ class EditVariablePropsTest(unittest.TestCase):
         self.assertEqual(ds1.__len__(), ds2.__len__())
         self.assertIn('geospatial_lat_max', ds2.attrs.keys())
         self.assertIn('geospatial_lat_min', ds2.attrs.keys())
-        self.assertIn('geospatial_lat_resolution', ds2.attrs.keys())
         self.assertIn('geospatial_lat_units', ds2.attrs.keys())
         self.assertIn('geospatial_lon_max', ds2.attrs.keys())
         self.assertEqual(180.0, ds2.attrs.__getitem__('geospatial_lon_max'))
         self.assertEqual(-180.0, ds2.attrs.__getitem__('geospatial_lon_min'))
-        self.assertEqual('2010-01-04T00:00:00.000000000', ds2.attrs.__getitem__('time_coverage_end'))
-        self.assertEqual('2010-01-01T00:00:00.000000000', ds2.attrs.__getitem__('time_coverage_start'))
+        self.assertEqual('2010-01-04T00:00:00', ds2.attrs.__getitem__('time_coverage_end'))
+        self.assertEqual('2010-01-01T00:00:00', ds2.attrs.__getitem__('time_coverage_start'))
         self.assertEqual('degrees_east', ds2.attrs.__getitem__('geospatial_lon_units'))
 
     def test_edit_metadata_in_place(self):

--- a/test/core/test_optimize.py
+++ b/test/core/test_optimize.py
@@ -17,7 +17,7 @@ OUTPUT_CUBE_PATH = 'test_opt.zarr'
 OUTPUT_CUBE_PATTERN = '{input}_opt.zarr'
 
 INPUT_CUBE_FILE_SET = {
-    '.zattrs', '.zgroup',
+    '.zattrs', '.zgroup',  '.zmetadata',
     'A/.zarray', 'A/.zattrs', 'A/0.0.0', 'A/1.0.0', 'A/2.0.0',
     'B/.zarray', 'B/.zattrs', 'B/0.0.0', 'B/1.0.0', 'B/2.0.0',
     'lat/.zarray', 'lat/.zattrs', 'lat/0',

--- a/test/core/test_verify.py
+++ b/test/core/test_verify.py
@@ -85,11 +85,11 @@ class AssertAndVerifyCubeTest(unittest.TestCase):
     def test_verify_cube_coord_equidistance_reverse_lat(self):
         ds = new_cube()
         ds['lat'] = np.flip(ds.lat)
-        ds['lat_bnds'] = (['lat', 'bnds'], np.flip(ds.lat_bnds))
+        ds['lat_bnds'] = xr.DataArray(np.flip(ds.lat_bnds.values),
+                                      dims=['lat', 'bnds'])
 
         ds['lon'] = np.roll(ds.lon, 90)
-        ds['lon_bnds'] = (['lon', 'bnds'], np.roll(ds.lon_bnds, 180))
+        ds['lon_bnds'] = xr.DataArray(np.roll(ds.lon_bnds.values, 180),
+                                      dims=['lon', 'bnds'])
 
         self.assertEqual([], verify_cube(ds))
-
-

--- a/test/webapi/s3/list-bucket-v1-result.xml
+++ b/test/webapi/s3/list-bucket-v1-result.xml
@@ -26,6 +26,13 @@
     <ETag>"c7a4dcb9d6a66348e2a4b41943878919"</ETag>
     <StorageClass>STANDARD</StorageClass>
   </Contents>
+  <Contents>
+    <Key>bibo.zarr/.zmetadata</Key>
+    <Size>6572</Size>
+    <LastModified>2019-06-24T20:43:40.862Z</LastModified>
+    <ETag>"5f82311295b3815f80c6814be9b83335"</ETag>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
   <CommonPrefixes>
     <Prefix>bibo.zarr/lat/</Prefix>
   </CommonPrefixes>

--- a/test/webapi/s3/list-bucket-v2-result.xml
+++ b/test/webapi/s3/list-bucket-v2-result.xml
@@ -27,6 +27,13 @@
     <ETag>"c7a4dcb9d6a66348e2a4b41943878919"</ETag>
     <StorageClass>STANDARD</StorageClass>
   </Contents>
+  <Contents>
+    <Key>bibo.zarr/.zmetadata</Key>
+    <Size>6572</Size>
+    <LastModified>2019-06-24T20:43:40.862Z</LastModified>
+    <ETag>"5f82311295b3815f80c6814be9b83335"</ETag>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
   <CommonPrefixes>
     <Prefix>bibo.zarr/lat/</Prefix>
   </CommonPrefixes>

--- a/test/webapi/test_s3util.py
+++ b/test/webapi/test_s3util.py
@@ -40,7 +40,7 @@ class ListS3BucketKeys(S3BucketTest):
     def test_list_bucket_keys(self):
         result = [key_path for key_path in list_s3_bucket_keys(S3_BUCKET_DICT)]
         self.assertEqual(EXPECTED_KEYS, [key for key, _ in result])
-        self.assertEqual(170, len(EXPECTED_KEYS))
+        self.assertEqual(172, len(EXPECTED_KEYS))
 
 
 class ListS3BucketTest(S3BucketTest, metaclass=ABCMeta):
@@ -61,14 +61,14 @@ class ListS3BucketV12TestsMixin:
         list_bucket_result = self.list_bucket(S3_BUCKET_DICT)
         self.assert_list_bucket_result(list_bucket_result)
         self.assertIsInstance(list_bucket_result.get('Contents'), list)
-        self.assertEqual(170, len(list_bucket_result.get('Contents')))
+        self.assertEqual(172, len(list_bucket_result.get('Contents')))
         self.assertNotIn('CommonPrefixes', list_bucket_result)
 
     def test_list_bucket_v12_prefix(self):
         list_bucket_result = self.list_bucket(S3_BUCKET_DICT, prefix='bibo.zarr/')
         self.assert_list_bucket_result(list_bucket_result, prefix='bibo.zarr/')
         self.assertIsInstance(list_bucket_result.get('Contents'), list)
-        self.assertEqual(85, len(list_bucket_result.get('Contents')))
+        self.assertEqual(86, len(list_bucket_result.get('Contents')))
         self.assertNotIn('CommonPrefixes', list_bucket_result)
 
     def test_list_bucket_v12_delimiter(self):
@@ -101,6 +101,11 @@ class ListS3BucketV12TestsMixin:
                            'Key': 'bert.zarr/.zgroup',
                            'LastModified': '2019-06-24T20:43:40.862Z',
                            'Size': 24,
+                           'StorageClass': 'STANDARD'},
+                          {'ETag': '"cc1a0115345e38f58a88b83722a9d2d8"',
+                           'Key': 'bert.zarr/.zmetadata',
+                           'LastModified': '2019-06-24T20:43:40.862Z',
+                           'Size': 6572,
                            'StorageClass': 'STANDARD'}],
                          list_bucket_result.get('Contents'))
         self.assertEqual([{'Prefix': 'bert.zarr/lat/'},
@@ -129,7 +134,7 @@ class ListBucketV1Test(ListS3BucketTest, ListS3BucketV12TestsMixin):
         list_bucket_result = self.list_bucket(S3_BUCKET_DICT,
                                               max_keys=5)
         self.assert_list_bucket_result(list_bucket_result, max_keys=5, is_truncated=True,
-                                       next_marker='bert.zarr/lat/.zattrs')
+                                       next_marker='bert.zarr/lat/.zarray')
         self.assertIsInstance(list_bucket_result.get('Contents'), list)
         self.assertEqual([{'ETag': '"5fb93bce985c60d724d9869f32e02d24"',
                            'Key': 'bert.zarr/',
@@ -146,15 +151,15 @@ class ListBucketV1Test(ListS3BucketTest, ListS3BucketV12TestsMixin):
                            'LastModified': '2019-06-24T20:43:40.862Z',
                            'Size': 24,
                            'StorageClass': 'STANDARD'},
+                          {'ETag': '"cc1a0115345e38f58a88b83722a9d2d8"',
+                           'Key': 'bert.zarr/.zmetadata',
+                           'LastModified': '2019-06-24T20:43:40.862Z',
+                           'Size': 6572,
+                           'StorageClass': 'STANDARD'},
                           {'ETag': '"f64109793f6ea9ec1c9cfcb8ee97e145"',
                            'Key': 'bert.zarr/lat/',
                            'LastModified': '2019-06-24T20:43:40.862Z',
                            'Size': 0,
-                           'StorageClass': 'STANDARD'},
-                          {'ETag': '"b74fb939f20cf7cff02c208e8824faec"',
-                           'Key': 'bert.zarr/lat/.zarray',
-                           'LastModified': '2019-06-24T20:43:40.862Z',
-                           'Size': 317,
                            'StorageClass': 'STANDARD'}],
                          list_bucket_result.get('Contents'))
         self.assertNotIn('CommonPrefixes', list_bucket_result)
@@ -217,15 +222,15 @@ class ListS3BucketV2Test(ListS3BucketTest, ListS3BucketV12TestsMixin):
                            'LastModified': '2019-06-24T20:43:40.862Z',
                            'Size': 24,
                            'StorageClass': 'STANDARD'},
+                          {'ETag': '"cc1a0115345e38f58a88b83722a9d2d8"',
+                           'Key': 'bert.zarr/.zmetadata',
+                           'LastModified': '2019-06-24T20:43:40.862Z',
+                           'Size': 6572,
+                           'StorageClass': 'STANDARD'},
                           {'ETag': '"f64109793f6ea9ec1c9cfcb8ee97e145"',
                            'Key': 'bert.zarr/lat/',
                            'LastModified': '2019-06-24T20:43:40.862Z',
                            'Size': 0,
-                           'StorageClass': 'STANDARD'},
-                          {'ETag': '"b74fb939f20cf7cff02c208e8824faec"',
-                           'Key': 'bert.zarr/lat/.zarray',
-                           'LastModified': '2019-06-24T20:43:40.862Z',
-                           'Size': 317,
                            'StorageClass': 'STANDARD'}],
                          list_bucket_result.get('Contents'))
         self.assertNotIn('CommonPrefixes', list_bucket_result)
@@ -270,6 +275,7 @@ EXPECTED_KEYS = [
     'bert.zarr/',
     'bert.zarr/.zattrs',
     'bert.zarr/.zgroup',
+    'bert.zarr/.zmetadata',
     'bert.zarr/lat/',
     'bert.zarr/lat/.zarray',
     'bert.zarr/lat/.zattrs',
@@ -355,6 +361,7 @@ EXPECTED_KEYS = [
     'bibo.zarr/',
     'bibo.zarr/.zattrs',
     'bibo.zarr/.zgroup',
+    'bibo.zarr/.zmetadata',
     'bibo.zarr/lat/',
     'bibo.zarr/lat/.zarray',
     'bibo.zarr/lat/.zattrs',

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -443,12 +443,14 @@ class ZarrDatasetIO(DatasetIO):
               s3_kwargs: Dict[str, Any] = None,
               s3_client_kwargs: Dict[str, Any] = None,
               **kwargs):
-        path_or_store, consolidated = get_path_or_s3_store(output_path,
-                                                           s3_kwargs=s3_kwargs,
-                                                           s3_client_kwargs=s3_client_kwargs,
-                                                           mode='w')
+        path_or_store, _ = get_path_or_s3_store(output_path,
+                                                s3_kwargs=s3_kwargs,
+                                                s3_client_kwargs=s3_client_kwargs,
+                                                mode='w')
         encoding = self._get_write_encodings(dataset, compressor, chunksizes, packing)
-        dataset.to_zarr(path_or_store, mode='w', encoding=encoding, **kwargs)
+        consolidated = kwargs.pop('consolidated', True)
+        dataset.to_zarr(path_or_store, mode='w', encoding=encoding,
+                        consolidated=consolidated, **kwargs)
 
     @classmethod
     def _get_write_encodings(cls, dataset, compressor, chunksizes, packing):
@@ -501,6 +503,7 @@ class ZarrDatasetIO(DatasetIO):
             import zarr
             ds = zarr.open_group(output_path, mode='r+', **kwargs)
             ds.attrs.update(global_attrs)
+            zarr.consolidate_metadata(output_path)
 
 
 # noinspection PyAbstractClass

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -313,7 +313,7 @@ def _process_input(input_processor: InputProcessor,
         def step8(input_slice):
             if not dry_run:
                 output_writer.append(input_slice, output_path, **output_writer_params)
-                _update_cube(output_writer, output_path, temporal_only=True, consolidate=True)
+                _update_cube(output_writer, output_path, temporal_only=True)
             return input_slice
 
         steps.append((step8, f'appending input slice to {output_path}'))
@@ -322,7 +322,7 @@ def _process_input(input_processor: InputProcessor,
         def step8(input_slice):
             if not dry_run:
                 output_writer.insert(input_slice, time_index, output_path)
-                _update_cube(output_writer, output_path, temporal_only=True, consolidate=True)
+                _update_cube(output_writer, output_path, temporal_only=True)
             return input_slice
 
         steps.append((step8, f'inserting input slice before index {time_index} in {output_path}'))
@@ -331,7 +331,7 @@ def _process_input(input_processor: InputProcessor,
         def step8(input_slice):
             if not dry_run:
                 output_writer.replace(input_slice, time_index, output_path)
-                _update_cube(output_writer, output_path, temporal_only=True, consolidate=True)
+                _update_cube(output_writer, output_path, temporal_only=True)
             return input_slice
 
         steps.append((step8, f'replacing input slice at index {time_index} in {output_path}'))
@@ -387,15 +387,17 @@ def _get_tile_size(output_writer_params):
     return tile_size
 
 
-def _update_cube(output_writer: DatasetIO, output_path: str, global_attrs: Dict = None, temporal_only: bool = False,
-                 consolidate: bool = True):
-    if consolidate and os.path.isfile(os.path.join(output_path, '.zgroup')):
-        optimize_dataset(input_path=output_path, in_place=True, unchunk_coords=True)
+def _update_cube(output_writer: DatasetIO,
+                 output_path: str,
+                 global_attrs: Dict = None,
+                 temporal_only: bool = False):
     cube = output_writer.read(output_path)
     if temporal_only:
-        cube = update_dataset_temporal_attrs(cube, update_existing=True, in_place=True)
+        cube = update_dataset_temporal_attrs(cube,
+                                             update_existing=True, in_place=True)
     else:
-        cube = update_dataset_attrs(cube, update_existing=True, in_place=True)
+        cube = update_dataset_attrs(cube,
+                                    update_existing=True, in_place=True)
     cube_attrs = dict(cube.attrs)
     cube.close()
 

--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -95,13 +95,6 @@ def append_time_slice(store: Union[str, MutableMapping],
 
     time_slice.to_zarr(store, mode='a', append_dim='time', consolidated=True)
 
-    # Note by forman:
-    # Since xcube 0.9.1 and xarray 0.19+ we no longer unchunk datasets,
-    # because this leads to problems with cf-decoded "time" and "time_bnds"
-    # variables. This is because we unchunk using the zarr API rather than
-    # xarray, but zarr isn't ware of CF encodings.
-    # Maybe the root cause lies in the time_slice.to_zarr() call above.
-    #
     unchunk_dataset(store, coords_only=True)
 
 

--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -93,7 +93,15 @@ def append_time_slice(store: Union[str, MutableMapping],
         # from next time_slice.to_zarr(...) call.
         time_slice.attrs.pop('coordinates')
 
-    time_slice.to_zarr(store, mode='a', append_dim='time')
+    time_slice.to_zarr(store, mode='a', append_dim='time', consolidated=True)
+
+    # Note by forman:
+    # Since xcube 0.9.1 and xarray 0.19+ we no longer unchunk datasets,
+    # because this leads to problems with cf-decoded "time" and "time_bnds"
+    # variables. This is because we unchunk using the zarr API rather than
+    # xarray, but zarr isn't ware of CF encodings.
+    # Maybe the root cause lies in the time_slice.to_zarr() call above.
+    #
     unchunk_dataset(store, coords_only=True)
 
 

--- a/xcube/core/unchunk.py
+++ b/xcube/core/unchunk.py
@@ -84,3 +84,5 @@ def _unchunk_vars(dataset_path: str, var_names: List[str]):
             # therefore we must modify attrs explicitly:
             var_array = zarr.convenience.open_array(var_path, 'r+')
             var_array.attrs.update(attributes)
+
+    zarr.consolidate_metadata(dataset_path)


### PR DESCRIPTION
Make xcube use xarray >= 0.19

@TonioF 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!