### PR TITLE
Only last configured Identifier is published via xcube serve

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,9 @@
 * Fixed bug that would cause that requesting data ids on some s3 stores would
   fail with a confusing ValueError.
   
-* Fixed that only last identifier was published via xcube serve (#576)
+* Fixed that only last dataset of a directory listing was published via 
+  `xcube serve` when using the `DataStores` configuration with 
+  filesystem-based datastores such as "s3" or "file". (#576)
   
 ### Other
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 * Fixed bug that would cause that requesting data ids on some s3 stores would
   fail with a confusing ValueError.
   
+* Fixed that only last identifier was published via xcube serve (#576)
+  
 ### Other
 
 * Pinned Python version to < 3.10 to avoid ImportErrors caused by a third-party

--- a/test/webapi/res/test/config-datastores.yml
+++ b/test/webapi/res/test/config-datastores.yml
@@ -1,0 +1,10 @@
+DataStores:
+  - Identifier: test
+    StoreId: file
+    StoreParams:
+      root: examples/serve/demo
+    Datasets:
+      - Identifier: "cube-1-250-250.zarr"
+        Style: "default"
+      - Identifier: "cube-5-100-200.zarr"
+        Style: "default"

--- a/test/webapi/test_context.py
+++ b/test/webapi/test_context.py
@@ -61,6 +61,16 @@ class ServiceContextTest(unittest.TestCase):
                 conc_chl_z = ctx.get_variable_for_z('demo-aug', var_name, z)
                 self.assertIsInstance(conc_chl_z, xr.DataArray)
 
+    def test_get_dataset_configs_from_stores(self):
+        ctx = new_test_service_context(config_file_name='config-datastores.yml')
+
+        dataset_configs_from_stores = ctx.get_dataset_configs_from_stores()
+        self.assertIsNotNone(dataset_configs_from_stores)
+        self.assertEqual(2, len(dataset_configs_from_stores))
+        ids = [config['Identifier'] for config in dataset_configs_from_stores]
+        self.assertIn('test~cube-1-250-250.zarr', ids)
+        self.assertIn('test~cube-5-100-200.zarr', ids)
+
     def test_config_and_dataset_cache(self):
         ctx = new_test_service_context()
         self.assertNotIn('demo', ctx.dataset_cache)

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -300,6 +300,7 @@ class ServiceContext:
                         if fnmatch.fnmatch(store_dataset_id,
                                            dataset_id_pattern):
                             dataset_config_base = store_dataset_config
+                            break
                         else:
                             dataset_config_base = None
                 if dataset_config_base is not None:


### PR DESCRIPTION
Solves #576 .

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)