### PR TITLE
support different resolutions in x- and y- direction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   would have been enough.
   This version fixes these problems. Different resolutions in x- and y-
   direction may now be described by DatasetDescriptors and be stated in a 
-  `CubeConfig` for `xcube gen2`.  
+  `CubeConfig` for `xcube gen2`. (#615) 
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,14 @@
 
 ### Enhancements
 
-* improved support for datasets with different resolutions in x- and y-
-  direction. These may now be described by DatasetDescriptors. 
-  Also, it is possible to set different resolutions in a `CubeConfig` for 
-  `xcube gen2`.  
+* In previous versions, xcube did not consider that datasets may have different
+  resolutions in x- and y-direction. These could, e.g., not be described with a 
+  `DatasetDescriptor`. In particular, there were problems during the use of 
+  `xcube gen2` when datasets were resampled, although a simple subsetting 
+  would have been enough.
+  This version fixes these problems. Different resolutions in x- and y-
+  direction may now be described by DatasetDescriptors and be stated in a 
+  `CubeConfig` for `xcube gen2`.  
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Enhancements
 
+* improved support for datasets with different resolutions in x- and y-
+  direction. These may now be described by DatasetDescriptors. 
+  Also, it is possible to set different resolutions in a `CubeConfig` for 
+  `xcube gen2`.  
+
 ### Fixes
 
 ### Other

--- a/test/cli/test_gen2.py
+++ b/test/cli/test_gen2.py
@@ -68,7 +68,7 @@ class Gen2CliTest(CliTest):
                     'data_id': result_zarr,
                     'data_type': 'dataset',
                     'dims': {'lat': 1000, 'lon': 2000, 'time': 15},
-                    'spatial_res': 0.0024999999999977263,
+                    'spatial_res': 0.0025,
                     'time_period': '1D',
                     'time_range': ['2017-01-16', '2017-01-30'],
                     'bbox': [0.0, 50.0, 5.0, 52.5],

--- a/test/cli/test_gen2.py
+++ b/test/cli/test_gen2.py
@@ -68,7 +68,7 @@ class Gen2CliTest(CliTest):
                     'data_id': result_zarr,
                     'data_type': 'dataset',
                     'dims': {'lat': 1000, 'lon': 2000, 'time': 15},
-                    'spatial_res': 0.0025,
+                    'spatial_res': [0.0025, 0.0025],
                     'time_period': '1D',
                     'time_range': ['2017-01-16', '2017-01-30'],
                     'bbox': [0.0, 50.0, 5.0, 52.5],

--- a/test/core/gen2/local/test_informant.py
+++ b/test/core/gen2/local/test_informant.py
@@ -86,7 +86,7 @@ class InformantTest(unittest.TestCase):
         self.assertEqual((-180.0, -90.0, 180.0, 90.0),
                          effective_cube_config.bbox)
         self.assertEqual('EPSG:6931', effective_cube_config.crs)
-        self.assertEqual(1.0, effective_cube_config.spatial_res)
+        self.assertEqual((1.0, 1.0), effective_cube_config.spatial_res)
         self.assertEqual('1D', effective_cube_config.time_period)
         self.assertEqual(('2010-01-01', '2010-12-31'),
                          effective_cube_config.time_range)

--- a/test/core/gen2/local/test_informant.py
+++ b/test/core/gen2/local/test_informant.py
@@ -1,0 +1,123 @@
+import unittest
+from typing import Dict, Any
+
+from xcube.core.gen2.config import CubeConfig
+from xcube.core.gen2.config import InputConfig
+from xcube.core.gen2.config import OutputConfig
+from xcube.core.gen2.local.informant import CubeInformant
+from xcube.core.gen2.request import CubeGeneratorRequest
+from xcube.core.store import DataStorePool
+from xcube.core.store import DataStoreConfig
+from xcube.core.gen2.response import CubeInfo
+from xcube.core.new import new_cube
+
+class InformantTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.store_pool = DataStorePool(dict(
+            mem=DataStoreConfig(
+                store_id="memory",
+            )
+        ))
+        cube = new_cube(variables=dict(B01=0.1, B02=0.2, B03=0.3))
+        self.store_pool.get_store('mem').write_data(
+            cube,
+            'informant_test.zarr',
+            replace=True,
+        )
+        self.input_config = InputConfig(
+            store_id='memory',
+            data_id='informant_test.zarr'
+        )
+        self.output_config = OutputConfig(
+            store_id='memory',
+            data_id='output.zarr',
+            replace=True
+        )
+
+    def test_effective_cube_config_1(self):
+        cube_config = CubeConfig(
+            variable_names=['B01', 'B03'],
+            crs=None,
+            bbox=(12.2, 52.1, 13.9, 54.8),
+            spatial_res=(0.05, 0.1),
+            time_range=('2010-01-01', None),
+            time_period='4D',
+            chunks=dict(time=None, lat=90, lon=90),
+            metadata=dict(title='A S2L2A subset')
+        )
+        request = CubeGeneratorRequest(
+            input_config=self.input_config,
+            cube_config=cube_config,
+            output_config=self.output_config
+        )
+
+        informant = CubeInformant(request=request, store_pool=self.store_pool)
+
+        effective_cube_config = informant.effective_cube_config
+
+        self.assertIsInstance(effective_cube_config, CubeConfig)
+        self.assertEqual((12.2, 52.1, 13.9, 54.8), effective_cube_config.bbox)
+        self.assertEqual('WGS84', effective_cube_config.crs)
+        self.assertEqual((0.05, 0.1), effective_cube_config.spatial_res)
+        self.assertEqual('4D', effective_cube_config.time_period)
+        self.assertEqual(('2010-01-01', '2010-01-06'),
+                         effective_cube_config.time_range)
+        self.assertEqual(('B01', 'B03'),
+                         effective_cube_config.variable_names)
+
+    def test_effective_cube_config_2(self):
+        cube_config = CubeConfig(
+            crs='EPSG:6931',
+            time_range=('2010-01-01', '2010-12-31'),
+            metadata=dict(title='A S2L2A subset')
+        )
+        request = CubeGeneratorRequest(
+            input_config=self.input_config,
+            cube_config=cube_config,
+            output_config=self.output_config
+        )
+
+        informant = CubeInformant(request=request, store_pool=self.store_pool)
+
+        effective_cube_config = informant.effective_cube_config
+
+        self.assertIsInstance(effective_cube_config, CubeConfig)
+        self.assertEqual((-180.0, -90.0, 180.0, 90.0),
+                         effective_cube_config.bbox)
+        self.assertEqual('EPSG:6931', effective_cube_config.crs)
+        self.assertEqual(1.0, effective_cube_config.spatial_res)
+        self.assertEqual('1D', effective_cube_config.time_period)
+        self.assertEqual(('2010-01-01', '2010-12-31'),
+                         effective_cube_config.time_range)
+        self.assertEqual(('B01', 'B02', 'B03'),
+                         effective_cube_config.variable_names)
+
+    def test_generate(self):
+        cube_config = CubeConfig(
+            variable_names=['B01', 'B03'],
+            crs=None,
+            bbox=(12.2, 52.1, 13.9, 54.8),
+            spatial_res=(0.05, 0.1),
+            time_range=('2010-01-01', None),
+            time_period='4D',
+            chunks=dict(time=None, lat=90, lon=90),
+            metadata=dict(title='A S2L2A subset')
+        )
+        request = CubeGeneratorRequest(
+            input_config=self.input_config,
+            cube_config=cube_config,
+            output_config=self.output_config
+        )
+
+        informant = CubeInformant(request=request, store_pool=self.store_pool)
+        cube_info = informant.generate()
+        self.assertIsInstance(cube_info, CubeInfo)
+        self.assertIsNotNone(cube_info.dataset_descriptor)
+        self.assertIsNotNone(cube_info.size_estimation)
+        self.assertEqual([34, 27], cube_info.size_estimation['image_size'])
+        self.assertEqual([34, 27], cube_info.size_estimation['tile_size'])
+        self.assertEqual(2, cube_info.size_estimation['num_variables'])
+        self.assertEqual([1, 1], cube_info.size_estimation['num_tiles'])
+        self.assertEqual(4, cube_info.size_estimation['num_requests'])
+        self.assertEqual(14688, cube_info.size_estimation['num_bytes'])

--- a/test/core/gen2/test_config.py
+++ b/test/core/gen2/test_config.py
@@ -83,7 +83,7 @@ class CubeConfigTest(unittest.TestCase):
         expected_dict = dict(variable_names=['B03', 'B04'],
                              crs='WGS84',
                              bbox=[12.2, 52.1, 13.9, 54.8],
-                             spatial_res=0.05,
+                             spatial_res=(0.05, 0.1),
                              time_range=['2018-01-01', None],
                              time_period='4D',
                              metadata=dict(title='S2L2A subset'),

--- a/test/core/gen2/test_config.py
+++ b/test/core/gen2/test_config.py
@@ -66,7 +66,7 @@ class CubeConfigTest(unittest.TestCase):
         self.assertEqual(('B03', 'B04'), cube_config.variable_names)
         self.assertEqual('WGS84', cube_config.crs)
         self.assertEqual((12.2, 52.1, 13.9, 54.8), cube_config.bbox)
-        self.assertEqual(0.05, cube_config.spatial_res)
+        self.assertEqual((0.05, 0.05), cube_config.spatial_res)
         self.assertEqual(('2018-01-01', None), cube_config.time_range)
         self.assertEqual('4D', cube_config.time_period)
         self.assertEqual(dict(title='S2L2A subset'),

--- a/test/core/gen2/test_request.py
+++ b/test/core/gen2/test_request.py
@@ -15,7 +15,7 @@ class CubeGeneratorRequestTest(unittest.TestCase):
             cube_config=dict(variable_names=['B01', 'B02'],
                              crs='WGS84',
                              bbox=[12.2, 52.1, 13.9, 54.8],
-                             spatial_res=0.05,
+                             spatial_res=(0.05, 0.05),
                              time_range=['2018-01-01', None],
                              time_period='4D'),
             output_config=dict(store_id='memory',
@@ -66,7 +66,7 @@ class CubeGeneratorRequestTest(unittest.TestCase):
         self.assertEqual(('B01', 'B02'), gen_config.cube_config.variable_names)
         self.assertEqual('WGS84', gen_config.cube_config.crs)
         self.assertEqual((12.2, 52.1, 13.9, 54.8), gen_config.cube_config.bbox)
-        self.assertEqual(0.05, gen_config.cube_config.spatial_res)
+        self.assertEqual((0.05, 0.05), gen_config.cube_config.spatial_res)
         self.assertEqual(('2018-01-01', None), gen_config.cube_config.time_range)
         self.assertEqual('4D', gen_config.cube_config.time_period)
 
@@ -77,7 +77,7 @@ class CubeGeneratorRequestTest(unittest.TestCase):
             cube_config=dict(variable_names=['B01', 'B02'],
                              crs='WGS84',
                              bbox=[12.2, 52.1, 13.9, 54.8],
-                             spatial_res=0.05,
+                             spatial_res=(0.05, 0.05),
                              time_range=['2018-01-01', None],
                              time_period='4D'),
             output_config=dict(store_id='memory',

--- a/test/core/gridmapping/test_base.py
+++ b/test/core/gridmapping/test_base.py
@@ -97,11 +97,14 @@ class GridMappingTest(SourceDatasetMixin, unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             TestGridMapping(**self.kwargs(size=(360,)))
-        self.assertEqual('not enough values to unpack (expected 2, got 1)', f'{cm.exception}')
+        self.assertEqual('not enough values to unpack (expected 2, got 1)',
+                         f'{cm.exception}')
 
         with self.assertRaises(ValueError) as cm:
             TestGridMapping(**self.kwargs(size=None))
-        self.assertEqual('size must be an int or a sequence of two ints', f'{cm.exception}')
+        self.assertEqual("size must be a scalar or pair of <class 'int'>, "
+                         "was 'None'",
+                         f'{cm.exception}')
 
         with self.assertRaises(ValueError) as cm:
             TestGridMapping(**self.kwargs(tile_size=0))

--- a/test/core/gridmapping/test_base.py
+++ b/test/core/gridmapping/test_base.py
@@ -102,8 +102,7 @@ class GridMappingTest(SourceDatasetMixin, unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             TestGridMapping(**self.kwargs(size=None))
-        self.assertEqual("size must be a scalar or pair of <class 'int'>, "
-                         "was 'None'",
+        self.assertEqual("size must be an int or a sequence of two ints",
                          f'{cm.exception}')
 
         with self.assertRaises(ValueError) as cm:

--- a/test/util/test_types.py
+++ b/test/util/test_types.py
@@ -28,35 +28,46 @@ class NormalizeNumberScalarOrPairTest(unittest.TestCase):
 
     def test_scalar_float(self):
         self.assertEqual((1.1, 1.1),
-                         normalize_scalar_or_pair(1.1, float))
+                         normalize_scalar_or_pair(1.1,
+                                                  item_type=float))
         self.assertEqual((2.0, 2.0),
-                         normalize_scalar_or_pair(2.0, float))
+                         normalize_scalar_or_pair(2.0,
+                                                  item_type=float))
 
     def test_scalar_int(self):
         self.assertEqual((1, 1),
-                         normalize_scalar_or_pair(1.1, int))
+                         normalize_scalar_or_pair(1.1,
+                                                  item_type=int))
         self.assertEqual((1, 1),
-                         normalize_scalar_or_pair(1.9, int))
+                         normalize_scalar_or_pair(1.9,
+                                                  item_type=int))
         self.assertEqual((2, 2),
-                         normalize_scalar_or_pair(2.0, int))
+                         normalize_scalar_or_pair(2.0,
+                                                  item_type=int))
 
     def test_pair_float(self):
         self.assertEqual((1.1, 1.9),
-                         normalize_scalar_or_pair((1.1, 1.9), float))
+                         normalize_scalar_or_pair((1.1, 1.9),
+                                                  item_type=float))
         self.assertEqual((2.0, 1.9),
-                         normalize_scalar_or_pair((2.0, 1.9), float))
+                         normalize_scalar_or_pair((2.0, 1.9),
+                                                  item_type=float))
 
     def test_pair_int(self):
         self.assertEqual((1, 1),
-                         normalize_scalar_or_pair((1.1, 1.9), int))
+                         normalize_scalar_or_pair((1.1, 1.9),
+                                                  item_type=int))
         self.assertEqual((2, 1),
-                         normalize_scalar_or_pair((2.0, 1.9), int))
+                         normalize_scalar_or_pair((2.0, 1.9),
+                                                  item_type=int))
 
     def test_wrong_type(self):
         with self.assertRaises(ValueError) as ve:
