### PR TITLE
Replaced file system values obs and local with s3 and file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@
 * Pinned Python version to < 3.10 to avoid ImportErrors caused by a third-party
   library.
 
+* Values `obs` and `local` for the `FileSystem` parameter in xcube configuration
+  files have been replaced by `s3` and `file`, but are kept temporarily for
+  the sake of backwards compatibility.
+
 ## Changes in 0.9.2
 
 ### Fixes

--- a/examples/serve/demo/config-cyanoalert.yml
+++ b/examples/serve/demo/config-cyanoalert.yml
@@ -2,7 +2,7 @@ Datasets:
 
   - Identifier: s2p
     Title: "S2+"
-    FileSystem: local
+    FileSystem: file
     Path: "D:\\Projects\\xcube\\xcube\\cli\\PROJ_WGS84_DCS4COP_S2A_0021_FLANDERS_20180802T105621Z_31UCS_V003.zarr"
     Format: zarr
     # Path: "D:\\Projects\\xcube\\xcube\\cli\\PROJ_WGS84_DCS4COP_S2A_0021_FLANDERS_20180802T105621Z_31UCS_V003.levels"
@@ -11,7 +11,7 @@ Datasets:
 
   - Identifier: Sweden_SE
     Title: Sverige
-    FileSystem: local
+    FileSystem: file
     Path: "C:\\Users\\Norman\\Brockmann Consult GmbH\\CyanoAlert Project Site - Data\\OLCI-SE-L2C-CUBE-v2-20180708_1_500_509.zarr"
     Format: zarr
     Style: default

--- a/examples/serve/demo/config-dcs4cop.yml
+++ b/examples/serve/demo/config-dcs4cop.yml
@@ -1,7 +1,7 @@
 Datasets:
   - Identifier: s2p
     Title: "Sentinel 2 Plus SNS"
-    FileSystem: "local"
+    FileSystem: "file"
     Path: "D:\\EOData\\DCS4COP\\S2Plus-GUC.zarr"
     Format: zarr
     Style: default
@@ -11,7 +11,7 @@ Datasets:
     BoundingBox: [0.0, 50, 5.0, 52.5]
     Endpoint: "https://s3.eu-central-1.amazonaws.com/"
     Path: "xcube-examples/bc-olci-sns-l2c-2017_1x1024x1024.zarr"
-    FileSystem: "obs"
+    FileSystem: "s3"
     Region: "eu-central-1"
     Anonymous: true
     Style: default

--- a/examples/serve/demo/config-with-stores.yml
+++ b/examples/serve/demo/config-with-stores.yml
@@ -6,7 +6,7 @@ DatasetChunkCacheSize: 100M
 
 DataStores:
 
-#  - Identifier: local
+#  - Identifier: file
 #    StoreId: file
 #    StoreParams:
 #      root: .

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -13,7 +13,7 @@ Datasets:
   - Identifier: local
     Title: "Local OLCI L2C cube for region SNS"
     BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: local
+    FileSystem: file
     Path: cube-1-250-250.zarr
     Style: default
     TimeSeriesDataset: local_ts
@@ -37,7 +37,7 @@ Datasets:
 #  - Identifier: local_levels
 #    Title: "Local OLCI L2C cube for region SNS (levels)"
 #    BoundingBox: [0.0, 50, 5.0, 52.5]
-#    FileSystem: local
+#    FileSystem: file
 #    Path: cube-1-250-250.levels
 #    Style: default
 
@@ -45,7 +45,7 @@ Datasets:
   - Identifier: local_ts
     Title: "'local' optimized for time-series"
     BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: local
+    FileSystem: file
     Path: cube-5-100-200.zarr
     Hidden: true
     Style: default
@@ -54,7 +54,7 @@ Datasets:
   - Identifier: remote
     Title: Remote OLCI L2C cube for region SNS
     BoundingBox: [0.0, 50, 5.0, 52.5]
-    FileSystem: obs
+    FileSystem: s3
     Endpoint: "https://s3.eu-central-1.amazonaws.com"
     Path: "xcube-examples/OLCI-SNS-RAW-CUBE-2.zarr"
     Region: "eu-central-1"

