### PR TITLE
xcube server to ignore datasets that cannot be opened

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Enhancements
 
+* `xcube serve` used to shut down with an error message 
+  if it encountered datasets it could not open. New behaviour 
+  is to emit a warning and ignore such datasets. (#630)
+
 * Introduced parameter `base_dataset_id` for writing multi-level 
   datasets with the "file", "s3", and "memory" data stores. 
   If given, the base dataset will be linked only with the 

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -40,7 +40,7 @@ from xcube.webapi.controllers.places import GeoJsonFeatureCollection
 from xcube.webapi.controllers.tiles import get_dataset_tile_url
 from xcube.webapi.controllers.tiles import get_tile_source_options
 from xcube.webapi.errors import ServiceBadRequestError
-
+import zarr
 
 def get_datasets(ctx: ServiceContext,
                  details: bool = False,
@@ -136,7 +136,11 @@ def get_dataset(ctx: ServiceContext,
         required_scopes = ctx.get_required_dataset_scopes(dataset_config)
         assert_scopes(required_scopes, granted_scopes or set())
 
-    ml_ds = ctx.get_ml_dataset(ds_id)
+    try:
+        ml_ds = ctx.get_ml_dataset(ds_id)
+    except ValueError as e:
+        raise DatasetIsNotACubeError(f'could not open dataset: {e}') from e
+
     grid_mapping = ml_ds.grid_mapping
     if not grid_mapping.crs.is_geographic:
         raise CubeIsNotDisplayable(f'CRS is not geographic:'


### PR DESCRIPTION
`xcube serve` used to shut down with an error message if it encountered datasets it could not open. New behaviour is to emit a warning and ignore such datasets. 

Closes #630

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!