### PR TITLE
Tile server: ensure timezone-naive time selector

### DIFF
--- a/test/core/test_tile.py
+++ b/test/core/test_tile.py
@@ -105,6 +105,17 @@ class ParseNonSpatialLabelsTest(unittest.TestCase):
         self.assertEqual("'jetzt' is not a valid value for dimension 'time'",
                          f'{cm.exception}')
 
+    def test_ensure_timezone_naive(self):
+        da_tznaive = xr.DataArray(
+            np.zeros((3,3,3)),
+            coords=self.coords,
+            dims=self.dims)
+        labels = parse_non_spatial_labels(dict(time='2000-01-02T00:00:00Z'),
+                                          dims=da_tznaive.dims,
+                                          coords=da_tznaive.coords,
+                                          var=da_tznaive)
+        self.assertIsNone(pd.Timestamp(labels['time']).tzinfo)
+
 
 class EnsureTimeCompatibleTest(unittest.TestCase):
     da_tznaive = xr.DataArray(
@@ -131,11 +142,11 @@ class EnsureTimeCompatibleTest(unittest.TestCase):
 
     def test_tznaive_array_tzaware_indexer(self):
         self.assertTrue(
-            self._are_times_equal(
+            _are_times_equal(
                 self.labels_tznaive,
                 _ensure_time_compatible(self.da_tznaive,
                                         self.labels_tzaware)))
 
-    @staticmethod
-    def _are_times_equal(labels1, labels2):
-        return pd.Timestamp(labels1['time']) == pd.Timestamp(labels2['time'])
+
+def _are_times_equal(labels1, labels2):
+    return pd.Timestamp(labels1['time']) == pd.Timestamp(labels2['time'])

--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -242,8 +242,7 @@ def _get_var_2d_array(var: xr.DataArray,
         if labels_are_indices:
             array = var.isel(**labels)
         else:
-            labels_safe_time = _ensure_time_compatible(var, labels)
-            array = var.sel(method='nearest', **labels_safe_time)
+            array = var.sel(method='nearest', **labels)
     else:
         raise exception_type(f'Variable "{var.name}" of dataset "{ds_id}" '
                              'must be an N-D Dataset with N >= 2, '
@@ -328,7 +327,8 @@ def parse_non_spatial_labels(
         dims: Sequence[Hashable],
         coords: Mapping[Hashable, xr.DataArray],
         allow_slices: bool = False,
-        exception_type: type = ValueError
+        exception_type: type = ValueError,
+        var: xr.DataArray = None
 ) -> Mapping[str, Any]:
     xy_var_names = get_dataset_xy_var_names(coords, must_exist=False)
     if xy_var_names is None:
@@ -384,4 +384,7 @@ def parse_non_spatial_labels(
             raise exception_type(f'{label_str!r} is not a valid'
                                  f' value for dimension {dim!r}') from e
 
-    return parsed_labels
+    if var is not None:
+        return _ensure_time_compatible(var, parsed_labels)
+    else:
+        return parsed_labels

--- a/xcube/core/tile.py
+++ b/xcube/core/tile.py
@@ -258,16 +258,20 @@ def _ensure_time_compatible(var: xr.DataArray,
     key with a timezone-aware value, return a modified labels dictionary with
     a timezone-naive time value. Otherwise return the original labels.
     """
-    if 'time' in var.dims and \
-        hasattr(var['time'], 'dtype') and \
-        hasattr(var['time'].dtype, 'type') and \
-        var['time'].dtype.type is np.datetime64 and \
-        'time' in labels and \
-        pd.Timestamp(labels['time']).tzinfo is not None:
+    if _has_datetime64_time(var) and \
+       'time' in labels and pd.Timestamp(labels['time']).tzinfo is not None:
         naive_time = pd.Timestamp(labels['time']).tz_convert(None)
         return dict(labels, time=naive_time)
     else:
         return labels
+
+
+def _has_datetime64_time(var: xr.DataArray) -> bool:
+    """Report whether var has a time dimension with type datetime64"""
+    return 'time' in var.dims and \
+           hasattr(var['time'], 'dtype') and \
+           hasattr(var['time'].dtype, 'type') and \
+           var['time'].dtype.type is np.datetime64
 
 
 def get_var_cmap_params(var: xr.DataArray,

--- a/xcube/webapi/controllers/tiles.py
+++ b/xcube/webapi/controllers/tiles.py
@@ -79,7 +79,8 @@ def get_dataset_tile(ctx: ServiceContext,
                                       var.dims,
                                       var.coords,
                                       allow_slices=False,
-                                      exception_type=ServiceBadRequestError)
+                                      exception_type=ServiceBadRequestError,
+                                      var=var)
 
     return get_ml_dataset_tile(ml_dataset,
                                var_name,


### PR DESCRIPTION
Fixes #555.

In tile._get_var_2d_array (used by new_color_mapped_image),
check for the possibility that the array uses datetime64 and the
indexer is timezone-aware. In this case, convert to a timezone-naive
indexer before performing the selection.

[Description of PR]

Checklist:

* ~~[ ] Add unit tests and/or doctests in docstrings~~ (not needed)
* ~~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~~ N/A
* ~~[ ] New/modified features documented in `docs/source/*`~~ N/A
* ~~[ ] Changes documented in `CHANGES.md`~~ N/A
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!