--- a/test/webapi/controllers/test_timeseries.py
+++ b/test/webapi/controllers/test_timeseries.py
@@ -294,7 +294,7 @@ class TsPerfTest(unittest.TestCase):
             config=dict(
                 Datasets=[
                     dict(Identifier='ts_test',
-                         FileSystem='local',
+                         FileSystem='file',
                          Path=TEST_CUBE,
                          Format='zarr')
                 ]

--- a/test/webapi/test_config.py
+++ b/test/webapi/test_config.py
@@ -30,7 +30,7 @@ class ServiceConfigTest(unittest.TestCase):
                     "Identifier": "local",
                     "Title": "Local OLCI L2C cube for region SNS",
                     "BoundingBox": [0.0, 50, 5.0, 52.5],
-                    "FileSystem": "local",
+                    "FileSystem": "file",
                     "Path": "cube-1-250-250.zarr",
                     "Style": "default",
                     "TimeSeriesDataset": "local_ts",

--- a/test/webapi/test_service.py
+++ b/test/webapi/test_service.py
@@ -13,14 +13,14 @@ class DefaultConfigTest(unittest.TestCase):
         self.assertEqual({
             'Datasets': [
                 {
-                    'FileSystem': 'local',
+                    'FileSystem': 'file',
                     'Format': 'zarr',
                     'Identifier': 'dataset_1',
                     'Path': '/home/bibo/data/cube-1.zarr',
                     'Title': 'cube-1.zarr'
                 },
                 {
-                    'FileSystem': 'local',
+                    'FileSystem': 'file',
                     'Format': 'netcdf4',
                     'Identifier': 'dataset_2',
                     'Path': '/home/bibo/data/cube-2.nc',

--- a/xcube/webapi/config.py
+++ b/xcube/webapi/config.py
@@ -20,7 +20,9 @@ BoundingBoxSchema = JsonArraySchema(items=[
     NumberSchema,
     NumberSchema
 ])
-FileSystemSchema = JsonStringSchema(enum=['memory', 'obs', 'local'])
+FileSystemSchema = JsonStringSchema(
+    enum=['memory', 'obs', 'local', 's3', 'file']
+)
 
 
 class _ConfigObject(JsonObject, ABC):

--- a/xcube/webapi/handlers.py
+++ b/xcube/webapi/handlers.py
@@ -268,12 +268,14 @@ class GetS3BucketObjectHandler(ServiceRequestHandler):
 
     def _get_key_and_local_path(self, ds_id: str, path: str):
         dataset_config = self.service_context.get_dataset_config(ds_id)
-        file_system = dataset_config.get('FileSystem', 'local')
-        required_file_system = 'local'
-        if file_system != required_file_system:
-            raise ServiceBadRequestError(f'AWS S3 data access: currently, only datasets in'
-                                         f' file system {required_file_system!r} are supported,'
-                                         f' but dataset {ds_id!r} uses file system {file_system!r}')
+        file_system = dataset_config.get('FileSystem', 'file')
+        required_file_systems = ['file', 'local']
+        if file_system not in required_file_systems:
+            required_file_system_string = " or ".join(required_file_systems)
+            raise ServiceBadRequestError(
+                f'AWS S3 data access: currently, only datasets in file systems '
+                f'{required_file_system_string!r} are supported, but dataset '
+                f'{ds_id!r} uses file system {file_system!r}')
 
         key = f'{ds_id}/{path}'
 

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -442,13 +442,13 @@ def new_default_config(cube_paths: List[str],
                               Path=cube_path)
         if is_s3_url(cube_path):
             dataset_config.update(Title=cube_path.split('/')[-1],
-                                  FileSystem='obs')
+                                  FileSystem='s3')
             if aws_access_key_id and aws_secret_access_key:
                 dataset_config.update(AccessKeyId=aws_access_key_id,
                                       SecretAccessKey=aws_secret_access_key)
         else:
             dataset_config.update(Title=os.path.split(cube_path)[-1],
-                                  FileSystem='local')
+                                  FileSystem='file')
         dataset_configs.append(dataset_config)
         index += 1
 


### PR DESCRIPTION
The file system identifiers 'obs' and 'local' have been replaced with the names of their respective protocols, 's3' and 'file'. The old values are still supported for backwards compatibility.