### PR TITLE
New function "add_spatial_ref"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,8 @@
 ### Enhancements
 
 * Introduced helper function `add_spatial_ref()`
-  of package `xcube.core.gridmapping.cfconv` that allows subsequently 
-  adding a missing spatial coordinate reference system to an existing  
+  of package `xcube.core.gridmapping.cfconv` that allows 
+  adding a spatial coordinate reference system to an existing  
   Zarr dataset. (#629)
 
 * Introduced parameter `base_dataset_id` for writing multi-level 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Enhancements
 
 * Introduced helper function `add_spatial_ref()`
-  of package `xcube.core.gridmapping` that allows subsequently 
+  of package `xcube.core.gridmapping.cfconv` that allows subsequently 
   adding a missing spatial coordinate reference system to an existing  
   Zarr dataset. (#629)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ### Enhancements
 
+* Introduced helper function `add_spatial_ref()`
+  of package `xcube.core.gridmapping` that allows subsequently 
+  adding a missing spatial coordinate reference system to an existing  
+  Zarr dataset. (#629)
+
 * Introduced parameter `base_dataset_id` for writing multi-level 
   datasets with the "file", "s3", and "memory" data stores. 
   If given, the base dataset will be linked only with the 

--- a/test/core/gridmapping/test_cfconv.py
+++ b/test/core/gridmapping/test_cfconv.py
@@ -2,13 +2,20 @@ import shutil
 import unittest
 from typing import Set
 
+import fsspec
 import numpy as np
 import pyproj
 import xarray as xr
 
+from test.s3test import MOTO_SERVER_ENDPOINT_URL
+from test.s3test import S3Test
+from xcube.core.gridmapping import GridMapping
 from xcube.core.gridmapping.cfconv import GridCoords
 from xcube.core.gridmapping.cfconv import GridMappingProxy
+from xcube.core.gridmapping.cfconv import add_spatial_ref
 from xcube.core.gridmapping.cfconv import get_dataset_grid_mapping_proxies
+from xcube.core.new import new_cube
+from xcube.core.store.fs.registry import new_fs_data_store
 
 CRS_WGS84 = pyproj.crs.CRS(4326)
 CRS_CRS84 = pyproj.crs.CRS.from_string("urn:ogc:def:crs:OGC:1.3:CRS84")
@@ -192,3 +199,76 @@ class XarrayDecodeCfTest(unittest.TestCase):
         self.assertEqual(('y', 'x'), lon.dims)
         self.assertEqual(('y', 'x'), lat.dims)
         return noise, crs, lon, lat
+
+
+class AddSpatialRefTest(S3Test):
+
+    def test_add_spatial_ref(self):
+        original_dataset = new_cube(x_name='x',
+                                    y_name='y',
+                                    x_start=0,
+                                    y_start=0,
+                                    x_res=10,
+                                    y_res=10,
+                                    x_units='metres',
+                                    y_units='metres',
+                                    drop_bounds=True,
+                                    width=100,
+                                    height=100,
+                                    variables=dict(A=1.3, B=8.3))
+
+        root = 'eurodatacube-test/xcube-eea'
+        data_id = 'test.zarr'
+        crs_var_name = 'spatial_ref'
+        crs = pyproj.CRS.from_string("EPSG:3035")
+
+        storage_options = dict(
+            anon=False,
+            client_kwargs=dict(
+                endpoint_url=MOTO_SERVER_ENDPOINT_URL,
+            )
+        )
+
+        fs: fsspec.AbstractFileSystem = fsspec.filesystem('s3',
+                                                          **storage_options)
+        if fs.isdir(root):
+            fs.rm(root, recursive=True)
+        fs.mkdirs(root, exist_ok=True)
+
+        data_store = new_fs_data_store('s3',
+                                       root=root,
+                                       storage_options=storage_options)
+
+        data_store.write_data(original_dataset, data_id=data_id)
+        opened_dataset = data_store.open_data(data_id)
+        self.assertEqual({'A', 'B', 'x', 'y', 'time'},
+                         set(opened_dataset.variables))
+
+        with self.assertRaises(ValueError) as cm:
+            GridMapping.from_dataset(opened_dataset)
+        self.assertEqual(
+            ('cannot find any grid mapping in dataset',),
+            cm.exception.args
+        )
+
+        path = f"{root}/{data_id}"
+        group_store = fs.get_mapper(path, create=True)
+
+        add_spatial_ref(group_store,
+                        crs,
+                        crs_var_name=crs_var_name)
+
+        self.assertTrue(fs.exists(f"{path}/{crs_var_name}"))
+        self.assertTrue(fs.exists(f"{path}/{crs_var_name}/.zarray"))
+        self.assertTrue(fs.exists(f"{path}/{crs_var_name}/.zattrs"))
+
+        opened_dataset = data_store.open_data(data_id)
+        self.assertEqual({'A', 'B', 'x', 'y', 'time', 'spatial_ref'},
+                         set(opened_dataset.variables))
+        self.assertEqual(crs_var_name,
+                         opened_dataset.A.attrs.get('grid_mapping'))
+        self.assertEqual(crs_var_name,
+                         opened_dataset.B.attrs.get('grid_mapping'))
+
+        gm = GridMapping.from_dataset(opened_dataset)
+        self.assertIn("LAEA Europe", gm.crs.srs)

--- a/xcube/core/gridmapping/__init__.py
+++ b/xcube/core/gridmapping/__init__.py
@@ -23,3 +23,4 @@ from .base import CRS_CRS84
 from .base import CRS_WGS84
 from .base import DEFAULT_TOLERANCE
 from .base import GridMapping
+from .cfconv import add_spatial_ref

--- a/xcube/core/gridmapping/__init__.py
+++ b/xcube/core/gridmapping/__init__.py
@@ -23,4 +23,3 @@ from .base import CRS_CRS84
 from .base import CRS_WGS84
 from .base import DEFAULT_TOLERANCE
 from .base import GridMapping
-from .cfconv import add_spatial_ref

--- a/xcube/core/gridmapping/cfconv.py
+++ b/xcube/core/gridmapping/cfconv.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 
 import warnings
+from collections.abc import MutableMapping
 from typing import Optional, Dict, Any, Hashable, Union, Set, List, Tuple
 
 import numpy as np
@@ -29,6 +30,7 @@ import zarr
 import zarr.convenience
 
 from xcube.core.schema import get_dataset_chunks
+from xcube.util.assertions import assert_instance
 
 
 class GridCoords:
@@ -290,7 +292,7 @@ def _find_dataset_tile_size(dataset: xr.Dataset,
     return None
 
 
-def add_spatial_ref(group_store: zarr.convenience.StoreLike,
+def add_spatial_ref(dataset_store: zarr.convenience.StoreLike,
                     crs: pyproj.CRS,
                     crs_var_name: Optional[str] = 'spatial_ref',
                     xy_dim_names: Optional[Tuple[str, str]] = None):
@@ -298,16 +300,20 @@ def add_spatial_ref(group_store: zarr.convenience.StoreLike,
     Helper function that allows adding a spatial reference to an
     existing Zarr dataset.
 
-    :param group_store: The dataset's existing Zarr store or path.
-    :param crs: The coordinate reference system.
+    :param dataset_store: The dataset's existing Zarr store or path.
+    :param crs: The spatial coordinate reference system.
     :param crs_var_name: The name of the variable that will hold the
         spatial reference. Defaults to "spatial_ref".
     :param xy_dim_names: The names of the x and y dimensions.
         Defaults to ("x", "y").
     """
+    assert_instance(dataset_store, (MutableMapping, str), name='group_store')
+    assert_instance(crs_var_name, str, name='crs_var_name')
+    x_dim_name, y_dim_name = xy_dim_names or ('x', 'y')
+
     spatial_attrs = crs.to_cf()
     spatial_attrs['_ARRAY_DIMENSIONS'] = []  # Required by xarray
-    group = zarr.open(group_store, mode='r+')
+    group = zarr.open(dataset_store, mode='r+')
     spatial_ref = group.array(crs_var_name,
                               0,
                               shape=(),
@@ -315,11 +321,12 @@ def add_spatial_ref(group_store: zarr.convenience.StoreLike,
                               fill_value=0)
     spatial_ref.attrs.update(**spatial_attrs)
 
-    yx_dim_names = list(reversed(xy_dim_names or ('x', 'y')))
     for item_name, item in group.items():
         if item_name != crs_var_name:
             dims = item.attrs.get('_ARRAY_DIMENSIONS')
-            if dims and len(dims) >= 2 and dims[-2:] == yx_dim_names:
+            if dims and len(dims) >= 2 \
+                    and dims[-2] == y_dim_name \
+                    and dims[-1] == x_dim_name:
                 item.attrs['grid_mapping'] = crs_var_name
 
-    zarr.convenience.consolidate_metadata(group_store)
+    zarr.convenience.consolidate_metadata(dataset_store)


### PR DESCRIPTION
Added new helper function `xcube.core.gridmapping.cfconv.add_spatial_ref`: 

```python
def add_spatial_ref(dataset_store: zarr.convenience.StoreLike,
                    crs: pyproj.CRS,
                    crs_var_name: Optional[str] = 'spatial_ref',
                    xy_dim_names: Optional[Tuple[str, str]] = None):
    """
    Helper function that allows adding a spatial reference to an
    existing Zarr dataset.

    :param dataset_store: The dataset's existing Zarr store or path.
    :param crs: The spatial coordinate reference system.
    :param crs_var_name: The name of the variable that will hold the
        spatial reference. Defaults to "spatial_ref".
    :param xy_dim_names: The names of the x and y dimensions.
        Defaults to ("x", "y").
    """
```

Closes #629


Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!