### PR TITLE
Pinning openssl to fix failing unittest on mac

### DIFF
--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -31,7 +31,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install pytest pytest-cov
-          mamba install -c conda-forge  flask-testing requests-mock
 
           pytest --cov=./ --cov-report=xml
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -31,7 +31,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install pytest pytest-cov
-          mamba install -c conda-forge  flask-testing moto requests-mock
+          mamba install -c conda-forge  flask-testing requests-mock
 
           pytest --cov=./ --cov-report=xml
       - uses: codecov/codecov-action@v1

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - requests-oauthlib >=1.3
   - s3fs >=2021.6
   - scipy >=1.6.0
-  - setuptools >=41.0
+  - setuptools =59.4.0
   - shapely >=1.6
   - strict-rfc3339 >=0.7  # for python-jsonschema date-time format validation
   - tornado >=6.0

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
-  - openssl =3.0.1
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
+  - openssl = 1.1.1l
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
-  - openssl =1.1.1l
+  - openssl =3.0.1
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
+  - openssl =1.1.1l # pinning openssl due to unit test issues on mac, https://github.com/conda/conda/issues/11111
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
-  - openssl <=3.0.0 # pinning openssl due to unit test issues on mac, https://github.com/conda/conda/issues/11111
+  - openssl <3.0.0 # pinning openssl due to unit test issues on mac, https://github.com/conda/conda/issues/11111
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
-  - openssl =1.1.1l # pinning openssl due to unit test issues on mac, https://github.com/conda/conda/issues/11111
+  - openssl <=3.0.0 # pinning openssl due to unit test issues on mac, https://github.com/conda/conda/issues/11111
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - netcdf4 >=1.5.0
   - numba >=0.52
   - numpy >=1.16
-  - openssl = 1.1.1l
+  - openssl =1.1.1l
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7
@@ -33,7 +33,7 @@ dependencies:
   - requests-oauthlib >=1.3
   - s3fs >=2021.6
   - scipy >=1.6.0
-  - setuptools =59.4.0
+  - setuptools >=41.0
   - shapely >=1.6
   - strict-rfc3339 >=0.7  # for python-jsonschema date-time format validation
   - tornado >=6.0

--- a/xcube/webapi/auth.py
+++ b/xcube/webapi/auth.py
@@ -149,9 +149,9 @@ class AuthMixin:
             except jwt.InvalidTokenError:
                 raise ServiceAuthError("Invalid claims",
                                        log_message="Incorrect claims, please check the audience and issuer")
-            # except Exception:
-            #     raise ServiceAuthError("Invalid header",
-            #                            log_message="Unable to parse authentication token.")
+            except Exception:
+                raise ServiceAuthError("Invalid header",
+                                       log_message="Unable to parse authentication token.")
             return id_token
 
         raise ServiceAuthError("Invalid header",

--- a/xcube/webapi/auth.py
+++ b/xcube/webapi/auth.py
@@ -149,9 +149,9 @@ class AuthMixin:
             except jwt.InvalidTokenError:
                 raise ServiceAuthError("Invalid claims",
                                        log_message="Incorrect claims, please check the audience and issuer")
-            except Exception:
-                raise ServiceAuthError("Invalid header",
-                                       log_message="Unable to parse authentication token.")
+            # except Exception:
+            #     raise ServiceAuthError("Invalid header",
+            #                            log_message="Unable to parse authentication token.")
             return id_token
 
         raise ServiceAuthError("Invalid header",


### PR DESCRIPTION
[Description of PR]
This PR only adds openssl to the dependencies of xcube, and pins it to the last working version. This should be undone, once https://github.com/conda/conda/issues/11111 is solved. 

No code has changed. 

FYI @forman @TonioF 


Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [ ] ~~Changes documented in `CHANGES.md`~~
* [x] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!