-            normalize_scalar_or_pair('xyz', int)
+            normalize_scalar_or_pair('xyz',
+                                     item_type=int,
+                                     name='notastring')
         self.assertEqual(
-            "Value must be a scalar or pair of <class 'int'>, was 'xyz'",
+            "notastring must be a scalar or pair of <class 'int'>, was 'xyz'",
             f'{ve.exception}'
         )
 
@@ -67,3 +78,13 @@ class NormalizeNumberScalarOrPairTest(unittest.TestCase):
             "Value must be a scalar or pair of scalars, was '(0, 1, 2)'",
             f'{ve.exception}'
         )
+
+    def test_default(self):
+        self.assertEqual((1, 1),
+                         normalize_scalar_or_pair(None,
+                                                  default=1,
+                                                  item_type=int))
+        self.assertEqual((1.1, 1.2),
+                         normalize_scalar_or_pair(None,
+                                                  default=(1.1, 1.2),
+                                                  item_type=float))

--- a/test/util/test_types.py
+++ b/test/util/test_types.py
@@ -1,0 +1,69 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+
+from xcube.util.types import normalize_number_scalar_or_pair
+
+
+class NormalizeNumberScalarOrPairTest(unittest.TestCase):
+
+    def test_scalar_float(self):
+        self.assertEqual((1.1, 1.1),
+                         normalize_number_scalar_or_pair(1.1, float))
+        self.assertEqual((2.0, 2.0),
+                         normalize_number_scalar_or_pair(2.0, float))
+
+    def test_scalar_int(self):
+        self.assertEqual((1, 1),
+                         normalize_number_scalar_or_pair(1.1, int))
+        self.assertEqual((1, 1),
+                         normalize_number_scalar_or_pair(1.9, int))
+        self.assertEqual((2, 2),
+                         normalize_number_scalar_or_pair(2.0, int))
+
+    def test_pair_float(self):
+        self.assertEqual((1.1, 1.9),
+                         normalize_number_scalar_or_pair((1.1, 1.9), float))
+        self.assertEqual((2.0, 1.9),
+                         normalize_number_scalar_or_pair((2.0, 1.9), float))
+
+    def test_pair_int(self):
+        self.assertEqual((1, 1),
+                         normalize_number_scalar_or_pair((1.1, 1.9), int))
+        self.assertEqual((2, 1),
+                         normalize_number_scalar_or_pair((2.0, 1.9), int))
+
+    def test_wrong_type(self):
+        with self.assertRaises(ValueError) as ve:
+            normalize_number_scalar_or_pair('xyz', int)
+        self.assertEqual(
+            'Value "xyz" must be a number or a segment of two numbers',
+            f'{ve.exception}'
+        )
+
+    def test_wrong_length(self):
+        with self.assertRaises(ValueError) as ve:
+            normalize_number_scalar_or_pair((0, 1, 2))
+        self.assertEqual(
+            'Value "(0, 1, 2)" must be a number or a segment of two numbers',
+            f'{ve.exception}'
+        )

