### PR TITLE
Ensure we keep encoding in pyramids

### DIFF
--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -2,11 +2,13 @@ import os.path
 import unittest
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 import fsspec
+import numpy as np
 import xarray as xr
 
+import xcube.core.mldataset
 from test.s3test import MOTO_SERVER_ENDPOINT_URL
 from test.s3test import S3Test
 from xcube.core.mldataset import MultiLevelDataset
@@ -22,6 +24,68 @@ from xcube.util.temp import new_temp_dir
 
 ROOT_DIR = 'xcube'
 DATA_PATH = 'testing/data'
+
+
+def new_cube_data():
+    width = 360
+    height = 180
+    time_periods = 5
+    shape = (time_periods, height, width)
+    var_a = np.full(shape, 8.5, dtype=np.float64)
+    var_b = np.full(shape, 9.5, dtype=np.float64)
+    var_c = np.full(shape, 255, dtype=np.uint8)
+
+    var_a[0, 0, 0] = np.nan
+    var_b[0, 0, 0] = np.nan
+
+    cube = new_cube(width=width,
+                    height=height,
+                    time_periods=time_periods,
+                    variables=dict(var_a=var_a,
+                                   var_b=var_b,
+                                   var_c=var_c))
+
+    cube.var_b.encoding['dtype'] = np.int16
+    cube.var_b.encoding['_FillValue'] = -9999
+    cube.var_b.encoding['scale_factor'] = 0.001
+    cube.var_b.encoding['add_offset'] = -10
+
+    return cube.chunk(dict(time=1, lat=90, lon=180))
+
+
+class NewCubeDataTestMixin(unittest.TestCase):
+    def test_new_cube_data_encoding(self):
+        data = new_cube_data()
+        path = f'{DATA_PATH}/data.zarr'
+        data.to_zarr(path, mode="w")
+
+        data_1 = xr.open_zarr(path)
+        self.assertEqual(np.float64, data_1.var_a.dtype)
+        self.assertEqual(np.float32, data_1.var_b.dtype)
+        self.assertEqual(np.uint8, data_1.var_c.dtype)
+
+        self.assertTrue(np.isnan(data_1.var_a[0, 0, 0]))
+        self.assertEqual(8.5, data_1.var_a[1, 0, 0].values)
+        self.assertTrue(np.isnan(data_1.var_b[0, 0, 0]))
+        self.assertEqual(9.5, data_1.var_b[1, 0, 0].values)
+        self.assertEqual(255, data_1.var_c[0, 0, 0].values)
+        self.assertEqual(255, data_1.var_c[1, 0, 0].values)
+
+        data_2 = xr.open_zarr(path, mask_and_scale=False)
+        self.assertEqual(np.float64, data_2.var_a.dtype)
+        self.assertEqual(np.int16, data_2.var_b.dtype)
+        self.assertEqual(np.uint8, data_2.var_c.dtype)
+
+        scale_factor = 0.001
+        add_offset = -10
+
+        self.assertTrue(np.isnan(data_2.var_a[0, 0, 0]))
+        self.assertEqual(8.5, data_2.var_a[1, 0, 0].values)
+        self.assertEqual(-9999, data_2.var_b[0, 0, 0].values)
+        self.assertEqual((9.5 - add_offset) / scale_factor,
+                         data_2.var_b[1, 0, 0].values)
+        self.assertEqual(255, data_2.var_c[0, 0, 0].values)
+        self.assertEqual(255, data_2.var_c[1, 0, 0].values)
 
 
 # noinspection PyUnresolvedReferences,PyPep8Naming
@@ -70,58 +134,93 @@ class FsDataStoresTestMixin(ABC):
 
     def assertMultiLevelDatasetFormatSupported(self,
                                                data_store: MutableDataStore):
-        self.assertDatasetSupported(data_store,
-                                    '.levels',
-                                    'mldataset',
-                                    MultiLevelDataset,
-                                    MultiLevelDatasetDescriptor)
+        self.assertDatasetSupported(
+            data_store,
+            '.levels',
+            'mldataset',
+            MultiLevelDataset,
+            MultiLevelDatasetDescriptor,
+            assert_data_ok=self.assertMultiLevelDatasetDataOk
+        )
 
         # Test that use_saved_levels works
-        self.assertDatasetSupported(data_store,
-                                    '.levels',
-                                    'mldataset',
-                                    MultiLevelDataset,
-                                    MultiLevelDatasetDescriptor,
-                                    write_params=dict(
-                                        use_saved_levels=True,
-                                    ))
+        self.assertDatasetSupported(
+            data_store,
+            '.levels',
+            'mldataset',
+            MultiLevelDataset,
+            MultiLevelDatasetDescriptor,
+            write_params=dict(
+                use_saved_levels=True,
+            ),
+            assert_data_ok=self.assertMultiLevelDatasetDataOk
+        )
 
     def assertMultiLevelDatasetFormatWithLinkSupported(
             self,
             data_store: MutableDataStore
     ):
-        base_dataset = self.new_cube_data()
+        base_dataset = new_cube_data()
         base_dataset_id = f'{DATA_PATH}/base-ds.zarr'
         data_store.write_data(base_dataset, base_dataset_id)
 
         # Test that base_dataset_id works
