### PR TITLE
Use "xcube level" tool with S3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,15 +27,16 @@
   Zarr dataset. (#629)
 
 * Support for multi-level datasets has been improved:
-  - Introduced parameter `base_dataset_id` for writing multi-level 
-    datasets with the "file", "s3", and "memory" data stores. 
-    If given, the base dataset will be linked only with the 
-    value of `base_dataset_id`, instead of being copied as-is.
-    This can save large amounts of storage space. (#617)
-  - Introduced parameter `tile_size` for writing multi-level 
-    datasets with the "file", "s3", and "memory" data stores. 
-    If given, it forces the spatial dimensions to use the specified 
-    chunking.
+  - Introduced new parameters for writing multi-level datasets with the 
+    "file", "s3", and "memory" data stores. They are 
+    + `base_dataset_id`: If given, the base dataset will be linked only 
+      with the value of `base_dataset_id`, instead of being copied as-is.
+      This can save large amounts of storage space. (#617)
+    + `tile_size`: If given, it forces the spatial dimensions to be 
+       chunked accordingly. `tile_size` can be a positive integer 
+       or a pair of positive integers.
+    + `num_levels`: If given, restricts the number of resolution levels 
+       to the given value. Must be a positive integer to be effective.
   - Added a new example notebook 
     [5_multi_level_datasets.ipynb](https://github.com/dcs4cop/xcube/blob/master/examples/notebooks/datastores/5_multi_level_datasets.ipynb) 
     that demonstrates writing and opening multi-level datasets with the 
@@ -64,6 +65,26 @@
   now tiled correctly. (#626)
 
 ### Other
+
+* The `xcube level` CLI tool has been rewritten from scratch to make use 
+  of xcube filesystem data stores. (#617)
+
+* Deprecated numerous classes and functions around multi-level datasets.
+  The non-deprecated functions and classes of `xcube.core.mldataset` should 
+  be used instead along with the xcube filesystem data stores for 
+  multi-level dataset i/o. (#516)
+  - Deprecated all functions of the `xcube.core.level` module
+    + `compute_levels()`
+    + `read_levels()`
+    + `write_levels()`
+  - Deprecated numerous classes and functions of the `xcube.core.mldataset`
+    module
+    + `FileStorageMultiLevelDataset`
+    + `ObjectStorageMultiLevelDataset`
+    + `open_ml_dataset()`
+    + `open_ml_dataset_from_object_storage()`
+    + `open_ml_dataset_from_local_fs()`
+    + `write_levels()`
 
 * Added packages `python-blosc` and `lz4` to the xcube Python environment 
   for better support of Dask `distributed` and the Dask service 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,10 +28,10 @@
 
 * Support for multi-level datasets has been improved:
   - Introduced new parameters for writing multi-level datasets with the 
-    "file", "s3", and "memory" data stores. They are 
+    "file", "s3", and "memory" data stores (#617). They are 
     + `base_dataset_id`: If given, the base dataset will be linked only 
       with the value of `base_dataset_id`, instead of being copied as-is.
-      This can save large amounts of storage space. (#617)
+      This can save large amounts of storage space. 
     + `tile_size`: If given, it forces the spatial dimensions to be 
        chunked accordingly. `tile_size` can be a positive integer 
        or a pair of positive integers.

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - cmocean >=2.0
   - dask >=2021.6
   - dask-image >=0.6
+  - deprecated >=1.2
   - distributed >=2021.6
   - fiona >=1.8
   - fontconfig <2.13.96  # temporary workaround for Mac CI bug; see Issue #640

--- a/test/cli/helpers.py
+++ b/test/cli/helpers.py
@@ -1,6 +1,6 @@
 import unittest
 from abc import ABCMeta
-from typing import List
+from typing import List, Dict, Optional
 
 import click
 import click.testing
@@ -28,10 +28,15 @@ class CliDataTest(CliTest, metaclass=ABCMeta):
     def time_periods(self) -> int:
         return 5
 
+    def chunks(self) -> Optional[Dict[str, int]]:
+        return None
+
     def setUp(self):
         self._rm_outputs()
         dataset = new_cube(variables=dict(precipitation=0.4, temperature=275.2, soil_moisture=0.5),
                            time_periods=self.time_periods())
+        if self.chunks() is not None:
+            dataset = dataset.chunk(self.chunks())
         dataset.to_netcdf(TEST_NC_FILE, mode="w")
         dataset.to_zarr(TEST_ZARR_DIR, mode="w")
 

--- a/test/cli/test_level.py
+++ b/test/cli/test_level.py
@@ -1,11 +1,11 @@
 import os.path
-from typing import List, Tuple
+from typing import List, Tuple, Optional, Dict
 
 from test.cli.helpers import CliDataTest
 from test.cli.helpers import CliTest
 from test.cli.helpers import TEST_NC_FILE, TEST_ZARR_DIR
-from xcube.core.level import read_levels
-from xcube.core.verify import assert_cube
+from xcube.core.mldataset import MultiLevelDataset
+from xcube.core.store import new_fs_data_store
 
 
 class LevelTest(CliTest):
@@ -21,15 +21,16 @@ class LevelDataTest(CliDataTest):
     def outputs(self) -> List[str]:
         return [LevelDataTest.TEST_OUTPUT, 'my.levels']
 
+    def chunks(self) -> Optional[Dict[str, int]]:
+        return dict(time=1, lat=90, lon=180)
+
     def test_all_defaults(self):
         result = self.invoke_cli(['level', TEST_ZARR_DIR])
         self._assert_result_ok(
             result, [((1, 1, 1, 1, 1), (90, 90), (180, 180)),
                      ((1, 1, 1, 1, 1), (90,), (180,))],
             LevelDataTest.TEST_OUTPUT,
-            'Level 1 of 2 written after .*\n'
-            'Level 2 of 2 written after .*\n'
-            '2 level\(s\) written into test.levels after .*\n'
+            'Multi-level dataset written to /test.levels after .*\n'
         )
 
     def test_with_output(self):
@@ -38,9 +39,7 @@ class LevelDataTest(CliDataTest):
         self._assert_result_ok(
             result, [((1, 1, 1, 1, 1), (90, 90), (180, 180)),
                      ((1, 1, 1, 1, 1), (90,), (180,))], 'my.levels',
-            'Level 1 of 2 written after .*\n'
-            'Level 2 of 2 written after .*\n'
-            '2 level\(s\) written into my.levels after .*\n'
+            'Multi-level dataset written to my.levels after .*\n'
         )
 
     def test_with_tile_size_and_num_levels(self):
@@ -51,10 +50,7 @@ class LevelDataTest(CliDataTest):
                      ((1, 1, 1, 1, 1), (45, 45), (90, 90)),
                      ((1, 1, 1, 1, 1), (45,), (90,))],
             LevelDataTest.TEST_OUTPUT,
-            'Level 1 of 3 written after .*\n'
-            'Level 2 of 3 written after .*\n'
-            'Level 3 of 3 written after .*\n'
-            '3 level\(s\) written into test.levels after .*\n'
+            'Multi-level dataset written to /test.levels after .*\n'
         )
 
     def _assert_result_ok(self,
@@ -65,10 +61,12 @@ class LevelDataTest(CliDataTest):
         self.assertEqual(0, result.exit_code)
         self.assertRegex(result.stdout, message_regex)
         self.assertTrue(os.path.isdir(output_path))
-        level_datasets = read_levels(output_path)
-        level = 0
-        for level_dataset in level_datasets:
-            assert_cube(level_dataset)
+        data_store = new_fs_data_store("file")
+        ml_dataset = data_store.open_data(output_path)
+        self.assertIsInstance(ml_dataset, MultiLevelDataset)
+        self.assertEqual(len(level_chunks), ml_dataset.num_levels)
+        for level in range(ml_dataset.num_levels):
+            level_dataset = ml_dataset.get_dataset(level)
             self.assertEqual({'precipitation',
                               'soil_moisture',
                               'temperature'},
@@ -78,7 +76,6 @@ class LevelDataTest(CliDataTest):
                 self.assertEqual(var_chunks,
                                  var.chunks,
                                  f'{var_name} at level {level}')
-            level += 1
 
     def _assert_result_not_ok(self, result, message_regex: str):
         self.assertEqual(1, result.exit_code)
@@ -168,12 +165,14 @@ class LevelDataTest(CliDataTest):
                                   TEST_NC_FILE])
         self._assert_result_not_ok(
             result,
-            "NUM_LEVELS_MAX must be a positive integer\n"
+            "NUM_LEVELS must be a positive integer\n"
         )
 
     def test_with_existing_output(self):
-        result = self.invoke_cli(['level', TEST_ZARR_DIR,
-                                  '--output', 'my.levels'])
+        # Product output
+        self.invoke_cli(['level', TEST_ZARR_DIR,
+                         '--output', 'my.levels'])
+        # Product output once mor
         result = self.invoke_cli(['level', TEST_ZARR_DIR,
                                   '--output', 'my.levels'])
         self._assert_result_not_ok(

--- a/test/cli/test_level.py
+++ b/test/cli/test_level.py
@@ -165,7 +165,7 @@ class LevelDataTest(CliDataTest):
                                   TEST_NC_FILE])
         self._assert_result_not_ok(
             result,
-            "NUM_LEVELS must be a positive integer\n"
+            "NUM_LEVELS_MAX must be a positive integer\n"
         )
 
     def test_with_existing_output(self):

--- a/test/core/test_mldataset.py
+++ b/test/core/test_mldataset.py
@@ -68,7 +68,7 @@ class CombinedMultiLevelDatasetTest(unittest.TestCase):
 
 
 class BaseMultiLevelDatasetTest(unittest.TestCase):
-    def test_it(self):
+    def test_ok(self):
         ds = _get_test_dataset()
 
         ml_ds = BaseMultiLevelDataset(ds)
@@ -98,6 +98,15 @@ class BaseMultiLevelDatasetTest(unittest.TestCase):
         self.assertEqual([ds0, ds1, ds2], ml_ds.datasets)
 
         ml_ds.close()
+
+    def test_fail(self):
+        ds = _get_test_dataset()
+        with self.assertRaises(TypeError):
+            BaseMultiLevelDataset('test.levels')
+        with self.assertRaises(TypeError):
+            BaseMultiLevelDataset(ds, tile_grid=512)
+        with self.assertRaises(TypeError):
+            BaseMultiLevelDataset(ds, grid_mapping='crs84')
 
 
 class ComputedMultiLevelDatasetTest(unittest.TestCase):

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Optional, Tuple
+
 import click
 
 DEFAULT_TILE_SIZE = 512
@@ -28,7 +30,9 @@ DEFAULT_TILE_SIZE = 512
 @click.command(name="level")
 @click.argument('input')
 @click.option('--output', '-o', metavar='OUTPUT',
-              help='Output path. If omitted, "INPUT.levels" will be used.')
+              help='Output path. If omitted, "INPUT.levels" will be used.'
+                   ' You can also use S3 object storage URLs of the form'
+                   ' "s3://<bucket>/<path>" or "https://<endpoint>"')
 @click.option('--link', '-L', is_flag=True, flag_value=True,
               help='Link the INPUT instead of converting it to a level'
                    ' zero dataset. Use with care, as the INPUT\'s internal'
@@ -46,40 +50,39 @@ DEFAULT_TILE_SIZE = 512
               help=f'Maximum number of levels to generate. '
                    f'If not given, the number of levels will'
                    f' be derived from spatial dimension and tile sizes.')
-def level(input, output, link, tile_size, num_levels_max):
+@click.option('--replace', '-r', is_flag=True, flag_value=True,
+              help=f'Whether to replace an existing dataset at OUTPUT.')
+@click.option('--anon', '-a', is_flag=True, flag_value=True,
+              help=f'For S3 inputs or outputs, whether the access'
+                   f' is anonymous. By default, credentials are required.')
+def level(input: str,
+          output: Optional[str],
+          link: bool,
+          tile_size: Optional[str],
+          num_levels_max: int,
+          replace: bool,
+          anon: bool):
     """
     Generate multi-resolution levels.
+
     Transform the given dataset by INPUT into the levels of a
     multi-level pyramid with spatial resolution decreasing by a
     factor of two in both spatial dimensions and write the
     result to directory OUTPUT.
+
+    INPUT may be an S3 object storage URL of the form
+    "s3://<bucket>/<path>" or "https://<endpoint>".
     """
     import time
     import os
     from xcube.cli.common import parse_cli_sequence
     from xcube.cli.common import assert_positive_int_item
-    from xcube.core.level import write_levels
+    from xcube.core.store import new_fs_data_store
 
     input_path = input
     output_path = output
     link_input = link
 
-    if num_levels_max is not None and num_levels_max < 1:
-        raise click.ClickException(
-            f"NUM_LEVELS_MAX must be a positive integer"
-        )
-
-    if not output_path:
-        dir_path = os.path.dirname(input_path)
-        basename, ext = os.path.splitext(os.path.basename(input_path))
-        output_path = os.path.join(dir_path, basename + ".levels")
-
-    if os.path.exists(output_path):
-        raise click.ClickException(
-            f"output {output_path!r} already exists"
-        )
-
-    spatial_tile_shape = None
     if tile_size is not None:
         tile_size = parse_cli_sequence(
             tile_size,
@@ -88,22 +91,60 @@ def level(input, output, link, tile_size, num_levels_max):
             item_parser=int,
             item_validator=assert_positive_int_item
         )
-        spatial_tile_shape = tile_size[1], tile_size[0]
 
-    start_time = t0 = time.perf_counter()
+    if num_levels_max is not None and num_levels_max < 1:
+        raise click.ClickException(
+            f"NUM_LEVELS_MAX must be a positive integer"
+        )
 
-    # noinspection PyUnusedLocal
-    def progress_monitor(dataset, index, num_levels):
-        nonlocal t0
-        print(f"Level {index + 1} of {num_levels} written"
-              f" after {time.perf_counter() - t0} seconds")
-        t0 = time.perf_counter()
+    input_protocol, input_path = _split_protocol_and_path(input_path)
 
-    levels = write_levels(output_path,
-                          input_path=input_path,
-                          link_input=link_input,
-                          progress_monitor=progress_monitor,
-                          spatial_tile_shape=spatial_tile_shape,
-                          num_levels_max=num_levels_max)
-    print(f"{len(levels)} level(s) written into {output_path}"
-          f" after {time.perf_counter() - start_time} seconds")
+    if not output_path:
+        dir_path = os.path.dirname(input_path).replace("\\", "/")
+        basename, ext = os.path.splitext(os.path.basename(input_path))
+        output_protocol = input_protocol
+        output_path = f'{dir_path}/{basename + ".levels"}'
+    else:
+        output_protocol, output_path = _split_protocol_and_path(output_path)
+
+    if link_input and input_protocol != output_protocol:
+        raise click.ClickException('Links can be used only'
+                                   ' if input and output are in'
+                                   ' the same filesystem')
+
+    start_time = time.time()
+
+    input_store = new_fs_data_store(input_protocol,
+                                    storage_options=dict(anon=anon)
+                                    if input_protocol == 's3' else None)
+    input_dataset = input_store.open_data(input_path)
+
+    output_store = new_fs_data_store(output_protocol,
+                                     storage_options=dict(anon=anon)
+                                     if output_protocol == 's3' else None)
+    try:
+        output_store.write_data(
+            input_dataset,
+            output_path,
+            replace=replace,
+            tile_size=tile_size,
+            num_levels=num_levels_max,
+            base_dataset_id=input_path if link_input else None,
+        )
+    except FileExistsError as e:
+        raise click.ClickException(
+            f"output {output_path!r} already exists"
+        ) from e
+
+    print(f"Multi-level dataset written to {output_path}"
+          f" after {time.time() - start_time} seconds")
+
+
+def _split_protocol_and_path(path) -> Tuple[str, str]:
+    if '://' in path:
+        protocol, path = path.split('://', 2)
+        if protocol == 'https':
+            protocol = 's3'
+    else:
+        protocol = 'file'
+    return protocol, path

--- a/xcube/core/level.py
+++ b/xcube/core/level.py
@@ -32,12 +32,12 @@ PyramidLevelCallback = Callable[[xr.Dataset, int, int], Optional[xr.Dataset]]
 _DEPRECATED_SINCE = '0.10.2'
 _DEPRECATED_READ = (
     'No longer in use. To read multi-level datasets, use:\n'
-    '>>> data_store = new_data_store("s3", ...)\n'
-    '>>> ml_dataset = data_store.read_data(path + ".levels")'
+    '>>> data_store = new_data_store("file")\n'
+    '>>> ml_dataset = data_store.open_data(path + ".levels")'
 )
 _DEPRECATED_WRITE = (
     'No longer in use. To write multi-level datasets, use:\n'
-    '>>> data_store = new_data_store("s3", ...)\n'
+    '>>> data_store = new_data_store("file")\n'
     '>>> data_store.write_data(dataset, path + ".levels")'
 )
 

--- a/xcube/core/level.py
+++ b/xcube/core/level.py
@@ -23,12 +23,26 @@ import os
 from typing import List, Callable, Sequence, Optional, Tuple
 
 import xarray as xr
+from deprecated import deprecated
 
 from xcube.core.dsio import open_dataset
 
 PyramidLevelCallback = Callable[[xr.Dataset, int, int], Optional[xr.Dataset]]
 
+_DEPRECATED_SINCE = '0.10.2'
+_DEPRECATED_READ = (
+    'No longer in use. To read multi-level datasets, use:\n'
+    '>>> data_store = new_data_store("s3", ...)\n'
+    '>>> ml_dataset = data_store.read_data(path + ".levels")'
+)
+_DEPRECATED_WRITE = (
+    'No longer in use. To write multi-level datasets, use:\n'
+    '>>> data_store = new_data_store("s3", ...)\n'
+    '>>> data_store.write_data(dataset, path + ".levels")'
+)
 
+
+@deprecated(version=_DEPRECATED_SINCE, reason=_DEPRECATED_WRITE)
 def compute_levels(
         dataset: xr.Dataset,
         spatial_dims: Tuple[str, str] = None,
@@ -135,6 +149,7 @@ def compute_levels(
     return level_datasets
 
 
+@deprecated(version=_DEPRECATED_SINCE, reason=_DEPRECATED_WRITE)
 def write_levels(output_path: str,
                  dataset: xr.Dataset = None,
                  input_path: str = None,
@@ -205,6 +220,7 @@ def write_levels(output_path: str,
                           **kwargs)
 
 
+@deprecated(version=_DEPRECATED_SINCE, reason=_DEPRECATED_READ)
 def read_levels(
         dir_path: str,
         progress_monitor: PyramidLevelCallback = None

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -147,10 +147,16 @@ class LazyMultiLevelDataset(MultiLevelDataset, metaclass=ABCMeta):
     """
 
     def __init__(self,
-                 grid_mapping: GridMapping = None,
-                 tile_grid: TileGrid = None,
-                 ds_id: str = None,
-                 parameters: Mapping[str, Any] = None):
+                 grid_mapping: Optional[GridMapping] = None,
+                 tile_grid: Optional[TileGrid] = None,
+                 ds_id: Optional[str] = None,
+                 parameters: Optional[Mapping[str, Any]] = None):
+        if grid_mapping is not None:
+            assert_instance(grid_mapping, GridMapping, name='grid_mapping')
+        if tile_grid is not None:
+            assert_instance(tile_grid, TileGrid, name='tile_grid')
+        if ds_id is not None:
+            assert_instance(ds_id, str, name='ds_id')
         self._grid_mapping = grid_mapping
         self._tile_grid = tile_grid
         self._ds_id = ds_id
@@ -500,10 +506,13 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
 
     def __init__(self,
                  base_dataset: xr.Dataset,
-                 tile_grid: TileGrid = None,
-                 ds_id: str = None):
+                 grid_mapping: Optional[GridMapping] = None,
+                 tile_grid: Optional[TileGrid] = None,
+                 ds_id: Optional[str] = None):
         assert_instance(base_dataset, xr.Dataset, name='base_dataset')
-        grid_mapping = GridMapping.from_dataset(base_dataset, tolerance=1e-4)
+        if grid_mapping is None:
+            grid_mapping = GridMapping.from_dataset(base_dataset,
+                                                    tolerance=1e-4)
         self._base_dataset = base_dataset
         super().__init__(grid_mapping=grid_mapping,
                          tile_grid=tile_grid,

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -28,6 +28,7 @@ from typing import Sequence, Any, Dict, Callable, Mapping, Optional
 import s3fs
 import xarray as xr
 import zarr
+from deprecated import deprecated
 
 from xcube.constants import FORMAT_NAME_LEVELS
 from xcube.constants import FORMAT_NAME_NETCDF4
@@ -44,6 +45,12 @@ from xcube.core.verify import assert_cube
 from xcube.util.assertions import assert_instance
 from xcube.util.perf import measure_time
 from xcube.util.tilegrid import TileGrid
+
+_DEPRECATED_VERSION = '0.10.2'
+_DEPRECATED_OPEN_ML_DATASET = ('Use xcube data store framework'
+                               ' to open multi-level datasets.')
+_DEPRECATED_WRITE_ML_DATASET = ('Use xcube data store framework'
+                                ' to write multi-level datasets.')
 
 COMPUTE_DATASET = 'compute_dataset'
 
@@ -300,6 +307,7 @@ class IdentityMultiLevelDataset(MappedMultiLevelDataset):
         super().__init__(ml_dataset, lambda ds: ds, ds_id=ds_id)
 
 
+@deprecated(version=_DEPRECATED_VERSION, reason=_DEPRECATED_OPEN_ML_DATASET)
 class FileStorageMultiLevelDataset(LazyMultiLevelDataset):
     """
     A stored multi-level dataset whose level datasets are lazily read from storage location.
@@ -376,6 +384,7 @@ class FileStorageMultiLevelDataset(LazyMultiLevelDataset):
         return tile_grid
 
 
+@deprecated(version=_DEPRECATED_VERSION, reason=_DEPRECATED_OPEN_ML_DATASET)
 class ObjectStorageMultiLevelDataset(LazyMultiLevelDataset):
     """
     A multi-level dataset whose level datasets are lazily read from object storage locations.
@@ -624,6 +633,8 @@ def guess_ml_dataset_format(path: str) -> str:
     return guess_dataset_format(path)
 
 
+# Note: only used by the "xcube tile" CLI impl.
+@deprecated(version=_DEPRECATED_VERSION, reason=_DEPRECATED_OPEN_ML_DATASET)
 def open_ml_dataset(path: str,
                     ds_id: str = None,
                     exception_type: type = ValueError,
@@ -647,7 +658,9 @@ def open_ml_dataset(path: str,
         return open_ml_dataset_from_local_fs(path, ds_id=ds_id, exception_type=exception_type, **kwargs)
 
 
+# Note: only used by open_ml_dataset()
 # noinspection PyUnusedLocal
+@deprecated(version=_DEPRECATED_VERSION, reason=_DEPRECATED_OPEN_ML_DATASET)
 def open_ml_dataset_from_object_storage(path: str,
                                         data_format: str = None,
                                         ds_id: str = None,
@@ -680,9 +693,12 @@ def open_ml_dataset_from_object_storage(path: str,
                                                   chunk_cache_capacity=chunk_cache_capacity,
                                                   exception_type=exception_type)
 
-    raise exception_type(f'Unrecognized multi-level dataset format {data_format!r} for path {path!r}')
+    raise exception_type(
+        f'Unrecognized multi-level dataset format {data_format!r} for path {path!r}')
 
 
+# Note: only used by open_ml_dataset()
+@deprecated(version=_DEPRECATED_VERSION, reason=_DEPRECATED_OPEN_ML_DATASET)
 def open_ml_dataset_from_local_fs(path: str,
                                   data_format: str = None,
                                   ds_id: str = None,
@@ -745,10 +761,15 @@ def augment_ml_dataset(ml_dataset: MultiLevelDataset,
         return CombinedMultiLevelDataset([ml_dataset, aug_ds], ds_id=orig_id)
 
 
+# Note: only used by unit-tests
+@deprecated(version=_DEPRECATED_VERSION, reason=_DEPRECATED_WRITE_ML_DATASET)
 def write_levels(ml_dataset: MultiLevelDataset,
                  levels_path: str,
                  s3_kwargs: Dict[str, Any] = None,
                  s3_client_kwargs: Dict[str, Any] = None):
+    """
+    Deprecated. Used only in xcube tests.
+    """
     tile_w, tile_h = ml_dataset.tile_grid.tile_size
     chunks = dict(time=1, lat=tile_h, lon=tile_w)
     for level in range(ml_dataset.num_levels):

--- a/xcube/core/store/__init__.py
+++ b/xcube/core/store/__init__.py
@@ -43,6 +43,7 @@ from .descriptor import MultiLevelDatasetDescriptor
 from .descriptor import VariableDescriptor
 from .descriptor import new_data_descriptor
 from .error import DataStoreError
+from .fs.registry import new_fs_data_store
 from .search import DefaultSearchMixin
 from .store import DataStore
 from .store import MutableDataStore

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -118,15 +118,18 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                 warnings.warn('tile_size is ignored for multi-level datasets')
         else:
             base_dataset: xr.Dataset = data
+            grid_mapping = None
             if tile_size is not None:
-                tile_w, tile_h = normalize_scalar_or_pair(
+                tile_size = normalize_scalar_or_pair(
                     tile_size, item_type=int, name='tile_size'
                 )
                 grid_mapping = GridMapping.from_dataset(base_dataset)
                 x_name, y_name = grid_mapping.xy_dim_names
-                base_dataset = base_dataset.chunk({x_name: tile_w,
-                                                   y_name: tile_h})
-            ml_dataset = BaseMultiLevelDataset(base_dataset)
+                base_dataset = base_dataset.chunk({x_name: tile_size[0],
+                                                   y_name: tile_size[1]})
+                grid_mapping = grid_mapping.derive(tile_size=tile_size)
+            ml_dataset = BaseMultiLevelDataset(base_dataset,
+                                               grid_mapping=grid_mapping)
         fs, root, write_params = self.load_fs(write_params)
         consolidated = write_params.pop('consolidated', True)
         use_saved_levels = write_params.pop('use_saved_levels', False)

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -118,15 +118,17 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                 warnings.warn('tile_size is ignored for multi-level datasets')
         else:
             base_dataset: xr.Dataset = data
+            grid_mapping = None
             if tile_size is not None:
                 tile_w, tile_h = normalize_scalar_or_pair(
                     tile_size, item_type=int, name='tile_size'
                 )
-                gm = GridMapping.from_dataset(base_dataset)
-                x_name, y_name = gm.xy_dim_names
+                grid_mapping = GridMapping.from_dataset(base_dataset)
+                x_name, y_name = grid_mapping.xy_dim_names
                 base_dataset = base_dataset.chunk({x_name: tile_w,
                                                    y_name: tile_h})
-            ml_dataset = BaseMultiLevelDataset(base_dataset)
+            ml_dataset = BaseMultiLevelDataset(base_dataset,
+                                               grid_mapping=grid_mapping)
         fs, root, write_params = self.load_fs(write_params)
         consolidated = write_params.pop('consolidated', True)
         use_saved_levels = write_params.pop('use_saved_levels', False)
@@ -136,6 +138,7 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
         if use_saved_levels:
             ml_dataset = BaseMultiLevelDataset(
                 ml_dataset.get_dataset(0),
+                grid_mapping=ml_dataset.grid_mapping,
                 tile_grid=ml_dataset.tile_grid
             )
 

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -118,7 +118,6 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                 warnings.warn('tile_size is ignored for multi-level datasets')
         else:
             base_dataset: xr.Dataset = data
-            grid_mapping = None
             if tile_size is not None:
                 tile_w, tile_h = normalize_scalar_or_pair(
                     tile_size, item_type=int, name='tile_size'
@@ -127,8 +126,7 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                 x_name, y_name = grid_mapping.xy_dim_names
                 base_dataset = base_dataset.chunk({x_name: tile_w,
                                                    y_name: tile_h})
-            ml_dataset = BaseMultiLevelDataset(base_dataset,
-                                               grid_mapping=grid_mapping)
+            ml_dataset = BaseMultiLevelDataset(base_dataset)
         fs, root, write_params = self.load_fs(write_params)
         consolidated = write_params.pop('consolidated', True)
         use_saved_levels = write_params.pop('use_saved_levels', False)

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -39,6 +39,7 @@ from xcube.util.jsonschema import JsonObjectSchema
 from xcube.util.jsonschema import JsonStringSchema
 from xcube.util.jsonschema import JsonNullSchema
 from xcube.util.tilegrid import TileGrid
+from xcube.util.types import normalize_scalar_or_pair
 from .dataset import DatasetZarrFsDataAccessor
 from ..helpers import get_fs_path_class
 from ..helpers import resolve_path
@@ -118,13 +119,9 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
         else:
             base_dataset: xr.Dataset = data
             if tile_size is not None:
-                try:
-                    tile_w, tile_h = tile_size
-                    assert_instance(tile_w, int, name='tile_size[0]')
-                    assert_instance(tile_h, int, name='tile_size[1]')
-                except TypeError:
-                    assert_instance(tile_size, int, name='tile_size')
-                    tile_w, tile_h = tile_size, tile_size
+                tile_w, tile_h = normalize_scalar_or_pair(
+                    tile_size, item_type=int, name='tile_size'
+                )
                 gm = GridMapping.from_dataset(base_dataset)
                 x_name, y_name = gm.xy_dim_names
                 base_dataset = base_dataset.chunk({x_name: tile_w,

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -120,10 +120,11 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
             if tile_size is not None:
                 try:
                     tile_w, tile_h = tile_size
-                except ValueError:
+                    assert_instance(tile_w, int, name='tile_size[0]')
+                    assert_instance(tile_h, int, name='tile_size[1]')
+                except TypeError:
+                    assert_instance(tile_size, int, name='tile_size')
                     tile_w, tile_h = tile_size, tile_size
-                assert_instance(tile_w, int, name='tile_size[0]')
-                assert_instance(tile_h, int, name='tile_size[1]')
                 gm = GridMapping.from_dataset(base_dataset)
                 x_name, y_name = gm.xy_dim_names
                 base_dataset = base_dataset.chunk({x_name: tile_w,


### PR DESCRIPTION
This PR closes #617 and addresses #516:

* The `xcube level` CLI tool has been rewritten from scratch to make use 
  of xcube filesystem data stores. (#617)

* Deprecated numerous classes and functions around multi-level datasets.
  The non-deprecated functions and classes of `xcube.core.mldataset` should 
  be used instead along with the xcube filesystem data stores for 
  multi-level dataset i/o. (#516)
  - Deprecated all functions of the `xcube.core.level` module
    + `compute_levels()`
    + `read_levels()`
    + `write_levels()`
  - Deprecated numerous classes and functions of the `xcube.core.mldataset`
    module
    + `FileStorageMultiLevelDataset`
    + `ObjectStorageMultiLevelDataset`
    + `open_ml_dataset()`
    + `open_ml_dataset_from_object_storage()`
    + `open_ml_dataset_from_local_fs()`
    + `write_levels()`

* Support for multi-level datasets has been improved:
  - Introduced new parameters for writing multi-level datasets with the "file", "s3", and "memory" data stores. They are 
    + ...
    + `num_levels`: If given, restricts the number of resolution levels 
       to the given value. Must be a positive integer to be effective.


Closes #617.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)

FYI @AliceBalfanz @pont-us 