### PR TITLE
Pin fontconfig version to <2.13.96 in dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - dask-image >=0.6
   - distributed >=2021.6
   - fiona >=1.8
+  - fontconfig <2.13.96  # temporary workaround for Mac CI bug; see Issue #640
   - fsspec >=2021.6
   - gdal >=3.0
   - geopandas >=0.8


### PR DESCRIPTION
Workaround for a bug in the Mac CI builds.
Fixes #640.

Checklist:

* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!