### PR TITLE
Allow running xcube Env with Coiled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,10 +49,14 @@
 
 ### Other
 
-* Replace the dependency on the rfc3339-validator PyPI package with a
+* Added packages `python-blosc` and `lz4` to the xcube Python environment 
+  for better support of Dask `distributed` and the Dask service 
+  [Coiled](https://coiled.io/).
+
+* Replace the dependency on the `rfc3339-validator` PyPI package with a
   dependency on its recently created conda-forge package.
 
-* Remove unneeded dependency on the no longer used strict-rfc3339 package.
+* Remove unneeded dependency on the no longer used `strict-rfc3339` package.
 
 ## Changes in 0.10.1
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - pandas >=1.3
   - pillow >=6.0
   - pyjwt >=1.7
-  - pyproj >=3.0,<3.3  # tests fail with 3.3.0
+  - pyproj >=3.0,<3.3  # tests fail with 3.3.0, missing database on Windows
   - pyyaml >=5.4
   - rasterio >=1.2
   - requests >=2.25
@@ -40,6 +40,10 @@ dependencies:
   - urllib3 >=1.26
   - xarray >=0.19
   - zarr >=2.8
+  # Required by Coiled
+  # These are very likely transitive deps anyway
+  - lz4
+  - python-blosc
   # Testing
   - flake8 >=3.7
   - moto >=1.3


### PR DESCRIPTION
Added lz4 and python-blosc (should be transitive deps anyway), so we can use xcube env on Coiled without modifications

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