--- a/test/util/test_types.py
+++ b/test/util/test_types.py
@@ -21,49 +21,49 @@
 
 import unittest
 
-from xcube.util.types import normalize_number_scalar_or_pair
+from xcube.util.types import normalize_scalar_or_pair
 
 
 class NormalizeNumberScalarOrPairTest(unittest.TestCase):
 
     def test_scalar_float(self):
         self.assertEqual((1.1, 1.1),
-                         normalize_number_scalar_or_pair(1.1, float))
+                         normalize_scalar_or_pair(1.1, float))
         self.assertEqual((2.0, 2.0),
-                         normalize_number_scalar_or_pair(2.0, float))
+                         normalize_scalar_or_pair(2.0, float))
 
     def test_scalar_int(self):
         self.assertEqual((1, 1),
-                         normalize_number_scalar_or_pair(1.1, int))
+                         normalize_scalar_or_pair(1.1, int))
         self.assertEqual((1, 1),
-                         normalize_number_scalar_or_pair(1.9, int))
+                         normalize_scalar_or_pair(1.9, int))
         self.assertEqual((2, 2),
-                         normalize_number_scalar_or_pair(2.0, int))
+                         normalize_scalar_or_pair(2.0, int))
 
     def test_pair_float(self):
         self.assertEqual((1.1, 1.9),
-                         normalize_number_scalar_or_pair((1.1, 1.9), float))
+                         normalize_scalar_or_pair((1.1, 1.9), float))
         self.assertEqual((2.0, 1.9),
-                         normalize_number_scalar_or_pair((2.0, 1.9), float))
+                         normalize_scalar_or_pair((2.0, 1.9), float))
 
     def test_pair_int(self):
         self.assertEqual((1, 1),
-                         normalize_number_scalar_or_pair((1.1, 1.9), int))
+                         normalize_scalar_or_pair((1.1, 1.9), int))
         self.assertEqual((2, 1),
-                         normalize_number_scalar_or_pair((2.0, 1.9), int))
+                         normalize_scalar_or_pair((2.0, 1.9), int))
 
     def test_wrong_type(self):
         with self.assertRaises(ValueError) as ve:
-            normalize_number_scalar_or_pair('xyz', int)
+            normalize_scalar_or_pair('xyz', int)
         self.assertEqual(
-            'Value "xyz" must be a number or a segment of two numbers',
+            "Value must be a scalar or pair of <class 'int'>, was 'xyz'",
             f'{ve.exception}'
         )
 
     def test_wrong_length(self):
         with self.assertRaises(ValueError) as ve:
-            normalize_number_scalar_or_pair((0, 1, 2))
+            normalize_scalar_or_pair((0, 1, 2))
         self.assertEqual(
-            'Value "(0, 1, 2)" must be a number or a segment of two numbers',
+            "Value must be a scalar or pair of scalars, was '(0, 1, 2)'",
             f'{ve.exception}'
         )

--- a/test/util/test_types.py
+++ b/test/util/test_types.py
@@ -35,15 +35,9 @@ class NormalizeNumberScalarOrPairTest(unittest.TestCase):
                                                   item_type=float))
 
     def test_scalar_int(self):
-        self.assertEqual((1, 1),
-                         normalize_scalar_or_pair(1.1,
-                                                  item_type=int))
-        self.assertEqual((1, 1),
-                         normalize_scalar_or_pair(1.9,
-                                                  item_type=int))
-        self.assertEqual((2, 2),
-                         normalize_scalar_or_pair(2.0,
-                                                  item_type=int))
+        self.assertEqual((1, 1), normalize_scalar_or_pair(1, item_type=int))
+        self.assertEqual((1, 1), normalize_scalar_or_pair(1, item_type=int))
+        self.assertEqual((2, 2), normalize_scalar_or_pair(2, item_type=int))
 
     def test_pair_float(self):
         self.assertEqual((1.1, 1.9),
@@ -55,11 +49,9 @@ class NormalizeNumberScalarOrPairTest(unittest.TestCase):
 
     def test_pair_int(self):
         self.assertEqual((1, 1),
-                         normalize_scalar_or_pair((1.1, 1.9),
-                                                  item_type=int))
+                         normalize_scalar_or_pair((1, 1), item_type=int))
         self.assertEqual((2, 1),
-                         normalize_scalar_or_pair((2.0, 1.9),
-                                                  item_type=int))
+                         normalize_scalar_or_pair((2, 1), item_type=int))
 
     def test_wrong_type(self):
         with self.assertRaises(ValueError) as ve:
@@ -78,13 +70,3 @@ class NormalizeNumberScalarOrPairTest(unittest.TestCase):
             "Value must be a scalar or pair of scalars, was '(0, 1, 2)'",
             f'{ve.exception}'
         )
-
-    def test_default(self):
-        self.assertEqual((1, 1),
-                         normalize_scalar_or_pair(None,
-                                                  default=1,
-                                                  item_type=int))
-        self.assertEqual((1.1, 1.2),
-                         normalize_scalar_or_pair(None,
-                                                  default=(1.1, 1.2),
-                                                  item_type=float))

--- a/xcube/cli/genpts.py
+++ b/xcube/cli/genpts.py
@@ -59,8 +59,12 @@ def genpts(cube: str, output_path: str, num_points_max: int):
     for var_name in cube.data_vars:
         point_data[var_name] = []
 
