### PR TITLE
Added pyramid aggregation methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 ## Changes in 0.10.3 (in development)
 
+### Enhancements
+
+* Support for multi-level datasets aka ND image pyramids has been 
+  further improved (#655):
+  - Introduced new parameter `agg_methods` for writing multi-level datasets 
+    with the "file", "s3", and "memory" data stores. 
+    The value of `agg_methods` is either a string `"first"`,
+    `"min"`, `"max"`, `"mean"`, `"median"` or a dictionary that maps
+    a variable name to an aggregation method. Variable names can be patterns
+    that may contain wildcard characters '*' and '?'. The special aggregation
+    method `"auto"` can be used to select `"first"` for integer variables 
+    and `"mean"` for floating point variables. 
+  - The `xcube level` CLI tool now has a new option `--agg-method` (or `-a`)
+    for the same purpose.
+
 ### Fixes
 
 * Fixed a problem where the `DataStores` configuration of `xcube serve` 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
     that may contain wildcard characters '*' and '?'. The special aggregation
     method `"auto"` can be used to select `"first"` for integer variables 
     and `"mean"` for floating point variables. 
-  - The `xcube level` CLI tool now has a new option `--agg-method` (or `-A`)
+  - The `xcube level` CLI tool now has a new option `--agg-methods` (or `-A`)
     for the same purpose.
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
     that may contain wildcard characters '*' and '?'. The special aggregation
     method `"auto"` can be used to select `"first"` for integer variables 
     and `"mean"` for floating point variables. 
-  - The `xcube level` CLI tool now has a new option `--agg-method` (or `-a`)
+  - The `xcube level` CLI tool now has a new option `--agg-method` (or `-A`)
     for the same purpose.
 
 ### Fixes

--- a/docs/source/cli/xcube_level.rst
+++ b/docs/source/cli/xcube_level.rst
@@ -15,14 +15,20 @@ Generate multi-resolution levels.
 
     Usage: xcube level [OPTIONS] INPUT
 
-      Generate multi-resolution levels. Transform the given dataset by INPUT
-      into the levels of a multi-level pyramid with spatial resolution
-      decreasing by a factor of two in both spatial dimensions and write the
-      result to directory OUTPUT.
+      Generate multi-resolution levels.
+
+      Transform the given dataset by INPUT into the levels of a multi-level
+      pyramid with spatial resolution decreasing by a factor of two in both
+      spatial dimensions and write the result to directory OUTPUT.
+
+      INPUT may be an S3 object storage URL of the form "s3://<bucket>/<path>" or
+      "https://<endpoint>".
 
     Options:
       -o, --output OUTPUT             Output path. If omitted, "INPUT.levels" will
-                                      be used.
+                                      be used. You can also use S3 object storage
+                                      URLs of the form "s3://<bucket>/<path>" or
+                                      "https://<endpoint>"
       -L, --link                      Link the INPUT instead of converting it to a
                                       level zero dataset. Use with care, as the
                                       INPUT's internal spatial chunk sizes may be
@@ -36,6 +42,18 @@ Generate multi-resolution levels.
                                       Maximum number of levels to generate. If not
                                       given, the number of levels will be derived
                                       from spatial dimension and tile sizes.
+      -A, --agg-methods AGG_METHODS   Aggregation method(s) to be used for data
+                                      variables. Either one of "first", "min",
+                                      "max", "mean", "median", "auto" or list of
+                                      assignments to individual variables using
+                                      the notation
+                                      "<var1>=<method1>,<var2>=<method2>,..."
+                                      Defaults to "first".
+      -r, --replace                   Whether to replace an existing dataset at
+                                      OUTPUT.
+      -a, --anon                      For S3 inputs or outputs, whether the access
+                                      is anonymous. By default, credentials are
+                                      required.
       --help                          Show this message and exit.
 
 

--- a/test/cli/test_level.py
+++ b/test/cli/test_level.py
@@ -106,7 +106,7 @@ class LevelDataTest(CliDataTest):
     def test_level_with_zarr_agg_method(self):
         result = self.invoke_cli(["level",
                                   "-t", "45",
-                                  "-a", "auto",
+                                  "-A", "auto",
                                   "-o", LevelDataTest.TEST_OUTPUT,
                                   TEST_ZARR_DIR,
                                   ])
@@ -119,7 +119,7 @@ class LevelDataTest(CliDataTest):
         result = self.invoke_cli([
             "level",
             "-t", "45",
-            "-a", "precipitation=mean,temperature=max,soil_moisture=median",
+            "-A", "precipitation=mean,temperature=max,soil_*=median",
             "-o", LevelDataTest.TEST_OUTPUT,
             TEST_ZARR_DIR,
         ])

--- a/test/cli/test_level.py
+++ b/test/cli/test_level.py
@@ -103,6 +103,31 @@ class LevelDataTest(CliDataTest):
         self.assertEqual({'0.zarr', '1.zarr', '2.zarr'},
                          set(os.listdir(LevelDataTest.TEST_OUTPUT)))
 
+    def test_level_with_zarr_agg_method(self):
+        result = self.invoke_cli(["level",
+                                  "-t", "45",
+                                  "-a", "auto",
+                                  "-o", LevelDataTest.TEST_OUTPUT,
+                                  TEST_ZARR_DIR,
+                                  ])
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isdir(LevelDataTest.TEST_OUTPUT))
+        self.assertEqual({'0.zarr', '1.zarr', '2.zarr'},
+                         set(os.listdir(LevelDataTest.TEST_OUTPUT)))
+
+    def test_level_with_zarr_agg_methods(self):
+        result = self.invoke_cli([
+            "level",
+            "-t", "45",
+            "-a", "precipitation=mean,temperature=max,soil_moisture=median",
+            "-o", LevelDataTest.TEST_OUTPUT,
+            TEST_ZARR_DIR,
+        ])
+        self.assertEqual(0, result.exit_code)
+        self.assertTrue(os.path.isdir(LevelDataTest.TEST_OUTPUT))
+        self.assertEqual({'0.zarr', '1.zarr', '2.zarr'},
+                         set(os.listdir(LevelDataTest.TEST_OUTPUT)))
+
     def test_level_with_zarr_link(self):
         result = self.invoke_cli(["level",
                                   "--link",

--- a/test/core/test_subsampling.py
+++ b/test/core/test_subsampling.py
@@ -36,15 +36,16 @@ class SubsampleDatasetTest(unittest.TestCase):
         test_data_1 = np.array([[1, 2, 3, 4, 5, 6],
                                 [2, 3, 4, 5, 6, 7],
                                 [3, 4, 5, 6, 7, 8],
-                                [4, 5, 6, 7, 8, 9]], dtype=np.int16)
+                                [4, 5, 6, 7, 8, 9],
+                                [1, 2, 3, 4, 5, 6]], dtype=np.int16)
         test_data_1 = np.stack([test_data_1, test_data_1 + 10])
         test_data_2 = 0.1 * test_data_1
