### PR TITLE
Fix FsDataAccessor.write_data() impls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 
+* Fixed `FsDataAccessor.write_data()` implementations, 
+  which now always return the passed in `data_id`. (#623)
+
 ### Other
 
 ## Changes in 0.10.1

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -117,7 +117,8 @@ class FsDataStoresTestMixin(ABC):
         self.assertEqual([], list(data_store.get_data_ids()))
 
         data = new_cube(variables=dict(A=8, B=9))
-        data_store.write_data(data, data_id)
+        written_data_id = data_store.write_data(data, data_id)
+        self.assertEqual(data_id, written_data_id)
         self.assertEqual({expected_data_type_alias},
                          set(data_store.get_data_types_for_data(data_id)))
         self.assertEqual(True, data_store.has_data(data_id))

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -191,7 +191,7 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor, ABC):
                    data: xr.Dataset,
                    data_id: str,
                    replace=False,
-                   **write_params):
+                   **write_params) -> str:
         assert_instance(data, xr.Dataset, name='data')
         assert_instance(data_id, str, name='data_id')
         fs, write_params = self.load_fs(write_params)
@@ -209,6 +209,7 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor, ABC):
         except ValueError as e:
             raise DataStoreError(f'Failed to write'
                                  f' dataset {data_id!r}: {e}') from e
+        return data_id
 
     def delete_data(self,
                     data_id: str,
@@ -277,7 +278,7 @@ class DatasetNetcdfFsDataAccessor(DatasetFsDataAccessor, ABC):
                    data: xr.Dataset,
                    data_id: str,
                    replace=False,
-                   **write_params):
+                   **write_params) -> str:
         assert_instance(data, xr.Dataset, name='data')
         assert_instance(data_id, str, name='data_id')
         fs, write_params = self.load_fs(write_params)
@@ -298,3 +299,4 @@ class DatasetNetcdfFsDataAccessor(DatasetFsDataAccessor, ABC):
         data.to_netcdf(file_path, engine=engine, **write_params)
         if not is_local:
             fs.put_file(file_path, data_id)
+        return data_id

--- a/xcube/core/store/fs/impl/geodataframe.py
+++ b/xcube/core/store/fs/impl/geodataframe.py
@@ -79,7 +79,10 @@ class GeoDataFrameFsDataAccessor(FsDataAccessor, ABC):
             ),
         )
 
-    def write_data(self, data: gpd.GeoDataFrame, data_id: str, **write_params):
+    def write_data(self,
+                   data: gpd.GeoDataFrame,
+                   data_id: str,
+                   **write_params) -> str:
         # TODO: implement me correctly,
         #  this is not valid for shapefile AND geojson
         assert_instance(data, (gpd.GeoDataFrame, pd.DataFrame), 'data')
@@ -92,6 +95,7 @@ class GeoDataFrameFsDataAccessor(FsDataAccessor, ABC):
         data.to_file(file_path, driver=self.get_driver_name(), **write_params)
         if not is_local:
             fs.put_file(file_path, data_id)
+        return data_id
 
 
 class GeoDataFrameShapefileFsDataAccessor(GeoDataFrameFsDataAccessor, ABC):

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -71,7 +71,7 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                    data: Union[xr.Dataset, MultiLevelDataset],
                    data_id: str,
                    replace=False,
-                   **write_params):
+                   **write_params) -> str:
         assert_instance(data, (xr.Dataset, MultiLevelDataset), name='data')
         assert_instance(data_id, str, name='data_id')
         if isinstance(data, MultiLevelDataset):
@@ -108,6 +108,7 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                 level_dataset = xr.open_zarr(zarr_store,
                                              consolidated=consolidated)
                 ml_dataset.set_dataset(index, level_dataset)
+        return data_id
 
 
 class FsMultiLevelDataset(LazyMultiLevelDataset):
@@ -139,7 +140,8 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
 
     def _get_tile_grid_lazily(self) -> TileGrid:
         """
-        Retrieve, i.e. read or compute, the tile grid used by the multi-level dataset.
+        Retrieve, i.e. read or compute, the tile grid used
+        by the multi-level dataset.
 
         :return: the dataset for the level at *index*.
         """


### PR DESCRIPTION
Fixed `FsDataAccessor.write_data()` implementations, which now always return the passed in `data_id`. 

Closes #623

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!