### PR TITLE
Pyramids may contain any variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Enhancements
 
+* Added new module `xcube.core.subsampling` for function
+  `subsample_dataset(dataset, step)` that is now used by default 
+  to generate the datasets level of multi-level datasets.
+
 * Added new setting `Authentication.IsRequired` to the `xcube serve` 
   configuration. If set to `true`, xcube Server will reject unauthorized 
   dataset requests by returning HTTP code 401.
@@ -42,6 +46,9 @@
 * `xcube gen2` returns more expressive error messages.
   
 ### Fixes
+
+* Fixed problem where the dataset levels of multi-level datasets were 
+  written without spatial coordinate reference system. (#646)
 
 * Fixed problem where xcube Server instances that required 
   user authentication published datasets and variables for 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,8 @@
 ### Fixes
 
 * Fixed problem where the dataset levels of multi-level datasets were 
-  written without spatial coordinate reference system. (#646)
+  written without spatial coordinate reference system. In fact, 
+  only spatial variables were written. (#646)
 
 * Fixed problem where xcube Server instances that required 
   user authentication published datasets and variables for 

--- a/test/core/test_subsampling.py
+++ b/test/core/test_subsampling.py
@@ -1,0 +1,80 @@
+#  The MIT License (MIT)
+#  Copyright (c) 2022 by the xcube development team and contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+import unittest
+
+import numpy as np
+import xarray as xr
+
+from xcube.core.new import new_cube
+from xcube.core.subsampling import get_dataset_subsampling_slices
+from xcube.core.subsampling import subsample_dataset
+
+
+class SubsampleDatasetTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        test_data = np.array([[1, 2, 3, 4, 5, 6],
+                              [2, 3, 4, 5, 6, 7],
+                              [3, 4, 5, 6, 7, 8],
+                              [4, 5, 6, 7, 8, 9]])
+        test_data = np.stack([test_data, test_data + 10])
+        self.dataset = new_cube(width=6,
+                                height=4,
+                                x_name='x',
+                                y_name='y',
+                                time_periods=2,
+                                crs='CRS84',
+                                crs_name='spatial_ref',
+                                variables=dict(test_var=test_data))
+
+    def test_get_dataset_subsampling_slices(self):
+        slices = get_dataset_subsampling_slices(self.dataset,
+                                                step=2)
+        self.assertEqual(
+            {'test_var': (slice(None, None, None),
+                          slice(None, None, 2),
+                          slice(None, None, 2))
+             },
+            slices)
+
+    def test_subsample_dataset(self):
+        subsampled_dataset = subsample_dataset(self.dataset,
+                                               step=2)
+        self.assertIsInstance(subsampled_dataset, xr.Dataset)
+        self.assertIn('spatial_ref',
+                      subsampled_dataset)
+        self.assertIn('grid_mapping_name',
+                      subsampled_dataset.spatial_ref.attrs)
+        self.assertIn('test_var',
+                      subsampled_dataset)
+        self.assertIn('grid_mapping',
+                      subsampled_dataset.test_var.attrs)
+        np.testing.assert_array_equal(
+            subsampled_dataset.test_var.values,
+            np.array([
+                [[1, 3, 5],
+                 [3, 5, 7]],
+
+                [[11, 13, 15],
+                 [13, 15, 17]]
+            ])
+        )

--- a/xcube/core/new.py
+++ b/xcube/core/new.py
@@ -51,7 +51,8 @@ def new_cube(title='Test Cube',
              use_cftime=False,
              drop_bounds=False,
              variables=None,
-             crs=None):
+             crs=None,
+             crs_name=None):
     """
     Create a new empty cube. Useful for creating cubes templates with
     predefined coordinate variables and metadata. The function is also
@@ -99,6 +100,8 @@ def new_cube(title='Test Cube',
         None by default.
     :param crs: pyproj-compatible CRS string or instance
         of pyproj.CRS or None
+    :param crs_name: Name of the variable that will
+        hold the CRS information. Ignored, if *crs* is not given.
     :return: A cube instance
     """
     y_dtype = y_dtype if y_dtype is not None else y_dtype
@@ -254,6 +257,9 @@ def new_cube(title='Test Cube',
         crs = pyproj.CRS.from_string(crs)
 
     if isinstance(crs, pyproj.CRS):
-        data_vars['crs'] = xr.DataArray(0, attrs=crs.to_cf())
+        crs_name = crs_name or 'crs'
+        for v in data_vars.values():
+            v.attrs['grid_mapping'] = crs_name
+        data_vars[crs_name] = xr.DataArray(0, attrs=crs.to_cf())
 
     return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -91,7 +91,6 @@ def get_dataset_subsampling_slices(
     for var_name, var in dataset.data_vars.items():
         var_index = slices_dict.get(var.dims)
         if var_index is None:
-            var_index = None
             for index, dim_name in enumerate(var.dims):
                 if dim_name == x_dim_name or dim_name == y_dim_name:
                     if var_index is None:

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -1,0 +1,107 @@
+#  The MIT License (MIT)
+#  Copyright (c) 2022 by the xcube development team and contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#
+from typing import Dict, Tuple, Hashable, Optional
+
+import xarray as xr
+
+from xcube.util.assertions import assert_instance
+
+
+def subsample_dataset(
+        dataset: xr.Dataset,
+        step: int,
+        xy_dim_names: Optional[Tuple[str, str]] = None,
+) -> xr.Dataset:
+    """
+    Subsample *dataset* with given integer subsampling *step*.
+    Only data variables with spatial dimensions given by
+    *xy_dim_names* are subsampled.
+
+    :param dataset: the dataset providing the variables
+    :param step: the integer subsampling step
+    :param xy_dim_names: the spatial dimension names
+    """
+    assert_instance(dataset, xr.Dataset, name='dataset')
+    assert_instance(step, int, name='step')
+    var_slices = get_dataset_subsampling_slices(dataset,
+                                                step,
+                                                xy_dim_names)
+    if not var_slices:
+        return dataset
+    return xr.Dataset(
+        data_vars={
+            var_name: (var[var_slices[var_name]]
+                       if var_name in var_slices else var)
+            for var_name, var in dataset.data_vars.items()
+        },
+        attrs=dataset.attrs
+    )
+
+
+_EMPTY_SLICE = slice(None, None, None)
+
+
+def get_dataset_subsampling_slices(
+        dataset: xr.Dataset,
+        step: int,
+        xy_dim_names: Optional[Tuple[str, str]] = None
+) -> Dict[Hashable, Optional[Tuple[slice, ...]]]:
+    """
+    Compute subsampling slices for variables in *dataset*.
+    Only data variables with spatial dimensions given by
+    *xy_dim_names* are considered.
+
+    :param dataset: the dataset providing the variables
+    :param step: the integer subsampling step
+    :param xy_dim_names: the spatial dimension names
+    """
+    assert_instance(dataset, xr.Dataset, name='dataset')
+    assert_instance(step, int, name='step')
+    x_dim_name, y_dim_name = xy_dim_names or ('x', 'y')
+    slices_dict: Dict[Tuple[Hashable, ...], Tuple[slice, ...]] = dict()
+    vars_dict: Dict[Hashable, Optional[Tuple[slice, ...]]] = dict()
+    for var_name, var in dataset.data_vars.items():
+        var_index = slices_dict.get(var.dims)
+        if var_index is None:
+            var_index = None
+            for index, dim_name in enumerate(var.dims):
+                if dim_name == x_dim_name or dim_name == y_dim_name:
+                    if var_index is None:
+                        var_index = index * [_EMPTY_SLICE]
+                    var_index.append(slice(None, None, step))
+                elif var_index is not None:
+                    var_index.append(_EMPTY_SLICE)
+            if var_index is not None:
+                var_index = tuple(var_index)
+                slices_dict[var.dims] = tuple(var_index)
+        if var_index is not None:
+            vars_dict[var_name] = var_index
+    return vars_dict

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -19,15 +19,6 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-#
-#  Permission is hereby granted, free of charge, to any person obtaining a
-#  copy of this software and associated documentation files (the "Software"),
-#  to deal in the Software without restriction, including without limitation
-#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-#  and/or sell copies of the Software, and to permit persons to whom the
-#  Software is furnished to do so, subject to the following conditions:
-#
-#
 from typing import Dict, Tuple, Hashable, Optional
 
 import xarray as xr
@@ -66,7 +57,7 @@ def subsample_dataset(
     )
 
 
-_EMPTY_SLICE = slice(None, None, None)
+_FULL_SLICE = slice(None, None, None)
 
 
 def get_dataset_subsampling_slices(
@@ -94,10 +85,10 @@ def get_dataset_subsampling_slices(
             for index, dim_name in enumerate(var.dims):
                 if dim_name == x_dim_name or dim_name == y_dim_name:
                     if var_index is None:
-                        var_index = index * [_EMPTY_SLICE]
+                        var_index = index * [_FULL_SLICE]
                     var_index.append(slice(None, None, step))
                 elif var_index is not None:
-                    var_index.append(_EMPTY_SLICE)
+                    var_index.append(_FULL_SLICE)
             if var_index is not None:
                 var_index = tuple(var_index)
                 slices_dict[var.dims] = tuple(var_index)


### PR DESCRIPTION
In this PR:

* Fixed problem where the dataset levels of multi-level datasets were written without spatial coordinate reference system. In fact, only spatial variables were written.

* Added new module `xcube.core.subsampling` for function `subsample_dataset(dataset, step)` that is now used by default to generate the datasets level of multi-level datasets.

Closes #646.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

Remember to close associated issues after merge!