-        self.dataset = new_cube(width=6,
-                                height=4,
+        self.dataset = new_cube(width=6,  # even
+                                height=5,  # odd
                                 x_name='x',
                                 y_name='y',
-                                x_start=0.,
-                                y_start=0.,
+                                x_start=0.5,
+                                y_start=1.5,
                                 x_res=1.,
                                 y_res=1.,
                                 time_periods=2,
@@ -76,18 +77,24 @@ class SubsampleDatasetTest(unittest.TestCase):
             subsampled_dataset,
             np.array([
                 [[1, 3, 5],
-                 [3, 5, 7]],
+                 [3, 5, 7],
+                 [1, 3, 5]],
 
                 [[11, 13, 15],
-                 [13, 15, 17]]
+                 [13, 15, 17],
+                 [11, 13, 15]]
             ], dtype=np.int16),
             np.array([
                 [[0.2, 0.4, 0.6],
-                 [0.4, 0.6, 0.8]],
+                 [0.4, 0.6, 0.8],
+                 [0.15, 0.35, 0.55]],
 
                 [[1.2, 1.4, 1.6],
-                 [1.4, 1.6, 1.8]]
-            ], dtype=np.float64)
+                 [1.4, 1.6, 1.8],
+                 [1.15, 1.35, 1.55]]
+            ], dtype=np.float64),
+            np.array([1., 3., 5.]),
+            np.array([2., 4., 6.]),
         )
 
     def test_subsample_dataset_first(self):