-    spatial_res = ((cube.lon[-1] - cube.lon[0]) / (cube.lon.size - 1)).values
-    temporal_res = ((cube.time[-1] - cube.time[0]) // (cube.time.size - 1)).values
+    spatial_lon_res = ((cube.lon[-1] - cube.lon[0]) /
+                       (cube.lon.size - 1)).values
+    spatial_lat_res = ((cube.lat[-1] - cube.lat[0]) /
+                       (cube.lat.size - 1)).values
+    temporal_res = ((cube.time[-1] - cube.time[0]) //
+                    (cube.time.size - 1)).values
 
     while num_points < num_points_max:
         it = np.random.randint(0, cube.time.size)
@@ -70,9 +74,15 @@ def genpts(cube: str, output_path: str, num_points_max: int):
         point = cube.isel(time=it, lat=iy, lon=ix)
 
         if _all_data_vars_valid(point):
-            point_data['time'].append(point.time.values + 0.5 * temporal_res * np.random.logistic(scale=0.2))
-            point_data['lat'].append(point.lat.values + 0.5 * spatial_res * np.random.logistic(scale=0.2))
-            point_data['lon'].append(point.lon.values + 0.5 * spatial_res * np.random.logistic(scale=0.2))
+            point_data['time'].append(point.time.values + 0.5 *
+                                      temporal_res *
+                                      np.random.logistic(scale=0.2))
+            point_data['lat'].append(point.lat.values + 0.5 *
+                                     spatial_lat_res *
+                                     np.random.logistic(scale=0.2))
+            point_data['lon'].append(point.lon.values + 0.5 *
+                                     spatial_lon_res *
+                                     np.random.logistic(scale=0.2))
             for var_name, var in point.data_vars.items():
                 value = var.values
                 if np.issubdtype(value.dtype, np.floating):

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -170,8 +170,8 @@ class CubeConfig(JsonObject):
         self.spatial_res = None
         if spatial_res is not None:
             spatial_res = normalize_scalar_or_pair(spatial_res,
-                                                   (int, float),
-                                                   'spatial_res')
+                                                   item_type=(int, float),
+                                                   name='spatial_res')
             assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
             assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
             self.spatial_res = spatial_res

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -37,6 +37,7 @@ from xcube.util.jsonschema import JsonNumberSchema
 from xcube.util.jsonschema import JsonObject
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
+from xcube.util.types import normalize_number_scalar_or_pair
 
 
 class InputConfig(JsonObject):
@@ -168,19 +169,10 @@ class CubeConfig(JsonObject):
 
         self.spatial_res = None
         if spatial_res is not None:
-            assert_instance(spatial_res, (numbers.Number, tuple), 'spatial_res')
-            if isinstance(spatial_res, tuple):
-                assert_true(len(spatial_res) == 2,
-                            'spatial_res must hold exactly two values when '
-                            'given as tuple')
-                assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
-                assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
-                assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
-                assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
-                self.spatial_res = float(spatial_res[0]), float(spatial_res[1])
-            else:
-                assert_true(spatial_res > 0, 'spatial_res must be positive')
-                self.spatial_res = float(spatial_res)
+            spatial_res = normalize_number_scalar_or_pair(spatial_res, float)
+            assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
+            assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
+            self.spatial_res = spatial_res
 
         self.tile_size = None
         if tile_size is not None:

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -30,6 +30,7 @@ from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema
+from xcube.util.jsonschema import JsonComplexSchema
 from xcube.util.jsonschema import JsonDateSchema
 from xcube.util.jsonschema import JsonIntegerSchema
 from xcube.util.jsonschema import JsonNumberSchema
@@ -138,7 +139,7 @@ class CubeConfig(JsonObject):
                  variable_names: Sequence[str] = None,
                  crs: str = None,
                  bbox: Tuple[float, float, float, float] = None,
-                 spatial_res: Union[float, Tuple[float]] = None,
+                 spatial_res: Union[float, Tuple[float, float]] = None,
                  tile_size: Union[int, Tuple[int, int]] = None,
                  time_range: Tuple[str, Optional[str]] = None,
                  time_period: str = None,
@@ -167,8 +168,19 @@ class CubeConfig(JsonObject):
 
         self.spatial_res = None
         if spatial_res is not None:
-            assert_instance(spatial_res, numbers.Number, 'spatial_res')
-            self.spatial_res = float(spatial_res)
+            assert_instance(spatial_res, (numbers.Number, tuple), 'spatial_res')
+            if isinstance(spatial_res, tuple):
+                assert_true(len(spatial_res) == 2,
+                            'spatial_res must hold exactly two values when '
+                            'given as tuple')
+                assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
+                assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
+                assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
+                assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
+                self.spatial_res = float(spatial_res[0]), float(spatial_res[1])
+            else:
+                assert_true(spatial_res > 0, 'spatial_res must be positive')
+                self.spatial_res = float(spatial_res)
 
         self.tile_size = None
         if tile_size is not None:
@@ -257,9 +269,17 @@ class CubeConfig(JsonObject):
                            JsonNumberSchema(),
                            JsonNumberSchema()]
                 ),
