### PR TITLE
extract CLI: ensure CSV times are timezone-naive

### DIFF
--- a/xcube/cli/extract.py
+++ b/xcube/cli/extract.py
@@ -60,6 +60,7 @@ def extract(cube,
     time_col_names = ["time"]
 
     points = pd.read_csv(points_path, parse_dates=time_col_names, infer_datetime_format=True)
+    points.time = points.time.dt.tz_localize(tz=None)
     with open_dataset(cube_path) as cube:
         values = get_cube_values_for_points(cube,
                                             points,


### PR DESCRIPTION
Fixes Issue #595.

pandas 1.4.0 produces timezone-aware datetime64s when reading our test CSVs, breaking a NumPy typecheck in xcube.core.extract.get_dataset_indexes. xcube.cli.extract now avoids this problem by explicitly converting the time variable to a timezone-naive datetime64 directly after reading the CSV.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ N/A
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ N/A
* ~[ ] New/modified features documented in `docs/source/*`~ N/A
* ~[ ] Changes documented in `CHANGES.md`~ N/A
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!