@@ -98,18 +105,24 @@ class SubsampleDatasetTest(unittest.TestCase):
             subsampled_dataset,
             np.array([
                 [[1, 3, 5],
-                 [3, 5, 7]],
+                 [3, 5, 7],
+                 [1, 3, 5]],
 
                 [[11, 13, 15],
-                 [13, 15, 17]]
+                 [13, 15, 17],
+                 [11, 13, 15]]
             ], dtype=np.int16),
             np.array([
                 [[0.1, 0.3, 0.5],
-                 [0.3, 0.5, 0.7]],
+                 [0.3, 0.5, 0.7],
+                 [0.1, 0.3, 0.5]],
 
                 [[1.1, 1.3, 1.5],
-                 [1.3, 1.5, 1.7]]
-            ], dtype=np.float64)
+                 [1.3, 1.5, 1.7],
+                 [1.1, 1.3, 1.5]]
+            ], dtype=np.float64),
+            np.array([1., 3., 5.]),
+            np.array([2., 4., 6.]),
         )
 
     def test_subsample_dataset_mean(self):
@@ -122,18 +135,24 @@ class SubsampleDatasetTest(unittest.TestCase):
             subsampled_dataset,
             np.array([
                 [[2, 4, 6],
-                 [4, 6, 8]],
+                 [4, 6, 8],
+                 [1, 3, 5]],
 
                 [[12, 14, 16],
-                 [14, 16, 18]]
+                 [14, 16, 18],
+                 [11, 13, 15]]
             ], dtype=np.int16),
             np.array([
                 [[0.2, 0.4, 0.6],
-                 [0.4, 0.6, 0.8]],
+                 [0.4, 0.6, 0.8],
+                 [0.15, 0.35, 0.55]],
 
                 [[1.2, 1.4, 1.6],
-                 [1.4, 1.6, 1.8]]
-            ], dtype=np.float64)
+                 [1.4, 1.6, 1.8],
+                 [1.15, 1.35, 1.55]]
+            ], dtype=np.float64),
+            np.array([1., 3., 5.]),
+            np.array([2., 4., 6.]),
         )
 
     def test_subsample_dataset_max(self):
@@ -144,34 +163,59 @@ class SubsampleDatasetTest(unittest.TestCase):
             subsampled_dataset,
             np.array([
                 [[3, 5, 7],
-                 [5, 7, 9]],
+                 [5, 7, 9],
+                 [2, 4, 6]],
 
                 [[13, 15, 17],
-                 [15, 17, 19]]
+                 [15, 17, 19],
+                 [12, 14, 16]]
             ], dtype=np.int16),
             np.array([
                 [[0.3, 0.5, 0.7],
-                 [0.5, 0.7, 0.9]],
+                 [0.5, 0.7, 0.9],
+                 [0.2, 0.4, 0.6]],
 
                 [[1.3, 1.5, 1.7],
-                 [1.5, 1.7, 1.9]]
-            ], dtype=np.float64)
+                 [1.5, 1.7, 1.9],
+                 [1.2, 1.4, 1.6]]
+            ], dtype=np.float64),
+            np.array([1., 3., 5.]),
+            np.array([2., 4., 6.]),
         )
 
     def assert_subsampling_ok(self,
                               subsampled_dataset: xr.Dataset,
                               expected_var_1: np.ndarray,
-                              expected_var_2: np.ndarray):
+                              expected_var_2: np.ndarray,
+                              expected_x: np.ndarray,
+                              expected_y: np.ndarray):
         self.assertIsInstance(subsampled_dataset, xr.Dataset)
         self.assertIn('spatial_ref',
                       subsampled_dataset)
         self.assertIn('grid_mapping_name',
                       subsampled_dataset.spatial_ref.attrs)
 
+        self.assertIn('x',
+                      subsampled_dataset.coords)
+        self.assertIn('y',
+                      subsampled_dataset.coords)
+
+        print(repr(subsampled_dataset.x.values))
+        print(repr(subsampled_dataset.y.values))
+
+        np.testing.assert_array_equal(
+            subsampled_dataset.x.values,
+            expected_x
+        )
+        np.testing.assert_array_almost_equal(
+            subsampled_dataset.y.values,
+            expected_y
+        )
+
         self.assertIn('var_1',
-                      subsampled_dataset)
+                      subsampled_dataset.data_vars)
         self.assertIn('var_2',
-                      subsampled_dataset)
+                      subsampled_dataset.data_vars)
 
         self.assertIn('grid_mapping',
                       subsampled_dataset.var_1.attrs)
