### PR TITLE
Restrict python version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 * Changed the `xcube gen` tool to extract metadata for pre-sorting inputs
   from other than NetCDF inputs, e.g. GeoTIFF.
+  
+* Pinned Python version to < 3.10 to avoid ImportErrors caused by a third-party
+  library.
 
 ## Changes in 0.9.2
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # Python
-  - python >=3.8
+  - python >=3.8,<3.10
   # Required
   - affine >=2.2
   - click >=8.0

--- a/test/core/test_select.py
+++ b/test/core/test_select.py
@@ -2,7 +2,7 @@ import itertools
 import json
 import math
 import unittest
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from typing import Dict, KeysView, Iterator, Sequence, Any
 
 import cftime


### PR DESCRIPTION
Addresses https://github.com/dcs4cop/xcube/issues/583 . Only Python versions 3.8 and 3.9 are allowed, also fixed an import.