### PR TITLE
now also serve nested datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   from other than NetCDF inputs, e.g. GeoTIFF.
   
 ### Fixes
+
+* `xcube serve` now also serves datasets that are located in 
+  subdirectories of filesystem-based data stores such as
+  "file", "s3", "memory". (#579)
   
 * Fixed bug that would cause that requesting data ids on some s3 stores would
   fail with a confusing ValueError.

--- a/xcube/webapi/controllers/tiles.py
+++ b/xcube/webapi/controllers/tiles.py
@@ -1,6 +1,6 @@
 import io
 from typing import Dict, Any
-
+import urllib.parse
 import matplotlib
 import matplotlib.colorbar
 import matplotlib.colors
@@ -164,9 +164,9 @@ def get_dataset_tile_url(ctx: ServiceContext,
                          base_url: str):
     return ctx.get_service_url(base_url,
                                'datasets',
-                               ds_id,
+                               urllib.parse.quote(ds_id),
                                'vars',
-                               var_name,
+                               urllib.parse.quote(var_name),
                                'tiles',
                                '{z}/{x}/{y}.png')
 

--- a/xcube/webapi/controllers/tiles.py
+++ b/xcube/webapi/controllers/tiles.py
@@ -164,9 +164,9 @@ def get_dataset_tile_url(ctx: ServiceContext,
                          base_url: str):
     return ctx.get_service_url(base_url,
                                'datasets',
-                               urllib.parse.quote(ds_id),
+                               urllib.parse.quote_plus(ds_id),
                                'vars',
-                               urllib.parse.quote(var_name),
+                               urllib.parse.quote_plus(var_name),
                                'tiles',
                                '{z}/{x}/{y}.png')
 

--- a/xcube/webapi/controllers/wmts.py
+++ b/xcube/webapi/controllers/wmts.py
@@ -199,7 +199,7 @@ def get_wmts_capabilities_xml(ctx: ServiceContext, base_url: str):
                 var_abstract = var.attrs.get('comment', '')
 
                 layer_tile_url = (layer_base_url
-                                  % tuple(map(urllib.parse.quote,
+                                  % tuple(map(urllib.parse.quote_plus,
                                               (ds_name, var_name))))
 
                 contents_xml_lines.append((2, '<Layer>'))

--- a/xcube/webapi/controllers/wmts.py
+++ b/xcube/webapi/controllers/wmts.py
@@ -1,3 +1,26 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import urllib.parse
+
 import math
 
 from xcube.webapi.context import ServiceContext
@@ -175,7 +198,10 @@ def get_wmts_capabilities_xml(ctx: ServiceContext, base_url: str):
                 var_title = ds_name + "/" + var.attrs.get('title', var.attrs.get('long_name', var_name))
                 var_abstract = var.attrs.get('comment', '')
 
-                layer_tile_url = layer_base_url % (ds_name, var_name)
+                layer_tile_url = (layer_base_url
+                                  % tuple(map(urllib.parse.quote,
+                                              (ds_name, var_name))))
+
                 contents_xml_lines.append((2, '<Layer>'))
                 contents_xml_lines.append((3, f'<ows:Identifier>{ds_name}.{var_name}</ows:Identifier>'))
                 contents_xml_lines.append((3, f'<ows:Title>{var_title}</ows:Title>'))


### PR DESCRIPTION
`xcube serve` now also serves datasets that are located in subdirectories of filesystem-based data stores such as "file", "s3", "memory".

Closes #579

**EDIT**: After this PR, please review https://github.com/dcs4cop/xcube-viewer/pull/191

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!