### PR TITLE
handle non-existing roots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Changes in 0.9.2
+## Changes in 0.9.2 (in development)
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in 0.9.2
+
+### Fixes
+
+* Be more robust with respect to non-existing data store root directories.   
+
 ## Changes in 0.9.1
 
 ### New features

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -581,6 +581,8 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
                            return_tuples: bool,
                            current_depth: int):
         root = self.root + ('/' + dir_path if dir_path else '')
+        if not self.fs.exists(root):
+            return
         # noinspection PyArgumentEqualDefault
         for file_info in self.fs.ls(root, detail=True):
             file_path: str = file_info['name']


### PR DESCRIPTION
Avoids errors when a file system data store is created with a root that does not yet exist. The root will be created the first time that data is written to the store, it will be ignored beforehand.