@@ -182,6 +226,9 @@ class SubsampleDatasetTest(unittest.TestCase):
                          subsampled_dataset.var_1.dtype)
         self.assertEqual(expected_var_2.dtype,
                          subsampled_dataset.var_2.dtype)
+
+        # print(repr(subsampled_dataset.var_1.values))
+        # print(repr(subsampled_dataset.var_2.values))
 
         np.testing.assert_array_equal(
             subsampled_dataset.var_1.values,

--- a/test/core/test_subsampling.py
+++ b/test/core/test_subsampling.py
@@ -129,8 +129,6 @@ class SubsampleDatasetTest(unittest.TestCase):
         subsampled_dataset = subsample_dataset(self.dataset,
                                                step=2,
                                                agg_methods='mean')
-        print(repr(subsampled_dataset.var_1.values))
-        print(repr(subsampled_dataset.var_2.values))
         self.assert_subsampling_ok(
             subsampled_dataset,
             np.array([
@@ -200,9 +198,6 @@ class SubsampleDatasetTest(unittest.TestCase):
         self.assertIn('y',
                       subsampled_dataset.coords)
 
-        print(repr(subsampled_dataset.x.values))
-        print(repr(subsampled_dataset.y.values))
-
         np.testing.assert_array_equal(
             subsampled_dataset.x.values,
             expected_x
@@ -226,9 +221,6 @@ class SubsampleDatasetTest(unittest.TestCase):
                          subsampled_dataset.var_1.dtype)
         self.assertEqual(expected_var_2.dtype,
                          subsampled_dataset.var_2.dtype)
-
-        # print(repr(subsampled_dataset.var_1.values))
-        # print(repr(subsampled_dataset.var_2.values))
 
         np.testing.assert_array_equal(
             subsampled_dataset.var_1.values,

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -51,7 +51,7 @@ DEFAULT_AGG_METHOD = 'first'
               help=f'Maximum number of levels to generate.'
                    f' If not given, the number of levels will'
                    f' be derived from spatial dimension and tile sizes.')
-@click.option('--agg-method', '-A', metavar='AGG_METHOD',
+@click.option('--agg-methods', '-A', metavar='AGG_METHOD',
               default=DEFAULT_AGG_METHOD,
               help=f'Aggregation method. One of'
                    f' "first", "min", "max", "mean", "median" or "auto.'

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -51,10 +51,10 @@ DEFAULT_AGG_METHOD = 'first'
               help=f'Maximum number of levels to generate.'
                    f' If not given, the number of levels will'
                    f' be derived from spatial dimension and tile sizes.')
-@click.option('--agg-methods', '-A', metavar='AGG_METHOD',
+@click.option('--agg-methods', '-A', metavar='AGG_METHODS',
               default=DEFAULT_AGG_METHOD,
               help=f'Aggregation method. One of'
-                   f' "first", "min", "max", "mean", "median" or "auto.'
+                   f' "first", "min", "max", "mean", "median", or "auto.'
                    f' You can also assign a method to individual variables'
                    f' using the notation'
                    f' "<var1>=<method1>,<var2>=<method2>,..."'
@@ -109,17 +109,15 @@ def level(input: str,
         )
 
     try:
-        if '=' in agg_method:
+        if '=' in agg_methods:
             agg_methods = {
                 p[0].strip(): (p[1].strip() if len(p) == 2 else None)
                 for p in (c.split('=', maxsplit=2)
-                          for c in agg_method.split(','))
+                          for c in agg_methods.split(','))
             }
-        else:
-            agg_methods = agg_method
         assert_valid_agg_methods(agg_methods)
     except (TypeError, ValueError, SyntaxError) as e:
-        raise click.ClickException('invalid AGG_METHOD') from e
+        raise click.ClickException('invalid AGG_METHODS') from e
 
     input_protocol, input_path = _split_protocol_and_path(input_path)
 

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -26,6 +26,7 @@ import click
 DEFAULT_TILE_SIZE = 512
 DEFAULT_AGG_METHOD = 'first'
 
+
 # noinspection PyShadowingBuiltins
 @click.command(name="level")
 @click.argument('input')
@@ -50,7 +51,7 @@ DEFAULT_AGG_METHOD = 'first'
               help=f'Maximum number of levels to generate.'
                    f' If not given, the number of levels will'
                    f' be derived from spatial dimension and tile sizes.')
-@click.option('--agg-method', '-a', metavar='AGG_METHOD',
+@click.option('--agg-method', '-A', metavar='AGG_METHOD',
               default=DEFAULT_AGG_METHOD,
               help=f'Aggregation method. One of'
                    f' "first", "min", "max", "mean", "median" or "auto.'
@@ -109,7 +110,11 @@ def level(input: str,
 
     try:
         if '=' in agg_method:
-            agg_methods = eval(f'dict({agg_method})', None, None)
+            agg_methods = {
+                p[0].strip(): (p[1].strip() if len(p) == 2 else None)
+                for p in (c.split('=', maxsplit=2)
+                          for c in agg_method.split(','))
+            }
         else:
             agg_methods = agg_method
         assert_valid_agg_methods(agg_methods)

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -53,9 +53,9 @@ DEFAULT_AGG_METHOD = 'first'
                    f' be derived from spatial dimension and tile sizes.')
 @click.option('--agg-methods', '-A', metavar='AGG_METHODS',
               default=DEFAULT_AGG_METHOD,
-              help=f'Aggregation method. One of'
-                   f' "first", "min", "max", "mean", "median", or "auto.'
-                   f' You can also assign a method to individual variables'
+              help=f'Aggregation method(s) to be used for data variables.'
+                   f' Either one of "first", "min", "max", "mean", "median",'
+                   f' "auto" or list of assignments to individual variables'
                    f' using the notation'
                    f' "<var1>=<method1>,<var2>=<method2>,..."'
                    f' Defaults to "{DEFAULT_AGG_METHOD}".')

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -69,7 +69,7 @@ def level(input: str,
           link: bool,
           tile_size: Optional[str],
           num_levels_max: int,
-          agg_method: str,
+          agg_methods: str,
           replace: bool,
           anon: bool):
     """

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -512,7 +512,7 @@ class ObjectStorageMultiLevelDataset(LazyMultiLevelDataset):
 
 class BaseMultiLevelDataset(LazyMultiLevelDataset):
     """
-    A multi-level dataset whose level datasets are a
+    A multi-level dataset whose level datasets are
     created by down-sampling a base dataset.
 
     :param base_dataset: The base dataset for the level at index zero.

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -40,6 +40,7 @@ from xcube.core.dsio import parse_s3_fs_and_root
 from xcube.core.dsio import write_cube
 from xcube.core.gridmapping import GridMapping
 from xcube.core.schema import rechunk_cube
+from xcube.core.subsampling import AggMethods
 from xcube.core.subsampling import assert_valid_agg_methods
 from xcube.core.subsampling import subsample_dataset
 from xcube.core.verify import assert_cube
@@ -530,7 +531,7 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
                  base_dataset: xr.Dataset,
                  grid_mapping: Optional[GridMapping] = None,
                  tile_grid: Optional[TileGrid] = None,
-                 agg_methods: Optional[str, Dict[str, str]] = 'first',
+                 agg_methods: AggMethods = 'first',
                  ds_id: Optional[str] = None):
         assert_instance(base_dataset, xr.Dataset, name='base_dataset')
         if grid_mapping is None:

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -108,8 +108,10 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
         )
         schema.properties['agg_methods'] = JsonComplexSchema(
             one_of=[
-                JsonStringSchema(enum=[AGG_METHODS]),
-                JsonArraySchema(items=JsonStringSchema(enum=[AGG_METHODS])),
+                JsonStringSchema(enum=AGG_METHODS),
+                JsonObjectSchema(
+                    additional_properties=JsonStringSchema(enum=AGG_METHODS)
+                ),
                 JsonNullSchema(),
             ],
             description='Aggregation method for the pyramid levels.'

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -140,7 +140,7 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                 )
             if agg_methods:
                 warnings.warn(
-                    'agg_method is ignored for multi-level datasets'
+                    'agg_methods is ignored for multi-level datasets'
                 )
         else:
             base_dataset: xr.Dataset = data

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -33,6 +33,7 @@ from xcube.core.gridmapping import GridMapping
 from xcube.core.mldataset import BaseMultiLevelDataset
 from xcube.core.mldataset import LazyMultiLevelDataset
 from xcube.core.mldataset import MultiLevelDataset
+from xcube.core.subsampling import AGG_METHODS
 from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema
@@ -105,6 +106,19 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
             minimum=1,
             nullable=True,
         )
+        schema.properties['agg_methods'] = JsonComplexSchema(
+            one_of=[
+                JsonStringSchema(enum=[AGG_METHODS]),
+                JsonArraySchema(items=JsonStringSchema(enum=[AGG_METHODS])),
+                JsonNullSchema(),
+            ],
+            description='Aggregation method for the pyramid levels.'
+                        ' If not explicitly set, "first" is used for integer '
+                        ' variables and "mean" for floating point variables.'
+                        ' If given as object, it is a mapping from variable '
+                        ' name pattern to aggregation method. The pattern'
+                        ' may include wildcard characters * and ?.'
+        )
         return schema
 
     def write_data(self,
@@ -115,10 +129,17 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
         assert_instance(data, (xr.Dataset, MultiLevelDataset), name='data')
         assert_instance(data_id, str, name='data_id')
         tile_size = write_params.pop('tile_size', None)
+        agg_methods = write_params.pop('agg_methods', None)
         if isinstance(data, MultiLevelDataset):
             ml_dataset = data
             if tile_size:
-                warnings.warn('tile_size is ignored for multi-level datasets')
+                warnings.warn(
+                    'tile_size is ignored for multi-level datasets'
+                )
+            if agg_methods:
+                warnings.warn(
+                    'agg_method is ignored for multi-level datasets'
+                )
         else:
             base_dataset: xr.Dataset = data
             grid_mapping = None
@@ -132,7 +153,8 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
                                                    y_name: tile_size[1]})
                 grid_mapping = grid_mapping.derive(tile_size=tile_size)
             ml_dataset = BaseMultiLevelDataset(base_dataset,
-                                               grid_mapping=grid_mapping)
+                                               grid_mapping=grid_mapping,
+                                               agg_methods=agg_methods)
         fs, root, write_params = self.load_fs(write_params)
         consolidated = write_params.pop('consolidated', True)
         use_saved_levels = write_params.pop('use_saved_levels', False)
@@ -143,7 +165,8 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
             ml_dataset = BaseMultiLevelDataset(
                 ml_dataset.get_dataset(0),
                 grid_mapping=ml_dataset.grid_mapping,
-                tile_grid=ml_dataset.tile_grid
+                tile_grid=ml_dataset.tile_grid,
+                agg_methods=agg_methods
             )
 
         path_class = get_fs_path_class(fs)

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -175,7 +175,7 @@ def find_agg_method(agg_methods: AggMethods,
 _FULL_SLICE = slice(None, None, None)
 
 
-@deprecated(version='0.10.2', reason='no longer in use')
+@deprecated(version='0.10.3', reason='no longer in use')
 def get_dataset_subsampling_slices(
         dataset: xr.Dataset,
         step: int,

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -84,7 +84,9 @@ def subsample_dataset(
                     dim[x_name] = step
                 if y_name in var.dims:
                     dim[y_name] = step
-                var_coarsen = var.coarsen(dim=dim, boundary='trim')
+                var_coarsen = var.coarsen(dim=dim,
+                                          boundary='pad',
+                                          coord_func='min')
                 new_var: xr.DataArray = getattr(var_coarsen, agg_method)()
                 if new_var.dtype != var.dtype:
                     # We don't want, e.g. "mean", to turn data

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -25,6 +25,7 @@ from typing import Dict, Tuple, Hashable, Optional, Mapping, Union
 
 import numpy as np
 import xarray as xr
+from deprecated import deprecated
 
 from xcube.util.assertions import assert_instance, assert_in, assert_true
 
@@ -172,6 +173,7 @@ def find_agg_method(agg_methods: AggMethods,
 _FULL_SLICE = slice(None, None, None)
 
 
+@deprecated(version='0.10.2', reason='no longer in use')
 def get_dataset_subsampling_slices(
         dataset: xr.Dataset,
         step: int,

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -19,17 +19,28 @@
 #  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #  DEALINGS IN THE SOFTWARE.
 
-from typing import Dict, Tuple, Hashable, Optional
+import collections.abc
+import fnmatch
+from typing import Dict, Tuple, Hashable, Optional, Mapping, Union
 
+import numpy as np
 import xarray as xr
 
-from xcube.util.assertions import assert_instance
+from xcube.util.assertions import assert_instance, assert_in, assert_true
+
+AGG_METHODS = 'auto', 'first', 'min', 'max', 'mean', 'median'
+DEFAULT_INT_AGG_METHOD = 'first'
+DEFAULT_FLOAT_AGG_METHOD = 'mean'
+
+AggMethod = Union[None, str]
+AggMethods = Union[AggMethod, Mapping[str, AggMethod]]
 
 
 def subsample_dataset(
         dataset: xr.Dataset,
         step: int,
         xy_dim_names: Optional[Tuple[str, str]] = None,
+        agg_methods: AggMethods = None
 ) -> xr.Dataset:
     """
     Subsample *dataset* with given integer subsampling *step*.
@@ -37,24 +48,125 @@ def subsample_dataset(
     *xy_dim_names* are subsampled.
 
     :param dataset: the dataset providing the variables
-    :param step: the integer subsampling step
+    :param step: the integer subsampling step size in pixels in
+        the x and y directions.
+        For aggregation methods other than "first" it defines the
+        window size for the aggregation.
     :param xy_dim_names: the spatial dimension names
+    :param agg_methods: Optional aggregation methods.
+        May be given as string or as mapping from variable name pattern
+        to aggregation method. Valid aggregation methods are
+        "auto", "first", "min", "max", "mean", "median".
+        If "auto", the default, "first" is used for integer variables
+        and "mean" for floating point variables.
     """
     assert_instance(dataset, xr.Dataset, name='dataset')
     assert_instance(step, int, name='step')
-    var_slices = get_dataset_subsampling_slices(dataset,
-                                                step,
-                                                xy_dim_names)
-    if not var_slices:
+    assert_valid_agg_methods(agg_methods)
+
+    x_name, y_name = xy_dim_names or ('y', 'x')
+
+    new_data_vars = dict()
+    new_coords = None  # used to collect coordinates from coarsen
+    for var_name, var in dataset.data_vars.items():
+        if x_name in var.dims or y_name in var.dims:
+            agg_method = find_agg_method(agg_methods, var_name, var.dtype)
+            if agg_method == 'first':
+                slices = get_variable_subsampling_slices(
+                    var, step, xy_dim_names=xy_dim_names
+                )
+                assert slices is not None
+                new_var = var[slices]
+            else:
+                dim = dict()
+                if x_name in var.dims:
+                    dim[x_name] = step
+                if y_name in var.dims:
+                    dim[y_name] = step
+                var_coarsen = var.coarsen(dim=dim, boundary='trim')
+                new_var: xr.DataArray = getattr(var_coarsen, agg_method)()
+                if new_var.dtype != var.dtype:
+                    # We don't want, e.g. "mean", to turn data
+                    # from dtype unit16 into float64
+                    new_var = new_var.astype(var.dtype)
+                new_var.attrs.update(var.attrs)
+                new_var.encoding.update(var.encoding)
+                # coarsen() recomputes spatial coordinates.
+                # Collect them, so we can later apply them to the
+                # variables that are subsampled by "first"
+                # (= slice selection).
+                if new_coords is None:
+                    new_coords = dict(new_var.coords)
+                else:
+                    new_coords.update(new_var.coords)
+        else:
+            new_var = var
+
+        new_data_vars[var_name] = new_var
+
+    if not new_data_vars:
         return dataset
-    return xr.Dataset(
-        data_vars={
-            var_name: (var[var_slices[var_name]]
-                       if var_name in var_slices else var)
-            for var_name, var in dataset.data_vars.items()
-        },
-        attrs=dataset.attrs
-    )
+
+    if new_coords:
+        # Make sure all variables use the same modified
+        # spatial coordinates from coarsen
+        new_data_vars = {
+            k: v.assign_coords({
+                d: new_coords[d]
+                for d in v.dims if d in new_coords
+            })
+            for k, v in new_data_vars.items()
+        }
+
+    return xr.Dataset(data_vars=new_data_vars,
+                      attrs=dataset.attrs)
+
+
+def assert_valid_agg_methods(agg_methods: AggMethods):
+    """Assert that the given *agg_methods* are valid."""
+    assert_instance(agg_methods,
+                    (type(None), str, collections.abc.Mapping),
+                    name='agg_methods')
+    if isinstance(agg_methods, str):
+        assert_in(
+            agg_methods, AGG_METHODS,
+            name='agg_methods'
+        )
+    elif agg_methods is not None:
+        enum = (None, *AGG_METHODS)
+        for k, v in agg_methods.items():
+            assert_true(
+                isinstance(k, str),
+                message='keys in agg_methods must be strings'
+            )
+            assert_true(
+                v in enum,
+                message=f'values in agg_methods must be one of {enum}'
+            )
+
+
+def find_agg_method(agg_methods: AggMethods,
+                    var_name: Hashable,
+                    var_dtype: np.dtype) -> str:
+    """
+    Find aggregation method in *agg_methods*
+    for given *var_name* and *var_dtype*.
+    """
+    assert_valid_agg_methods(agg_methods)
+    if isinstance(agg_methods, str) and agg_methods != 'auto':
+        return agg_methods
+    if isinstance(agg_methods, collections.abc.Mapping):
+        for var_name_pat, agg_method in agg_methods.items():
+            if var_name == var_name_pat or fnmatch.fnmatch(str(var_name),
+                                                           var_name_pat):
+                if agg_method in (None, 'auto'):
+                    break
+                return agg_method
+    # here: agg_method is either None or 'auto'
+    if np.issubdtype(var_dtype, np.integer):
+        return 'first'
+    else:
+        return 'mean'
 
 
 _FULL_SLICE = slice(None, None, None)
@@ -76,22 +188,45 @@ def get_dataset_subsampling_slices(
     """
     assert_instance(dataset, xr.Dataset, name='dataset')
     assert_instance(step, int, name='step')
-    x_dim_name, y_dim_name = xy_dim_names or ('x', 'y')
     slices_dict: Dict[Tuple[Hashable, ...], Tuple[slice, ...]] = dict()
     vars_dict: Dict[Hashable, Optional[Tuple[slice, ...]]] = dict()
     for var_name, var in dataset.data_vars.items():
         var_index = slices_dict.get(var.dims)
         if var_index is None:
-            for index, dim_name in enumerate(var.dims):
-                if dim_name == x_dim_name or dim_name == y_dim_name:
-                    if var_index is None:
-                        var_index = index * [_FULL_SLICE]
-                    var_index.append(slice(None, None, step))
-                elif var_index is not None:
-                    var_index.append(_FULL_SLICE)
+            var_index = get_variable_subsampling_slices(
+                var, step, xy_dim_names=xy_dim_names
+            )
             if var_index is not None:
-                var_index = tuple(var_index)
-                slices_dict[var.dims] = tuple(var_index)
+                slices_dict[var.dims] = var_index
         if var_index is not None:
             vars_dict[var_name] = var_index
     return vars_dict
+
+
+def get_variable_subsampling_slices(
+        variable: xr.DataArray,
+        step: int,
+        xy_dim_names: Optional[Tuple[str, str]] = None
+) -> Optional[Tuple[slice, ...]]:
+    """
+    Compute subsampling slices for *variable*.
+    Return None, if *variable* does not contain spatial
+    dimensions.
+
+    :param variable: the dataset providing the variables
+    :param step: the integer subsampling step
+    :param xy_dim_names: the spatial dimension names
+    """
+    assert_instance(variable, xr.DataArray, name='variable')
+    assert_instance(step, int, name='step')
+    x_dim_name, y_dim_name = xy_dim_names or ('x', 'y')
+
+    var_index = None
+    for index, dim_name in enumerate(variable.dims):
+        if dim_name == x_dim_name or dim_name == y_dim_name:
+            if var_index is None:
+                var_index = index * [_FULL_SLICE]
+            var_index.append(slice(None, None, step))
+        elif var_index is not None:
+            var_index.append(_FULL_SLICE)
+    return tuple(var_index) if var_index is not None else None


### PR DESCRIPTION
Closes #655

In detail:

- Introduced new parameter `agg_methods` for writing multi-level datasets with the "file", "s3", and "memory" data stores. The value of `agg_methods` is either a string `"first"`, `"min"`, `"max"`, `"mean"`, `"median"` or a dictionary that maps a variable name to an aggregation method. Variable names can be patterns that may contain wildcard characters '*' and '?'. The special aggregation method `"auto"` can be used to select `"first"` for integer variables and `"mean"` for floating point variables. 

- The `xcube level` CLI tool now has a new option `--agg-method` (or `-A`) for the same purpose.


Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
