### PR TITLE
Fix WMTS endpoint w.o. service provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 * Changed the `xcube gen` tool to extract metadata for pre-sorting inputs
   from other than NetCDF inputs, e.g. GeoTIFF.
 
+* It is no longer required to have a `ServiceProvider` entry in 
+  the configuration for the xcube server (`xcube serve` tool).
+
 ## Changes in 0.9.2
 
 ### Fixes

--- a/test/webapi/test_auth.py
+++ b/test/webapi/test_auth.py
@@ -79,6 +79,8 @@ class AuthMixinIdTokenTest(unittest.TestCase):
         auth_mixin.request = RequestMock(headers={})
         self.assertEqual(None, auth_mixin.get_id_token())
 
+    @unittest.skipUnless(XCUBE_TEST_CLIENT_ID and XCUBE_TEST_CLIENT_SECRET,
+                         'XCUBE_TEST_CLIENT_ID and XCUBE_TEST_CLIENT_SECRET must be set')
     def test_expired_access_token(self):
         auth_mixin = AuthMixin()
         auth_mixin.service_context = ServiceContextMock(config=dict(

--- a/xcube/util/dask.py
+++ b/xcube/util/dask.py
@@ -36,9 +36,9 @@ def compute_array_from_func(func: Callable[..., np.ndarray],
     * ``dtype``: The array's numpy data type.
     * ``name``: The array's name. A string or ``None``.
     * ``block_id``: The block's unique ID. An integer number ranging from zero to number of blocks minus one.
-    * ``block_index``: The block's index. A tuple of ints.
-    * ``block_shape``: The block's shape. A tuple of ints.
-    * ``block_slices``: The block's shape. A tuple of int pair tuples.
+    * ``block_index``: The block's index as a tuple of ints.
+    * ``block_shape``: The block's shape as a tuple of ints.
+    * ``block_slices``: The block's shape as a tuple of int pair tuples.
 
     :param func: User function that is called for each block of the array using arguments specified by
         *ctx_arg_names*, *args*, and *kwargs*. It must return a numpy array of shape "block_shape" and type

--- a/xcube/webapi/controllers/wmts.py
+++ b/xcube/webapi/controllers/wmts.py
@@ -27,41 +27,45 @@ def get_wmts_capabilities_xml(ctx: ServiceContext, base_url: str):
         f"    </ows:ServiceIdentification>\n"
     )
 
-    service_provider = ctx.config['ServiceProvider']
-    service_contact = service_provider['ServiceContact']
-    contact_info = service_contact['ContactInfo']
-    phone = contact_info['Phone']
-    address = contact_info['Address']
+    service_provider = ctx.config.get('ServiceProvider')
+    if not service_provider:
+        service_provider_xml = None
+    else:
+        service_contact = service_provider['ServiceContact']
+        contact_info = service_contact['ContactInfo']
+        phone = contact_info['Phone']
+        address = contact_info['Address']
 
-    service_provider_xml = (
-        f"\n"
-        f"    <ows:ServiceProvider>\n"
-        f"        <ows:ProviderName>{service_provider['ProviderName']}</ows:ProviderName>\n"
-        f"        <ows:ProviderSite xlink:href=\"{service_provider['ProviderSite']}\"/>\n"
-        f"        <ows:ServiceContact>\n"
-        f"            <ows:IndividualName>{service_contact['IndividualName']}</ows:IndividualName>\n"
-        f"            <ows:PositionName>{service_contact['PositionName']}</ows:PositionName>\n"
-        f"            <ows:ContactInfo>\n"
-        f"                <ows:Phone>\n"
-        f"                    <ows:Voice>{phone['Voice']}</ows:Voice>\n"
-        f"                    <ows:Facsimile>{phone['Facsimile']}</ows:Facsimile>\n"
-        f"                </ows:Phone>\n"
-        f"                <ows:Address>\n"
-        f"                    <ows:DeliveryPoint>{address['DeliveryPoint']}</ows:DeliveryPoint>\n"
-        f"                    <ows:City>{address['City']}</ows:City>\n"
-        f"                    <ows:AdministrativeArea>{address['AdministrativeArea']}</ows:AdministrativeArea>\n"
-        f"                    <ows:PostalCode>{address['PostalCode']}</ows:PostalCode>\n"
-        f"                    <ows:Country>{address['Country']}</ows:Country>\n"
-        f"                    <ows:ElectronicMailAddress>{address['ElectronicMailAddress']}"
-        f"</ows:ElectronicMailAddress>\n"
-        f"                </ows:Address>\n"
-        f"            </ows:ContactInfo>\n"
-        f"        </ows:ServiceContact>\n"
-        f"    </ows:ServiceProvider>\n"
-    )
+        service_provider_xml = (
+            f"\n"
+            f"    <ows:ServiceProvider>\n"
+            f"        <ows:ProviderName>{service_provider['ProviderName']}</ows:ProviderName>\n"
+            f"        <ows:ProviderSite xlink:href=\"{service_provider['ProviderSite']}\"/>\n"
+            f"        <ows:ServiceContact>\n"
+            f"            <ows:IndividualName>{service_contact['IndividualName']}</ows:IndividualName>\n"
+            f"            <ows:PositionName>{service_contact['PositionName']}</ows:PositionName>\n"
+            f"            <ows:ContactInfo>\n"
+            f"                <ows:Phone>\n"
+            f"                    <ows:Voice>{phone['Voice']}</ows:Voice>\n"
+            f"                    <ows:Facsimile>{phone['Facsimile']}</ows:Facsimile>\n"
+            f"                </ows:Phone>\n"
+            f"                <ows:Address>\n"
+            f"                    <ows:DeliveryPoint>{address['DeliveryPoint']}</ows:DeliveryPoint>\n"
+            f"                    <ows:City>{address['City']}</ows:City>\n"
+            f"                    <ows:AdministrativeArea>{address['AdministrativeArea']}</ows:AdministrativeArea>\n"
+            f"                    <ows:PostalCode>{address['PostalCode']}</ows:PostalCode>\n"
+            f"                    <ows:Country>{address['Country']}</ows:Country>\n"
+            f"                    <ows:ElectronicMailAddress>{address['ElectronicMailAddress']}"
+            f"</ows:ElectronicMailAddress>\n"
+            f"                </ows:Address>\n"
+            f"            </ows:ContactInfo>\n"
+            f"        </ows:ServiceContact>\n"
+            f"    </ows:ServiceProvider>\n"
+        )
 
     wmts_kvp_url = ctx.get_service_url(base_url, 'wmts/kvp?')
-    wmts_rest_cap_url = ctx.get_service_url(base_url, 'wmts/1.0.0/WMTSCapabilities.xml')
+    wmts_rest_cap_url = ctx.get_service_url(base_url,
+                                            'wmts/1.0.0/WMTSCapabilities.xml')
     wmts_rest_tile_url = ctx.get_service_url(base_url, 'wmts/1.0.0/')
 
     operations_metadata_xml = (
@@ -259,18 +263,35 @@ def get_wmts_capabilities_xml(ctx: ServiceContext, base_url: str):
         var_names = sorted(ds.data_vars)
         for var_name in var_names:
             var = ds[var_name]
-            var_title = var.attrs.get('title', var.attrs.get('long_name', var_name))
+            var_title = var.attrs.get('title',
+                                      var.attrs.get('long_name', var_name))
             themes_xml_lines.append((3, '<Theme>'))
-            themes_xml_lines.append((4, f'<ows:Title>{var_title}</ows:Title>'))
-            themes_xml_lines.append((4, f'<ows:Identifier>{ds_name}.{var_name}</ows:Identifier>'))
-            themes_xml_lines.append((4, f'<LayerRef>{ds_name}.{var_name}</LayerRef>'))
+            themes_xml_lines.append(
+                (4, f'<ows:Title>{var_title}</ows:Title>'))
+            themes_xml_lines.append(
+                (4, f'<ows:Identifier>{ds_name}.{var_name}</ows:Identifier>'))
+            themes_xml_lines.append(
+                (4, f'<LayerRef>{ds_name}.{var_name}</LayerRef>'))
             themes_xml_lines.append((3, '</Theme>'))
         themes_xml_lines.append((2, '</Theme>'))
     themes_xml_lines.append((1, '</Themes>'))
-    themes_xml = '\n'.join(['%s%s' % (n * indent, xml) for n, xml in themes_xml_lines])
+    themes_xml = '\n'.join(
+        ['%s%s' % (n * indent, xml) for n, xml in themes_xml_lines])
 
-    get_capablities_rest_url = ctx.get_service_url(base_url, 'wmts/1.0.0/WMTSCapabilities.xml')
+    get_capablities_rest_url = ctx.get_service_url(base_url,
+                                                   'wmts/1.0.0/WMTSCapabilities.xml')
     service_metadata_url_xml = f'<ServiceMetadataURL xlink:href="{get_capablities_rest_url}"/>'
+
+    body_parts = [
+        service_identification_xml,
+        service_provider_xml,
+        operations_metadata_xml,
+        contents_xml,
+        themes_xml,
+        service_metadata_url_xml,
+    ]
+
+    body = ''.join(f"    {p}\n" for p in body_parts)
 
     return (
         f"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -281,11 +302,6 @@ def get_wmts_capabilities_xml(ctx: ServiceContext, base_url: str):
         f"          xsi:schemaLocation=\"http://www.opengis.net/wmts/1.0"
         f" http://schemas.opengis.net/wmts/1.0.0/wmtsGetCapabilities_response.xsd\"\n"
         f"          version=\"1.0.0\">\n"
-        f"    {service_identification_xml}\n"
-        f"    {service_provider_xml}\n"
-        f"    {operations_metadata_xml}\n"
-        f"    {contents_xml}\n"
-        f"    {themes_xml}\n"
-        f"    {service_metadata_url_xml}\n"
+        f"{body}"
         f"</Capabilities>\n"
     )


### PR DESCRIPTION
When server is run w.o. `ServiceProvider`, the WMTS endpoint was broken. Made `ServiceProvider` optional.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