-                spatial_res=JsonNumberSchema(
-                    nullable=True,
-                    exclusive_minimum=0.0),
+                spatial_res=JsonComplexSchema(
+                    one_of=[
+                        JsonArraySchema(
+                            items=[
+                                JsonNumberSchema(exclusive_minimum=0.0),
+                                JsonNumberSchema(exclusive_minimum=0.0)
+                            ]
+                        ),
+                        JsonNumberSchema(exclusive_minimum=0.0)
+                    ]
+                ),
                 tile_size=JsonArraySchema(
                     nullable=True,
                     items=[

--- a/xcube/core/gen2/config.py
+++ b/xcube/core/gen2/config.py
@@ -37,7 +37,7 @@ from xcube.util.jsonschema import JsonNumberSchema
 from xcube.util.jsonschema import JsonObject
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
-from xcube.util.types import normalize_number_scalar_or_pair
+from xcube.util.types import normalize_scalar_or_pair
 
 
 class InputConfig(JsonObject):
@@ -169,7 +169,9 @@ class CubeConfig(JsonObject):
 
         self.spatial_res = None
         if spatial_res is not None:
-            spatial_res = normalize_number_scalar_or_pair(spatial_res, float)
+            spatial_res = normalize_scalar_or_pair(spatial_res,
+                                                   (int, float),
+                                                   'spatial_res')
             assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
             assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
             self.spatial_res = spatial_res

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -31,7 +31,7 @@ from xcube.core.store import DataStorePool
 from xcube.core.store import DatasetDescriptor
 from xcube.core.store import VariableDescriptor
 from xcube.util.assertions import assert_instance
-from xcube.util.assertions import assert_true
+from xcube.util.types import normalize_number_scalar_or_pair
 from .describer import DatasetsDescriber
 from ..config import CubeConfig
 from ..request import CubeGeneratorRequest
@@ -211,17 +211,9 @@ class CubeInformant:
         spatial_res = cube_config.spatial_res
         if spatial_res is None:
             spatial_res = self.first_input_dataset_descriptor.spatial_res
-        assert_instance(spatial_res, (numbers.Number, tuple), 'spatial_res')
-        if isinstance(spatial_res, tuple):
-            assert_true(len(spatial_res) == 2,
-                        'spatial_res must hold exactly two values when given '
-                        'as tuple')
-            assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
-            assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
-            assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
-            assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
-        else:
-            assert_true(spatial_res > 0, 'spatial_res must be positive')
+        spatial_res = normalize_number_scalar_or_pair(spatial_res, float)
+        assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
+        assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
 
         tile_size = cube_config.tile_size
         if tile_size is not None:

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -209,8 +209,8 @@ class CubeInformant:
         if spatial_res is None:
             spatial_res = self.first_input_dataset_descriptor.spatial_res
         spatial_res = normalize_scalar_or_pair(spatial_res,
-                                               (int, float),
-                                               'spatial_res')
+                                               item_type=(int, float),
+                                               name='spatial_res')
         assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
         assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
 

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -80,8 +80,12 @@ class CubeInformant:
         x_min, y_min, x_max, y_max = cube_config.bbox
         spatial_res = cube_config.spatial_res
 
-        width = round((x_max - x_min) / spatial_res)
-        height = round((y_max - y_min) / spatial_res)
+        if isinstance(spatial_res, tuple):
+            width = round((x_max - x_min) / spatial_res[0])
+            height = round((y_max - y_min) / spatial_res[1])
+        else:
+            width = round((x_max - x_min) / spatial_res)
+            height = round((y_max - y_min) / spatial_res)
         width = 2 if width < 2 else width
         height = 2 if height < 2 else height
 
@@ -207,8 +211,17 @@ class CubeInformant:
         spatial_res = cube_config.spatial_res
         if spatial_res is None:
             spatial_res = self.first_input_dataset_descriptor.spatial_res
-        assert_instance(spatial_res, numbers.Number, 'spatial_res')
-        assert_true(spatial_res > 0, 'spatial_res must be positive')
+        assert_instance(spatial_res, (numbers.Number, tuple), 'spatial_res')
+        if isinstance(spatial_res, tuple):
+            assert_true(len(spatial_res) == 2,
+                        'spatial_res must hold exactly two values when given '
+                        'as tuple')
+            assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
+            assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
+            assert_true(spatial_res[0] > 0, 'spatial_res must be positive')
+            assert_true(spatial_res[1] > 0, 'spatial_res must be positive')
+        else:
+            assert_true(spatial_res > 0, 'spatial_res must be positive')
 
         tile_size = cube_config.tile_size
         if tile_size is not None:

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -80,12 +80,12 @@ class CubeInformant:
         x_min, y_min, x_max, y_max = cube_config.bbox
         spatial_res = cube_config.spatial_res
 
-        if isinstance(spatial_res, tuple):
-            width = round((x_max - x_min) / spatial_res[0])
-            height = round((y_max - y_min) / spatial_res[1])
-        else:
-            width = round((x_max - x_min) / spatial_res)
-            height = round((y_max - y_min) / spatial_res)
+        try:
+            spatial_res_x, spatial_res_y = spatial_res
+        except TypeError:
+            spatial_res_x, spatial_res_y = spatial_res, spatial_res
+        width = round((x_max - x_min) / spatial_res_x)
+        height = round((y_max - y_min) / spatial_res_y)
         width = 2 if width < 2 else width
         height = 2 if height < 2 else height
 

--- a/xcube/core/gen2/local/informant.py
+++ b/xcube/core/gen2/local/informant.py
@@ -31,7 +31,7 @@ from xcube.core.store import DataStorePool
 from xcube.core.store import DatasetDescriptor
 from xcube.core.store import VariableDescriptor
 from xcube.util.assertions import assert_instance
-from xcube.util.types import normalize_number_scalar_or_pair
+from xcube.util.types import normalize_scalar_or_pair
 from .describer import DatasetsDescriber
 from ..config import CubeConfig
 from ..request import CubeGeneratorRequest
@@ -80,10 +80,7 @@ class CubeInformant:
         x_min, y_min, x_max, y_max = cube_config.bbox
         spatial_res = cube_config.spatial_res
 
-        try:
-            spatial_res_x, spatial_res_y = spatial_res
-        except TypeError:
-            spatial_res_x, spatial_res_y = spatial_res, spatial_res
+        spatial_res_x, spatial_res_y = normalize_scalar_or_pair(spatial_res)
         width = round((x_max - x_min) / spatial_res_x)
         height = round((y_max - y_min) / spatial_res_y)
         width = 2 if width < 2 else width
@@ -211,7 +208,9 @@ class CubeInformant:
         spatial_res = cube_config.spatial_res
         if spatial_res is None:
             spatial_res = self.first_input_dataset_descriptor.spatial_res
-        spatial_res = normalize_number_scalar_or_pair(spatial_res, float)
+        spatial_res = normalize_scalar_or_pair(spatial_res,
+                                               (int, float),
+                                               'spatial_res')
         assert_instance(spatial_res[0], numbers.Number, 'spatial_res')
         assert_instance(spatial_res[1], numbers.Number, 'spatial_res')
 

--- a/xcube/core/gen2/local/resamplerxy.py
+++ b/xcube/core/gen2/local/resamplerxy.py
@@ -68,7 +68,10 @@ def _compute_target_grid_mapping(cube_config: CubeConfig,
         return source_gm.to_regular(tile_size=cube_config.tile_size)
 
     if target_spatial_res is not None:
-        xy_res = (target_spatial_res, target_spatial_res)
+        if isinstance(target_spatial_res, tuple):
+            xy_res = target_spatial_res
+        else:
+            xy_res = (target_spatial_res, target_spatial_res)
     else:
         xy_res = source_gm.xy_res
     if target_bbox is not None:

--- a/xcube/core/gen2/local/resamplerxy.py
+++ b/xcube/core/gen2/local/resamplerxy.py
@@ -24,6 +24,7 @@ import xarray as xr
 
 from xcube.core.gridmapping import GridMapping
 from xcube.core.resampling import resample_in_space
+from xcube.util.types import normalize_number_scalar_or_pair
 from .transformer import CubeTransformer
 from .transformer import TransformedCube
 from ..config import CubeConfig
@@ -68,10 +69,7 @@ def _compute_target_grid_mapping(cube_config: CubeConfig,
         return source_gm.to_regular(tile_size=cube_config.tile_size)
 
     if target_spatial_res is not None:
-        if isinstance(target_spatial_res, tuple):
-            xy_res = target_spatial_res
-        else:
-            xy_res = (target_spatial_res, target_spatial_res)
+        xy_res = normalize_number_scalar_or_pair(target_spatial_res, float)
     else:
         xy_res = source_gm.xy_res
     if target_bbox is not None:

--- a/xcube/core/gen2/local/resamplerxy.py
+++ b/xcube/core/gen2/local/resamplerxy.py
@@ -24,7 +24,7 @@ import xarray as xr
 
 from xcube.core.gridmapping import GridMapping
 from xcube.core.resampling import resample_in_space
-from xcube.util.types import normalize_number_scalar_or_pair
+from xcube.util.types import normalize_scalar_or_pair
 from .transformer import CubeTransformer
 from .transformer import TransformedCube
 from ..config import CubeConfig
@@ -69,7 +69,9 @@ def _compute_target_grid_mapping(cube_config: CubeConfig,
         return source_gm.to_regular(tile_size=cube_config.tile_size)
 
     if target_spatial_res is not None:
-        xy_res = normalize_number_scalar_or_pair(target_spatial_res, float)
+        xy_res = normalize_scalar_or_pair(target_spatial_res,
+                                          (int, float),
+                                          'spatial_res')
     else:
         xy_res = source_gm.xy_res
     if target_bbox is not None:

--- a/xcube/core/gen2/local/resamplerxy.py
+++ b/xcube/core/gen2/local/resamplerxy.py
@@ -70,8 +70,8 @@ def _compute_target_grid_mapping(cube_config: CubeConfig,
 
     if target_spatial_res is not None:
         xy_res = normalize_scalar_or_pair(target_spatial_res,
-                                          (int, float),
-                                          'spatial_res')
+                                          item_type=(int, float),
+                                          name='spatial_res')
     else:
         xy_res = source_gm.xy_res
     if target_bbox is not None:

--- a/xcube/core/gen2/local/subsetter.py
+++ b/xcube/core/gen2/local/subsetter.py
@@ -27,7 +27,7 @@ from xcube.core.gridmapping import GridMapping
 from xcube.core.select import select_spatial_subset
 from xcube.core.select import select_temporal_subset
 from xcube.core.select import select_variables_subset
-from xcube.util.types import normalize_number_scalar_or_pair
+from xcube.util.types import normalize_scalar_or_pair
 from .transformer import CubeTransformer
 from .transformer import TransformedCube
 from ..config import CubeConfig
@@ -60,7 +60,8 @@ class CubeSubsetter(CubeTransformer):
                 desired_res = cube_config.spatial_res
                 if desired_res is not None:
                     desired_x_res, desired_y_res = \
-                        normalize_number_scalar_or_pair(desired_res, float)
+                        normalize_scalar_or_pair(desired_res,
+                                                 (int, float))
                     if not (math.isclose(gm.x_res, desired_x_res)
                             and math.isclose(gm.y_res, desired_y_res)):
                         can_do_spatial_subset = False

--- a/xcube/core/gen2/local/subsetter.py
+++ b/xcube/core/gen2/local/subsetter.py
@@ -57,10 +57,16 @@ class CubeSubsetter(CubeTransformer):
                 # is required later, which will include the desired
                 # subsetting.
                 desired_res = cube_config.spatial_res
-                if desired_res is not None \
-                        and not (math.isclose(gm.x_res, desired_res)
-                                 and math.isclose(gm.y_res, desired_res)):
-                    can_do_spatial_subset = False
+                if desired_res is not None:
+                    if isinstance(desired_res, tuple):
+                        desired_x_res = desired_res[0]
+                        desired_y_res = desired_res[1]
+                    else:
+                        desired_x_res = desired_res
+                        desired_y_res = desired_res
+                    if not (math.isclose(gm.x_res, desired_x_res)
+                            and math.isclose(gm.y_res, desired_y_res)):
+                        can_do_spatial_subset = False
                 if can_do_spatial_subset:
                     # Finally, the desired CRS must be equal to the current
                     # one, or they must both be geographic.

--- a/xcube/core/gen2/local/subsetter.py
+++ b/xcube/core/gen2/local/subsetter.py
@@ -61,7 +61,7 @@ class CubeSubsetter(CubeTransformer):
                 if desired_res is not None:
                     desired_x_res, desired_y_res = \
                         normalize_scalar_or_pair(desired_res,
-                                                 (int, float))
+                                                 item_type=(int, float))
                     if not (math.isclose(gm.x_res, desired_x_res)
                             and math.isclose(gm.y_res, desired_y_res)):
                         can_do_spatial_subset = False

--- a/xcube/core/gen2/local/subsetter.py
+++ b/xcube/core/gen2/local/subsetter.py
@@ -27,6 +27,7 @@ from xcube.core.gridmapping import GridMapping
 from xcube.core.select import select_spatial_subset
 from xcube.core.select import select_temporal_subset
 from xcube.core.select import select_variables_subset
+from xcube.util.types import normalize_number_scalar_or_pair
 from .transformer import CubeTransformer
 from .transformer import TransformedCube
 from ..config import CubeConfig
@@ -58,12 +59,8 @@ class CubeSubsetter(CubeTransformer):
                 # subsetting.
                 desired_res = cube_config.spatial_res
                 if desired_res is not None:
-                    if isinstance(desired_res, tuple):
-                        desired_x_res = desired_res[0]
-                        desired_y_res = desired_res[1]
-                    else:
-                        desired_x_res = desired_res
-                        desired_y_res = desired_res
+                    desired_x_res, desired_y_res = \
+                        normalize_number_scalar_or_pair(desired_res, float)
                     if not (math.isclose(gm.x_res, desired_x_res)
                             and math.isclose(gm.y_res, desired_y_res)):
                         can_do_spatial_subset = False

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -36,13 +36,12 @@ from xcube.util.dask import get_block_iterators
 from xcube.util.dask import get_chunk_sizes
 from xcube.util.tilegrid import ImageTileGrid
 from xcube.util.tilegrid import TileGrid
+from xcube.util.types import normalize_scalar_or_pair
 from .helpers import AffineTransformMatrix
 from .helpers import Number
 from .helpers import _assert_valid_xy_coords
 from .helpers import _assert_valid_xy_names
 from .helpers import _from_affine
-from .helpers import _normalize_int_pair
-from .helpers import _normalize_number_pair
 from .helpers import _to_affine
 from .helpers import scale_xy_res_and_size
 
@@ -94,12 +93,17 @@ class GridMapping(abc.ABC):
                  is_lon_360: Optional[bool],
                  is_j_axis_up: Optional[bool]):
 
-        width, height = _normalize_int_pair(size, name='size')
+        width, height = normalize_scalar_or_pair(size,
+                                                 item_type=int,
+                                                 name='size')
         assert_true(width > 1 and height > 1,
                     'invalid size')
 
-        tile_width, tile_height = _normalize_int_pair(tile_size,
-                                                      default=(width, height))
+        tile_width, tile_height = normalize_scalar_or_pair(
+            tile_size,
+            item_type=int,
+            default=(width, height)
+        )
         assert_true(tile_width > 1 and tile_height > 1,
                     'invalid tile_size')
 
@@ -110,7 +114,9 @@ class GridMapping(abc.ABC):
         assert_instance(crs, pyproj.crs.CRS, name='crs')
 
         x_min, y_min, x_max, y_max = xy_bbox
-        x_res, y_res = _normalize_number_pair(xy_res, name='xy_res')
+        x_res, y_res = normalize_scalar_or_pair(xy_res,
+                                                item_type=(float, int),
+                                                name='xy_res')
         assert_true(x_res > 0 and y_res > 0,
                     'invalid xy_res')
 
@@ -151,8 +157,9 @@ class GridMapping(abc.ABC):
             _assert_valid_xy_names(xy_dim_names, name='xy_dim_names')
             other._xy_dim_names = xy_dim_names
         if tile_size is not None:
-            tile_width, tile_height = _normalize_int_pair(tile_size,
-                                                          name='tile_size')
+            tile_width, tile_height = normalize_scalar_or_pair(tile_size,
+                                                               item_type=int,
+                                                               name='tile_size')
             assert_true(tile_width > 1 and tile_height > 1, 'invalid tile_size')
             tile_size = tile_width, tile_height
             if other.tile_size != tile_size:
@@ -184,13 +191,14 @@ class GridMapping(abc.ABC):
         :return: A new, scaled grid mapping.
         """
         self._assert_regular()
-        x_scale, y_scale = _normalize_number_pair(xy_scale)
+        x_scale, y_scale = normalize_scalar_or_pair(xy_scale)
         new_xy_res, new_size = scale_xy_res_and_size(self.xy_res,
                                                      self.size,
                                                      (x_scale, y_scale))
         if tile_size is not None:
-            tile_width, tile_height = _normalize_int_pair(tile_size,
-                                                          name='tile_size')
+            tile_width, tile_height = normalize_scalar_or_pair(tile_size,
+                                                               item_type=int,
+                                                               name='tile_size')
         else:
             tile_width, tile_height = self.tile_size
         tile_width = min(new_size[0], tile_width)

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -36,13 +36,14 @@ from xcube.util.dask import get_block_iterators
 from xcube.util.dask import get_chunk_sizes
 from xcube.util.tilegrid import ImageTileGrid
 from xcube.util.tilegrid import TileGrid
-from xcube.util.types import normalize_scalar_or_pair
 from .helpers import AffineTransformMatrix
 from .helpers import Number
 from .helpers import _assert_valid_xy_coords
 from .helpers import _assert_valid_xy_names
 from .helpers import _from_affine
 from .helpers import _to_affine
+from .helpers import normalize_int_pair
+from .helpers import normalize_number_pair
 from .helpers import scale_xy_res_and_size
 
 # WGS84, axis order: lat, lon
@@ -93,15 +94,12 @@ class GridMapping(abc.ABC):
                  is_lon_360: Optional[bool],
                  is_j_axis_up: Optional[bool]):
 
-        width, height = normalize_scalar_or_pair(size,
-                                                 item_type=int,
-                                                 name='size')
+        width, height = normalize_int_pair(size, name='size')
         assert_true(width > 1 and height > 1,
                     'invalid size')
 
-        tile_width, tile_height = normalize_scalar_or_pair(
+        tile_width, tile_height = normalize_int_pair(
             tile_size,
-            item_type=int,
             default=(width, height)
         )
         assert_true(tile_width > 1 and tile_height > 1,
@@ -114,9 +112,7 @@ class GridMapping(abc.ABC):
         assert_instance(crs, pyproj.crs.CRS, name='crs')
 
         x_min, y_min, x_max, y_max = xy_bbox
-        x_res, y_res = normalize_scalar_or_pair(xy_res,
-                                                item_type=(float, int),
-                                                name='xy_res')
+        x_res, y_res = normalize_number_pair(xy_res, name='xy_res')
         assert_true(x_res > 0 and y_res > 0,
                     'invalid xy_res')
 
@@ -157,9 +153,8 @@ class GridMapping(abc.ABC):
             _assert_valid_xy_names(xy_dim_names, name='xy_dim_names')
             other._xy_dim_names = xy_dim_names
         if tile_size is not None:
-            tile_width, tile_height = normalize_scalar_or_pair(tile_size,
-                                                               item_type=int,
-                                                               name='tile_size')
+            tile_width, tile_height = normalize_int_pair(tile_size,
+                                                         name='tile_size')
             assert_true(tile_width > 1 and tile_height > 1, 'invalid tile_size')
             tile_size = tile_width, tile_height
             if other.tile_size != tile_size:
@@ -191,14 +186,13 @@ class GridMapping(abc.ABC):
         :return: A new, scaled grid mapping.
         """
         self._assert_regular()
-        x_scale, y_scale = normalize_scalar_or_pair(xy_scale)
+        x_scale, y_scale = normalize_number_pair(xy_scale)
         new_xy_res, new_size = scale_xy_res_and_size(self.xy_res,
                                                      self.size,
                                                      (x_scale, y_scale))
         if tile_size is not None:
-            tile_width, tile_height = normalize_scalar_or_pair(tile_size,
-                                                               item_type=int,
-                                                               name='tile_size')
+            tile_width, tile_height = normalize_int_pair(tile_size,
+                                                         name='tile_size')
         else:
             tile_width, tile_height = self.tile_size
         tile_width = min(new_size[0], tile_width)

--- a/xcube/core/gridmapping/coords.py
+++ b/xcube/core/gridmapping/coords.py
@@ -30,12 +30,12 @@ import xarray as xr
 
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
+from xcube.util.types import normalize_scalar_or_pair
 from .base import DEFAULT_TOLERANCE
 from .base import GridMapping
 from .helpers import _assert_valid_xy_names
 from .helpers import _default_xy_var_names
 from .helpers import _normalize_crs
-from .helpers import _normalize_int_pair
 from .helpers import _to_int_or_float
 from .helpers import from_lon_360
 from .helpers import round_to_fraction
@@ -105,7 +105,10 @@ def new_grid_mapping_from_coords(
     else:
         xy_var_names = _default_xy_var_names(crs)
 
-    tile_size = _normalize_int_pair(tile_size, default=None)
+    try:
+        tile_size = normalize_scalar_or_pair(tile_size, item_type=int)
+    except ValueError:
+        tile_size = None
     is_lon_360 = None  # None means "not yet known"
     if crs.is_geographic:
         is_lon_360 = bool(np.any(x_coords > 180))

--- a/xcube/core/gridmapping/coords.py
+++ b/xcube/core/gridmapping/coords.py
@@ -30,7 +30,6 @@ import xarray as xr
 
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
-from xcube.util.types import normalize_scalar_or_pair
 from .base import DEFAULT_TOLERANCE
 from .base import GridMapping
 from .helpers import _assert_valid_xy_names
@@ -38,6 +37,7 @@ from .helpers import _default_xy_var_names
 from .helpers import _normalize_crs
 from .helpers import _to_int_or_float
 from .helpers import from_lon_360
+from .helpers import normalize_int_pair
 from .helpers import round_to_fraction
 from .helpers import to_lon_360
 
@@ -106,7 +106,7 @@ def new_grid_mapping_from_coords(
         xy_var_names = _default_xy_var_names(crs)
 
     try:
-        tile_size = normalize_scalar_or_pair(tile_size, item_type=int)
+        tile_size = normalize_int_pair(tile_size)
     except ValueError:
         tile_size = None
     is_lon_360 = None  # None means "not yet known"

--- a/xcube/core/gridmapping/helpers.py
+++ b/xcube/core/gridmapping/helpers.py
@@ -68,43 +68,6 @@ def _normalize_crs(crs: Union[str, pyproj.CRS]) -> pyproj.CRS:
     return pyproj.CRS.from_string(crs)
 
 
-def _normalize_int_pair(
-        value: Any,
-        name: str = None,
-        default: Optional[Tuple[int, int]] = UNDEFINED
-) -> Optional[Tuple[int, int]]:
-    if isinstance(value, int):
-        return value, value
-    elif value is not None:
-        x, y = value
-        return int(x), int(y)
-    elif default != UNDEFINED:
-        return default
-    else:
-        assert_given(name, 'name')
-        raise ValueError(f'{name} must be an int'
-                         f' or a sequence of two ints')
-
-
-def _normalize_number_pair(
-        value: Any,
-        name: str = None,
-        default: Optional[Tuple[Number, Number]] = UNDEFINED
-) -> Optional[Tuple[Number, Number]]:
-    if isinstance(value, (float, int)):
-        x, y = value, value
-        return _to_int_or_float(x), _to_int_or_float(y)
-    elif value is not None:
-        x, y = value
-        return _to_int_or_float(x), _to_int_or_float(y)
-    elif default != UNDEFINED:
-        return default
-    else:
-        assert_given(name, 'name')
-        raise ValueError(f'{name} must be a number'
-                         f' or a sequence of two numbers')
-
-
 def to_lon_360(lon_var: Union[np.ndarray, da.Array, xr.DataArray]):
     if isinstance(lon_var, xr.DataArray):
         return lon_var.where(lon_var >= 0.0, lon_var + 360.0)

--- a/xcube/core/gridmapping/helpers.py
+++ b/xcube/core/gridmapping/helpers.py
@@ -68,6 +68,43 @@ def _normalize_crs(crs: Union[str, pyproj.CRS]) -> pyproj.CRS:
     return pyproj.CRS.from_string(crs)
 
 
+def normalize_int_pair(
+        value: Any,
+        name: str = None,
+        default: Optional[Tuple[int, int]] = UNDEFINED
+) -> Optional[Tuple[int, int]]:
+    if isinstance(value, int):
+        return value, value
+    elif value is not None:
+        x, y = value
+        return int(x), int(y)
+    elif default != UNDEFINED:
+        return default
+    else:
+        assert_given(name, 'name')
+        raise ValueError(f'{name} must be an int'
+                         f' or a sequence of two ints')
+
+
+def normalize_number_pair(
+        value: Any,
+        name: str = None,
+        default: Optional[Tuple[Number, Number]] = UNDEFINED
+) -> Optional[Tuple[Number, Number]]:
+    if isinstance(value, (float, int)):
+        x, y = value, value
+        return _to_int_or_float(x), _to_int_or_float(y)
+    elif value is not None:
+        x, y = value
+        return _to_int_or_float(x), _to_int_or_float(y)
+    elif default != UNDEFINED:
+        return default
+    else:
+        assert_given(name, 'name')
+        raise ValueError(f'{name} must be a number'
+                         f' or a sequence of two numbers')
+
+
 def to_lon_360(lon_var: Union[np.ndarray, da.Array, xr.DataArray]):
     if isinstance(lon_var, xr.DataArray):
         return lon_var.where(lon_var >= 0.0, lon_var + 360.0)

--- a/xcube/core/gridmapping/regular.py
+++ b/xcube/core/gridmapping/regular.py
@@ -26,12 +26,11 @@ import pyproj
 import xarray as xr
 
 from xcube.util.assertions import assert_true
+from xcube.util.types import normalize_scalar_or_pair
 from .base import GridMapping
 from .helpers import _default_xy_dim_names
 from .helpers import _default_xy_var_names
 from .helpers import _normalize_crs
-from .helpers import _normalize_int_pair
-from .helpers import _normalize_number_pair
 from .helpers import _to_int_or_float
 
 
@@ -73,12 +72,18 @@ def new_regular_grid_mapping(
         tile_size: Union[int, Tuple[int, int]] = None,
         is_j_axis_up: bool = False
 ) -> GridMapping:
-    width, height = _normalize_int_pair(size, name='size')
+    width, height = normalize_scalar_or_pair(size,
+                                             item_type=int,
+                                             name='size')
     assert_true(width > 1 and height > 1, 'invalid size')
 
-    x_min, y_min = _normalize_number_pair(xy_min, name='xy_min')
+    x_min, y_min = normalize_scalar_or_pair(xy_min,
+                                            item_type=(int, float),
+                                            name='xy_min')
 
-    x_res, y_res = _normalize_number_pair(xy_res, name='xy_res')
+    x_res, y_res = normalize_scalar_or_pair(xy_res,
+                                            item_type=(int, float),
+                                            name='xy_res')
     assert_true(x_res > 0 and y_res > 0, 'invalid xy_res')
 
     crs = _normalize_crs(crs)

--- a/xcube/core/gridmapping/regular.py
+++ b/xcube/core/gridmapping/regular.py
@@ -26,12 +26,13 @@ import pyproj
 import xarray as xr
 
 from xcube.util.assertions import assert_true
-from xcube.util.types import normalize_scalar_or_pair
 from .base import GridMapping
 from .helpers import _default_xy_dim_names
 from .helpers import _default_xy_var_names
 from .helpers import _normalize_crs
 from .helpers import _to_int_or_float
+from .helpers import normalize_int_pair
+from .helpers import normalize_number_pair
 
 
 class RegularGridMapping(GridMapping):
@@ -72,18 +73,12 @@ def new_regular_grid_mapping(
         tile_size: Union[int, Tuple[int, int]] = None,
         is_j_axis_up: bool = False
 ) -> GridMapping:
-    width, height = normalize_scalar_or_pair(size,
-                                             item_type=int,
-                                             name='size')
+    width, height = normalize_int_pair(size, name='size')
     assert_true(width > 1 and height > 1, 'invalid size')
 
-    x_min, y_min = normalize_scalar_or_pair(xy_min,
-                                            item_type=(int, float),
-                                            name='xy_min')
+    x_min, y_min = normalize_number_pair(xy_min, name='xy_min')
 
-    x_res, y_res = normalize_scalar_or_pair(xy_res,
-                                            item_type=(int, float),
-                                            name='xy_res')
+    x_res, y_res = normalize_number_pair(xy_res, name='xy_res')
     assert_true(x_res > 0 and y_res > 0, 'invalid xy_res')
 
     crs = _normalize_crs(crs)

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -31,6 +31,7 @@ from dask_image import ndinterp
 from xcube.core.gridmapping import GridMapping
 from xcube.core.gridmapping.helpers import AffineTransformMatrix
 from xcube.util.assertions import assert_true
+from xcube.util.types import normalize_scalar_or_pair
 
 NDImage = Union[np.ndarray, da.Array]
 Aggregator = Callable[[NDImage], NDImage]
@@ -307,12 +308,10 @@ def _normalize_pair(pair: Optional[Sequence[float]],
                     default: float,
                     ndim: int,
                     name: str) -> Tuple[int, ...]:
-    if pair is None:
-        pair = [default, default]
-    elif isinstance(pair, (int, float)):
-        pair = [pair, pair]
-    elif len(pair) != 2:
-        raise ValueError(f'illegal image {name}')
+    pair = normalize_scalar_or_pair(tuple(pair),
+                                    item_type=float,
+                                    default=default,
+                                    name=name)
     return (ndim - 2) * (default,) + tuple(pair)
 
 

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -173,7 +173,8 @@ def resample_ndimage(
         axes = {image.ndim - 2: divisor_y, image.ndim - 1: divisor_x}
         elongation = _normalize_scale((scale_y / divisor_y,
                                        scale_x / divisor_x), image.ndim)
-        larger_shape = resize_shape(shape, (divisor_y, divisor_x),
+        larger_shape = resize_shape(shape,
+                                    scale=(float(divisor_y), float(divisor_x)),
                                     divisor_x=divisor_x,
                                     divisor_y=divisor_y)
         # print('Downsampling: ', scale)
@@ -308,9 +309,10 @@ def _normalize_pair(pair: Optional[Sequence[float]],
                     default: float,
                     ndim: int,
                     name: str) -> Tuple[int, ...]:
+    if pair is None:
+        pair = default, default
     pair = normalize_scalar_or_pair(tuple(pair),
                                     item_type=float,
-                                    default=default,
                                     name=name)
     return (ndim - 2) * (default,) + tuple(pair)
 

--- a/xcube/core/store/descriptor.py
+++ b/xcube/core/store/descriptor.py
@@ -202,7 +202,9 @@ class DatasetDescriptor(DataDescriptor):
         temporal extent
     :param time_period: The data's periodicity
         if it is evenly temporally resolved
-    :param spatial_res: The spatial extent of a pixel in crs units
+    :param spatial_res: The spatial extent of a pixel in crs units. May be
+        given as a single value or a tuple of two values
+        when x- and y-resolutions are different
     :param dims: A mapping of the dataset's dimensions to their sizes
     :param coords: mapping of the dataset's data coordinate names
         to instances of :class:VariableDescriptor

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -25,17 +25,22 @@ from xcube.util.assertions import assert_true
 
 T = TypeVar('T', int, float)
 
-Bbox = Tuple[T, T, T, T]
 ItemType = Union[Type[T], Tuple[Type[T], ...]]
 Pair = Tuple[T, T]
 ScalarOrPair = Union[T, Pair]
 
 
 def normalize_scalar_or_pair(
-        value: ScalarOrPair,
+        value: Optional[ScalarOrPair] = None,
+        *,
         item_type: Optional[ItemType[T]] = None,
+        default: Optional[ScalarOrPair] = None,
         name: Optional[str] = None
 ) -> Pair:
+    if value is None and default is not None:
+        # not returning default immediately so that default is checked for
+        # validity
+        value = default
     try:
         assert_true(len(value) <= 2,
                     message=f"{name or 'Value'} must be a scalar or pair of "

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -35,7 +35,7 @@ def normalize_number_scalar_or_pair(
     if isinstance(value, (float, int)):
         x, y = value, value
         return t(x), t(y)
-    elif isinstance(value, tuple) and len(value) == 2:
+    elif len(value) == 2:
         x, y = value
         return t(x), t(y)
     else:

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -23,7 +23,7 @@ from typing import Optional, Tuple, Type, TypeVar, Union
 
 from xcube.util.assertions import assert_true
 
-T = TypeVar('T', int, float)
+T = TypeVar('T')
 
 ItemType = Union[Type[T], Tuple[Type[T], ...]]
 Pair = Tuple[T, T]

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -1,0 +1,43 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Tuple, Type, TypeVar, Union
+
+T = TypeVar('T', int, float)
+
+Pair = Tuple[T, T]
+ScalarOrPair = Union[T, Pair]
+Bbox = Tuple[T, T, T, T]
+
+
+def normalize_number_scalar_or_pair(
+        value: ScalarOrPair,
+        t: Type[T] = float
+) -> Pair:
+    if isinstance(value, (float, int)):
+        x, y = value, value
+        return t(x), t(y)
+    elif isinstance(value, tuple) and len(value) == 2:
+        x, y = value
+        return t(x), t(y)
+    else:
+        raise ValueError(f'Value "{value}" must be a number or a segment of '
+                         f'two numbers')

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -31,7 +31,7 @@ ScalarOrPair = Union[T, Pair]
 
 
 def normalize_scalar_or_pair(
-        value: Optional[ScalarOrPair] = None,
+        value: ScalarOrPair[T],
         *,
         item_type: Optional[ItemType[T]] = None,
         default: Optional[ScalarOrPair] = None,

--- a/xcube/util/types.py
+++ b/xcube/util/types.py
@@ -34,13 +34,8 @@ def normalize_scalar_or_pair(
         value: ScalarOrPair[T],
         *,
         item_type: Optional[ItemType[T]] = None,
-        default: Optional[ScalarOrPair] = None,
         name: Optional[str] = None
 ) -> Pair:
-    if value is None and default is not None:
-        # not returning default immediately so that default is checked for
-        # validity
-        value = default
     try:
         assert_true(len(value) <= 2,
                     message=f"{name or 'Value'} must be a scalar or pair of "
@@ -49,27 +44,7 @@ def normalize_scalar_or_pair(
     except TypeError:
         x, y = value, value
     if item_type is not None:
-        x = _maybe_convert(x, item_type)
-        y = _maybe_convert(y, item_type)
         assert_true(isinstance(x, item_type) and isinstance(y, item_type),
                     message=f"{name or 'Value'} must be a scalar or pair of "
                             f"{item_type}, was '{value}'")
     return x, y
-
-
-def _maybe_convert(value: T, item_type: ItemType[T]) -> T:
-    if not isinstance(value, item_type):
-        try:
-            for t in item_type:
-                try:
-                    value = t(value)
-                    break
-                except TypeError:
-                    continue
-        except TypeError:
-            try:
-                value = item_type(value)
-            except TypeError:
-                # leave value as is
-                value = value
-    return value


### PR DESCRIPTION
Solves #615 . DatasetDescriptors may hold a tuple of two values for spatial resolution, the resolution determined from a dataset may consist of two values, different resolutions are considered during cube generation.
Checklist:

* [x] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)