-        self.assertDatasetSupported(data_store,
-                                    '.levels',
-                                    'mldataset',
-                                    MultiLevelDataset,
-                                    MultiLevelDatasetDescriptor,
-                                    write_params=dict(
-                                        base_dataset_id=base_dataset_id,
-                                    ))
+        self.assertDatasetSupported(
+            data_store,
+            '.levels',
+            'mldataset',
+            MultiLevelDataset,
+            MultiLevelDatasetDescriptor,
+            write_params=dict(
+                base_dataset_id=base_dataset_id,
+            ),
+            assert_data_ok=self.assertMultiLevelDatasetDataOk
+        )
 
         # Test that base_dataset_id + use_saved_levels works
-        self.assertDatasetSupported(data_store,
-                                    '.levels',
-                                    'mldataset',
-                                    MultiLevelDataset,
-                                    MultiLevelDatasetDescriptor,
-                                    write_params=dict(
-                                        base_dataset_id=base_dataset_id,
-                                        use_saved_levels=True,
-                                    ))
+        self.assertDatasetSupported(
+            data_store,
+            '.levels',
+            'mldataset',
+            MultiLevelDataset,
+            MultiLevelDatasetDescriptor,
+            write_params=dict(
+                base_dataset_id=base_dataset_id,
+                use_saved_levels=True,
+            ),
+            assert_data_ok=self.assertMultiLevelDatasetDataOk
+        )
 
         data_store.delete_data(base_dataset_id)
+
+    def assertMultiLevelDatasetDataOk(
+            self,
+            ml_dataset: xcube.core.mldataset.MultiLevelDataset
+    ):
+        self.assertEqual(2, ml_dataset.num_levels)
+        for level in range(ml_dataset.num_levels):
+            dataset = ml_dataset.get_dataset(level)
+            self.assertEqual({'var_a', 'var_b', 'var_c'},
+                             set(dataset.data_vars))
+            self.assertEqual(np.float64,
+                             dataset.var_a.encoding.get('dtype'))
+            self.assertEqual(np.int16,
+                             dataset.var_b.encoding.get('dtype'))
+            self.assertEqual(np.uint8,
+                             dataset.var_c.encoding.get('dtype'))
+            self.assertTrue(np.isnan(
+                dataset.var_a.encoding.get('_FillValue')
+            ))
+            self.assertEqual(-9999,
+                             dataset.var_b.encoding.get('_FillValue'))
+            self.assertEqual(None,
+                             dataset.var_c.encoding.get('_FillValue'))
 
     def assertMultiLevelDatasetFormatWithTileSize(
             self,
             data_store: MutableDataStore
     ):
-        base_dataset = self.new_cube_data()
+        base_dataset = new_cube_data()
         base_dataset_id = f'{DATA_PATH}/base-ds.zarr'
         data_store.write_data(base_dataset, base_dataset_id)
 
@@ -170,6 +269,7 @@ class FsDataStoresTestMixin(ABC):
             ],
             write_params: Optional[Dict[str, Any]] = None,
             open_params: Optional[Dict[str, Any]] = None,
+            assert_data_ok: Optional[Callable[[Any], Any]] = None
     ):
         """
         Call all DataStore operations to ensure data of type
@@ -183,6 +283,7 @@ class FsDataStoresTestMixin(ABC):
         :param expected_descriptor_type: The expected data descriptor type.
         :param write_params: Optional write parameters
         :param open_params: Optional open parameters
+        :param assert_data_ok: Optional function to assert read data is ok
         """
 
         data_id = f'{DATA_PATH}/ds{filename_ext}'
@@ -200,7 +301,7 @@ class FsDataStoresTestMixin(ABC):
         self.assertEqual(False, data_store.has_data(data_id))
         self.assertNotIn(data_id, set(data_store.get_data_ids()))
 
-        data = self.new_cube_data()
+        data = new_cube_data()
         written_data_id = data_store.write_data(data, data_id, **write_params)
         self.assertEqual(data_id, written_data_id)
 
@@ -218,6 +319,8 @@ class FsDataStoresTestMixin(ABC):
 
         data = data_store.open_data(data_id, **open_params)
         self.assertIsInstance(data, expected_type)
+        if assert_data_ok:
+            assert_data_ok(data)
 
         try:
             data_store.delete_data(data_id)
@@ -228,11 +331,6 @@ class FsDataStoresTestMixin(ABC):
             data_store.get_data_types_for_data(data_id)
         self.assertEqual(False, data_store.has_data(data_id))
         self.assertNotIn(data_id, set(data_store.get_data_ids()))
-
-    @staticmethod
-    def new_cube_data():
-        cube = new_cube(variables=dict(A=8.5, B=9.5))
-        return cube.chunk(dict(time=1, lat=90, lon=180))
 
 
 class FileFsDataStoresTest(FsDataStoresTestMixin, unittest.TestCase):
@@ -265,3 +363,4 @@ class S3FsDataStoresTest(FsDataStoresTestMixin, S3Test):
                                  root=root,
                                  max_depth=3,
                                  storage_options=storage_options)
+

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -69,7 +69,7 @@ ZARR_OPEN_DATA_PARAMS_SCHEMA = JsonObjectSchema(
         mask_and_scale=JsonBooleanSchema(
             description='If True, replace array values equal'
                         ' to attribute "_FillValue" with NaN. '
-                        ' Use "scaling_factor" and "add_offset"'
+                        ' Use "scale_factor" and "add_offset"'
                         ' attributes to compute actual values.',
             default=True,
         ),


### PR DESCRIPTION
Extended multi-level dataset tests to ensure encodings are retained.

Closes #643

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
