### PR TITLE
Fixing tests for accessing data from xcube server via python api

### DIFF
--- a/test/webapi/test_s3buckethandlers.py
+++ b/test/webapi/test_s3buckethandlers.py
@@ -31,13 +31,20 @@ class S3BucketHandlersTest(unittest.TestCase):
     def test_open_cube_from_xube_server_rel_path(self):
         ds = open_cube('s3bucket/local',
                        format_name='zarr',
+                       s3_kwargs={
+                           'anon': True
+                       },
                        s3_client_kwargs=dict(endpoint_url=SERVER_URL))
         self.assertCubeOk(ds)
 
     @unittest.skipUnless(XCUBE_SERVER_IS_RUNNING, SKIP_HELP)
     def test_open_cube_from_xube_server_abs_path(self):
         ds = open_cube('http://localhost:8080/s3bucket/local',
-                       format_name='zarr')
+                       format_name='zarr',
+                       s3_kwargs={
+                           'anon': True
+                       }
+                       )
         self.assertCubeOk(ds)
 
     def assertCubeOk(self, ds):


### PR DESCRIPTION
This PR only fixes the tests for test_s3buckethandlers.py when serving data the classical way: one dataset per identifyer, as in `examples/serve/demo/config.yml` . The data access does not work yet for cubes served via DataStores like in the config `examples/serve/demo/config-with-stores.yml`
Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [ ] ~~Changes documented in `CHANGES.md`~~
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!