### PR TITLE
Revise spatial x,y resolutions check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,8 +20,8 @@
   subdirectories of filesystem-based data stores such as
   "file", "s3", "memory". (#579)
 
-* `xcube serve` no longer rejects datasets whose spatial
-  resolutions differ less than 1%. (#590)
+* xcube serve now accepts datasets whose spatial 
+  resolutions differ up to 1%. (#590)
   It also no longer rejects datasets with large dimension 
   sizes. (Formerly, an integer-overflow occurred in size 
   computation.) 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@
   "file", "s3", "memory". (#579)
 
 * `xcube serve` no longer rejects datasets whose spatial
-  resolutions in x any differ less than 1%. (#590)
+  resolutions differ less than 1%. (#590)
   It also no longer rejects datasets with large dimension 
   sizes. (Formerly, an integer-overflow occurred in size 
   computation.) 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,15 @@
 * `xcube serve` now also serves datasets that are located in 
   subdirectories of filesystem-based data stores such as
   "file", "s3", "memory". (#579)
+
+* `xcube serve` no longer rejects datasets whose spatial
+  resolutions in x any differ less than 1%. (#590)
+  It also no longer rejects datasets with large dimension 
+  sizes. (Formerly, an integer-overflow occurred in size 
+  computation.) 
+
+* `DatasetChunkCacheSize` is now optional in `xcube serve`
+  configuration. (Formerly, when omitted, the server crashed.)
   
 * Fixed bug that would cause that requesting data ids on some s3 stores would
   fail with a confusing ValueError.

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -773,7 +773,10 @@ class GridMapping(abc.ABC):
 
     @property
     def tile_grid(self) -> TileGrid:
-        assert_true(math.isclose(self.x_res, self.y_res),
+        # we allow up to 1% dev
+        assert_true(math.isclose(self.x_res,
+                                 self.y_res,
+                                 rel_tol=0.01),
                     message='spatial resolutions must be'
                             ' same in both directions')
         return ImageTileGrid(image_size=self.size,

--- a/xcube/core/normalize.py
+++ b/xcube/core/normalize.py
@@ -214,7 +214,7 @@ def decode_cube(dataset: xr.Dataset,
                 and var.dims[0] == time_name \
                 and var.dims[-2] == y_dim_name \
                 and var.dims[-1] == x_dim_name \
-                and np.product(var.shape) > 0 \
+                and np.all(var.shape) \
                 and var.shape[-2] > 1 \
                 and var.shape[-1] > 1:
             cube_vars.add(var_name)

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -476,7 +476,9 @@ class ServiceContext:
             chunk_cache_capacity = self.get_dataset_chunk_cache_capacity(
                 dataset_config
             )
-            if (ds_id.endswith('.zarr') or ds_id.endswith('.levels')) \
+            if chunk_cache_capacity \
+                    and (ds_id.endswith('.zarr')
+                         or ds_id.endswith('.levels')) \
                     and 'cache_size' not in open_params:
                 open_params['cache_size'] = chunk_cache_capacity
             with self.measure_time(tag=f"opened dataset {ds_id!r}"

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -110,7 +110,7 @@ def get_datasets(ctx: ServiceContext,
                         )
                     filtered_dataset_dicts.append(dataset_dict)
                 except (DatasetIsNotACubeError, CubeIsNotDisplayable) as e:
-                    LOG.warn(f'skipping dataset {ds_id}: {e}')
+                    LOG.warning(f'skipping dataset {ds_id}: {e}')
             dataset_dicts = filtered_dataset_dicts
     if point:
         is_point_in_dataset_bbox = functools.partial(
@@ -143,15 +143,15 @@ def get_dataset(ctx: ServiceContext,
                                    f' {grid_mapping.crs.srs}')
     if not math.isclose(grid_mapping.x_res,
                         grid_mapping.y_res,
-                        abs_tol=0.01):
+                        rel_tol=0.01):  # we allow up to 1% dev
         raise CubeIsNotDisplayable(f'spatial resolutions are'
                                    f' different in x, y:'
                                    f' {grid_mapping.x_res}'
                                    f' and {grid_mapping.y_res}')
     try:
         # Make sure we have a valid tile grid
-        # noinspection PyStatementEffect
-        assert_instance(ml_ds.tile_grid, TileGrid)
+        tile_grid = ml_ds.tile_grid
+        assert_instance(tile_grid, TileGrid)
     except ValueError as e:
         raise CubeIsNotDisplayable(f'could not create tile grid: {e}')
 


### PR DESCRIPTION
In this PR:

* `xcube serve` no longer rejects datasets whose spatial resolutions in x any differ less than 1%. It also no longer rejects datasets with large dimension sizes. (Formerly, an integer-overflow occurred in size computation.) 

* `DatasetChunkCacheSize` is now optional in `xcube serve` configuration. (Formerly, when omitted, the server crashed.)
  
Closes  #590

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!