### PR TITLE
Toniof 598 gridmapping test fail

### DIFF
--- a/test/core/gridmapping/test_base.py
+++ b/test/core/gridmapping/test_base.py
@@ -264,6 +264,7 @@ class GridMappingTest(SourceDatasetMixin, unittest.TestCase):
     def test_transform(self):
         gm = TestGridMapping(**self.kwargs(xy_min=(20, 56),
                                            size=(400, 200),
+                                           tile_size=(400, 200),
                                            xy_res=(0.01, 0.01)))
         transformed_gm = gm.transform('EPSG:32633')
 


### PR DESCRIPTION
Solves #598 . 

The issue here is that since v0.21, when a dataarray is created from another dataarray (as happens here: https://github.com/dcs4cop/xcube/blob/ca1718a7483d9e60a9c7f4a835cd4dc1ad6a364f/xcube/core/gridmapping/transform.py#L101), the chunking of the input dataarray is used. I find this correct, so I changed the test to set the tilesize explicitly.