### PR TITLE
Consistent logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,10 @@
 
 ### Enhancements
 
-* The xcube package now consistently make use of logging.
-  We distinguish general logging and xcube logging.
-  General logging refers to the log messages of any Python module while
-  xcube logging only refers to log messages emitted by xcube modules.
+* The xcube package now consistently makes use of logging.
+  We distinguish general logging and specific xcube logging.
+  General logging refers to the log messages emitted by any Python module 
+  while xcube logging only refers to log messages emitted by xcube modules.
 
   * The output of general logging from xcube CLI tools can now be 
     configured with two new CLI options: 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,46 @@
 
 ### Enhancements
 
+* The xcube package now consistently make use of logging.
+  We distinguish general logging and xcube logging.
+  General logging refers to the log messages of any Python module while
+  xcube logging only refers to log messages emitted by xcube modules.
+
+  * The output of general logging from xcube CLI tools can now be 
+    configured with two new CLI options: 
+    
+    - `--loglevel LEVEL`: Can be one of `CRITICAL`, `ERROR`,
+      `WARNING`, `INFO`, `DETAIL`, `DEBUG`, `TRACE`, or `OFF` (the default).
+    - `--logfile PATH`: Effective only if log level is not `OFF`.
+      If given, log messages will be written into the file
+      given by PATH. If omitted, log messages will be redirected 
+      to standard error (`sys.stderr`).
+
+    The output of general logging from xcube CLI is disabled by default.
+    If enabled, the log message format includes the level, date-time,
+    logger name, and message.
+
+  * All xcube modules use the logger named `xcube` 
+    (i.e. `LOG = logging.getLogger("xcube")`) to emit 
+    messages regarding progress, debugging, errors. Packages that extend
+    the xcube package should use a dot suffix for their logger names, e.g.
+    `xcube.cci` for the xcube plugin package `xcube-cci`.
+  
+  * All xcube CLI tools will output log messages, if any, 
+    on standard error (`sys.stderr`). 
+    Only the actual result, if any, 
+    is written to standard out (`sys.stdout`).
+
+  * Some xcube CLI tools have a `--quiet`/`-q` option to disable output
+    of log messages on the console and a `--verbose`/`-v` option to enable 
+    it and control the log level. For this purpose the option `-v` 
+    can be given multiple times and even be combined: `-v` = `INFO`, 
+    `-vv` = `DETAIL`, `-vvv` = `DEBUG`, `-vvvv` = `TRACE`.
+    The `quiet` and `verbose` settings only affect the logger named `xcube`
+    and its children. 
+    If enabled, a simple message format will be used, unless the general 
+    logging is redirected to stdout.
+
 * Support for multi-level datasets aka ND image pyramids has been 
   further improved (#655):
   - Introduced new parameter `agg_methods` for writing multi-level datasets 
@@ -14,10 +54,6 @@
     and `"mean"` for floating point variables. 
   - The `xcube level` CLI tool now has a new option `--agg-methods` (or `-A`)
     for the same purpose.
-
-* All xcube CLI tools now consistently provide logging output. It can be 
-  controlled using the `--loglevel LEVEL` with level being one of 
-  `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Default is `WARNING`.
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   - The `xcube level` CLI tool now has a new option `--agg-methods` (or `-A`)
     for the same purpose.
 
+* All xcube CLI tools now consistently provide logging output. It can be 
+  controlled using the `--loglevel LEVEL` with level being one of 
+  `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`. Default is `WARNING`.
+
 ### Fixes
 
 * Fixed a problem where the `DataStores` configuration of `xcube serve` 

--- a/test/cli/helpers.py
+++ b/test/cli/helpers.py
@@ -16,8 +16,11 @@ TEST_ZARR_DIR = "test.zarr"
 class CliTest(unittest.TestCase, metaclass=ABCMeta):
 
     def invoke_cli(self, args: List[str]):
-        self.runner = click.testing.CliRunner()
-        return self.runner.invoke(cli, args, catch_exceptions=False)
+        self.runner = click.testing.CliRunner(mix_stderr=False)
+        # noinspection PyTypeChecker
+        return self.runner.invoke(cli,
+                                  args,
+                                  catch_exceptions=False)
 
 
 class CliDataTest(CliTest, metaclass=ABCMeta):

--- a/test/cli/test_chunk.py
+++ b/test/cli/test_chunk.py
@@ -58,7 +58,7 @@ class ChunkTest(CliDataTest):
                                   "--chunks", "time=1,lat!gnnn,lon=40"])
         self.assertEqual("Error: Invalid value for CHUNKS:"
                          " 'time=1,lat!gnnn,lon=40'\n",
-                         result.output)
+                         result.stderr)
         self.assertEqual(1, result.exit_code)
 
     def test_chunk_size_not_an_int(self):
@@ -69,7 +69,7 @@ class ChunkTest(CliDataTest):
         self.assertEqual("Error: Invalid value for CHUNKS,"
                          " chunk sizes must be positive integers:"
                          " time=1,lat=20.3,lon=40\n",
-                         result.output)
+                         result.stderr)
         self.assertEqual(1, result.exit_code)
 
     def test_chunk_size_not_a_dim(self):
@@ -80,5 +80,5 @@ class ChunkTest(CliDataTest):
         self.assertEqual("Error: Invalid value for CHUNKS,"
                          " 'lati' is not the name of any dimension:"
                          " time=1,lati=20,lon=40\n",
-                         result.output)
+                         result.stderr)
         self.assertEqual(1, result.exit_code)

--- a/test/cli/test_io.py
+++ b/test/cli/test_io.py
@@ -46,7 +46,7 @@ class IOStoreTest(CliTest):
                          " with parameters ('root=42',):"
                          " Invalid parameterization detected:"
                          " 42 is not of type 'string'\n",
-                         result.stdout)
+                         result.stderr)
 
     def test_data(self):
         demo_dir = os.path.join(os.path.dirname(__file__),

--- a/test/cli/test_level.py
+++ b/test/cli/test_level.py
@@ -25,7 +25,7 @@ class LevelDataTest(CliDataTest):
         return dict(time=1, lat=90, lon=180)
 
     def test_all_defaults(self):
-        result = self.invoke_cli(['level', TEST_ZARR_DIR])
+        result = self.invoke_cli(['level', '-v', TEST_ZARR_DIR])
         self._assert_result_ok(
             result, [((1, 1, 1, 1, 1), (90, 90), (180, 180)),
                      ((1, 1, 1, 1, 1), (90,), (180,))],
@@ -34,7 +34,7 @@ class LevelDataTest(CliDataTest):
         )
 
     def test_with_output(self):
-        result = self.invoke_cli(['level', TEST_ZARR_DIR,
+        result = self.invoke_cli(['level', '-v', TEST_ZARR_DIR,
                                   '--output', 'my.levels'])
         self._assert_result_ok(
             result, [((1, 1, 1, 1, 1), (90, 90), (180, 180)),
@@ -43,7 +43,7 @@ class LevelDataTest(CliDataTest):
         )
 
     def test_with_tile_size_and_num_levels(self):
-        result = self.invoke_cli(['level', TEST_ZARR_DIR,
+        result = self.invoke_cli(['level', '-v', TEST_ZARR_DIR,
                                   '-t', '90,45', '-n', '4'])
         self._assert_result_ok(
             result, [((1, 1, 1, 1, 1), (45, 45, 45, 45), (90, 90, 90, 90)),
@@ -59,7 +59,7 @@ class LevelDataTest(CliDataTest):
                           output_path: str,
                           message_regex: str):
         self.assertEqual(0, result.exit_code)
-        self.assertRegex(result.stdout, message_regex)
+        self.assertRegex(result.stderr, message_regex)
         self.assertTrue(os.path.isdir(output_path))
         data_store = new_fs_data_store("file")
         ml_dataset = data_store.open_data(output_path)
@@ -79,7 +79,7 @@ class LevelDataTest(CliDataTest):
 
     def _assert_result_not_ok(self, result, message_regex: str):
         self.assertEqual(1, result.exit_code)
-        self.assertRegex(result.stdout, message_regex)
+        self.assertRegex(result.stderr, message_regex)
 
     def test_level_with_nc(self):
         result = self.invoke_cli(["level",

--- a/test/cli/test_prune.py
+++ b/test/cli/test_prune.py
@@ -55,7 +55,7 @@ class PruneDataTest(CliTest):
                 "Deleted 24 block file(s) for variable 'temperature'.\n"
                 "Done, 48 block file(s) deleted total.\n"
             ),
-            result.stdout)
+            result.stderr)
         expected_file_names = sorted([
             '.zarray',
             '.zattrs',
@@ -94,7 +94,7 @@ class PruneDataTest(CliTest):
                 "Deleted 24 block file(s) for variable 'temperature'.\n"
                 "Done, 48 block file(s) deleted total.\n"
             ),
-            result.stdout)
+            result.stderr)
         expected_file_names = sorted(['.zarray', '.zattrs'])
         self.assertEqual(expected_file_names,
                          sorted(os.listdir('test.zarr/precipitation')))
@@ -125,7 +125,7 @@ class PruneDataTest(CliTest):
                                  'precipitation', '0.3.76')
         dir_path = os.path.join(self.TEST_CUBE,
                                 'precipitation', '0', '3', '76')
-        self.assertEqual(f"Error: could find neither block file "
+        self.assertEqual(f"Could find neither block file "
                          f"{file_path} nor "
                          f"{dir_path}", actual_message)
 
@@ -163,5 +163,5 @@ class PruneDataTest(CliTest):
                 self.assertIsNotNone(actual_message)
                 # noinspection PyUnresolvedReferences
                 self.assertTrue(actual_message.startswith(
-                    f'Error: failed to delete block file {block_file}: '
+                    f'Failed to delete block file {block_file}: '
                 ))

--- a/test/cli/test_rectify.py
+++ b/test/cli/test_rectify.py
@@ -19,6 +19,7 @@ class RectifyTest(CliDataTest):
         # been fixed, these options can be omitted.
 
         result = self.invoke_cli(['rectify',
+                                  '--verbose',
                                   '--size', '508,253',
                                   '--point', '-179.5,-89.5',
                                   '--res', '0.7071067811865475',
@@ -29,7 +30,7 @@ class RectifyTest(CliDataTest):
                          'Rectifying...\n'
                          'Writing rectified dataset to \'out.zarr\'...\n'
                          'Done.\n',
-                         result.stdout)
+                         result.stderr)
         self.assertTrue(os.path.isdir('out.zarr'))
         ds = xr.open_zarr('out.zarr')
         assert_cube(ds)
@@ -48,6 +49,7 @@ class RectifyTest(CliDataTest):
         # been fixed, these options can be omitted.
 
         result = self.invoke_cli(['rectify',
+                                  '--verbose',
                                   '--size', '508,253',
                                   '--point', '-179.5,-89.5',
                                   '--res', '0.7071067811865475',
@@ -60,7 +62,7 @@ class RectifyTest(CliDataTest):
                          'Rectifying...\n'
                          'Writing rectified dataset to \'out.zarr\'...\n'
                          'Done.\n',
-                         result.stdout)
+                         result.stderr)
         self.assertTrue(os.path.isdir('out.zarr'))
         ds = xr.open_zarr('out.zarr')
         assert_cube(ds)

--- a/test/cli/test_resample.py
+++ b/test/cli/test_resample.py
@@ -19,13 +19,13 @@ class ResampleDataTest(CliDataTest):
         return ['out.zarr', 'resampled.zarr']
 
     def test_all_defaults(self):
-        result = self.invoke_cli(['resample', TEST_ZARR_DIR])
+        result = self.invoke_cli(['resample', '-v', TEST_ZARR_DIR])
         self.assertEqual(0, result.exit_code)
         self.assertEqual("Opening cube from 'test.zarr'...\n"
                          "Resampling...\n"
                          "Writing resampled cube to 'out.zarr'...\n"
                          "Done.\n",
-                         result.stdout)
+                         result.stderr)
         self.assertTrue(os.path.isdir('out.zarr'))
         ds = xr.open_zarr('out.zarr')
         assert_cube(ds)

--- a/test/cli/test_serve.py
+++ b/test/cli/test_serve.py
@@ -13,13 +13,13 @@ class ServerCliTest(CliDataTest):
     def test_config(self):
         result = self.invoke_cli(["serve", "--config", "x.yml", "pippo.zarr"])
         self.assertEqual('Error: CONFIG and CUBES cannot be used at the same time.\n',
-                         result.output[-58:])
+                         result.stderr[-58:])
         self.assertEqual(1, result.exit_code)
 
         with ChangeEnv({CONFIG_ENV_VAR: "x.yml"}):
             result = self.invoke_cli(["serve"])
             self.assertEqual('Error: Configuration file not found: x.yml\n',
-                             result.output[-44:])
+                             result.stderr[-44:])
             self.assertEqual(1, result.exit_code)
 
     def test_base_dir(self):
@@ -29,13 +29,13 @@ class ServerCliTest(CliDataTest):
         with ChangeEnv({BASE_ENV_VAR: None}):
             result = self.invoke_cli(["serve", "--config", config_path, "--base-dir", "pippo/gnarz"])
             self.assertEqual('Error: Base directory not found: pippo/gnarz\n',
-                             result.output[-45:])
+                             result.stderr[-45:])
             self.assertEqual(1, result.exit_code)
 
         with ChangeEnv({BASE_ENV_VAR: 'pippo/configs'}):
             result = self.invoke_cli(["serve", "--config", config_path])
             self.assertEqual('Error: Base directory not found: pippo/configs\n',
-                             result.output[-47:])
+                             result.stderr[-47:])
             self.assertEqual(1, result.exit_code)
 
     def test_show(self):
@@ -47,7 +47,7 @@ class ServerCliTest(CliDataTest):
             self.assertEqual(f'Error: Option "--show": In order to run the viewer, '
                              f'set environment variable {VIEWER_ENV_VAR} to a valid '
                              f'xcube-viewer deployment or build directory.\n',
-                             result.output[-150:])
+                             result.stderr[-150:])
             self.assertEqual(2, result.exit_code)
 
         with ChangeEnv({VIEWER_ENV_VAR: "pippo/viewer"}):
@@ -55,7 +55,7 @@ class ServerCliTest(CliDataTest):
             self.assertEqual(f'Error: Option "--show": Viewer path set by environment '
                              f'variable {VIEWER_ENV_VAR} '
                              f'must be a directory: pippo/viewer\n',
-                             result.output[-116:])
+                             result.stderr[-116:])
             self.assertEqual(2, result.exit_code)
 
     def test_help(self):

--- a/test/cli/test_tile.py
+++ b/test/cli/test_tile.py
@@ -186,4 +186,4 @@ class LevelDataTest(CliDataTest):
 
     def _assert_result_not_ok(self, result, message_regex: str):
         self.assertEqual(1, result.exit_code)
-        self.assertRegex(result.stdout, message_regex)
+        self.assertRegex(result.stderr, message_regex)

--- a/test/cli/test_verify.py
+++ b/test/cli/test_verify.py
@@ -28,8 +28,7 @@ class VerifyDataTest(CliTest):
         write_cube(cube, self.TEST_CUBE, "zarr", cube_asserted=True)
         result = self.invoke_cli(['verify', self.TEST_CUBE])
         self.assertEqual(0, result.exit_code)
-        self.assertEqual("Opening cube from 'test.zarr'...\n"
-                         "INPUT is a valid cube.\n",
+        self.assertEqual("INPUT is a valid cube.\n",
                          result.stdout)
 
     def test_verify_failure(self):
@@ -41,8 +40,7 @@ class VerifyDataTest(CliTest):
 
         result = self.invoke_cli(['verify', self.TEST_CUBE])
         self.assertEqual(3, result.exit_code)
-        self.assertEqual("Opening cube from 'test.zarr'...\n"
-                         "INPUT is not a valid cube due to the following reasons:\n"
+        self.assertEqual("INPUT is not a valid cube due to the following reasons:\n"
                          "- dimensions of data variable 'chl' must be ('time', ..., 'lat', 'lon'),"
                          " but were ('lat', 'lon') for 'chl'\n"
                          "- dimensions of all data variables must be same, but found ('lat', 'lon')"

--- a/xcube/cli/chunk.py
+++ b/xcube/cli/chunk.py
@@ -21,7 +21,10 @@
 
 import click
 
-from xcube.cli.common import parse_cli_kwargs
+from xcube.cli.common import (parse_cli_kwargs,
+                              cli_option_quiet,
+                              cli_option_verbosity,
+                              configure_cli_output)
 
 DEFAULT_OUTPUT_PATH = 'out.zarr'
 
@@ -31,7 +34,8 @@ DEFAULT_OUTPUT_PATH = 'out.zarr'
 @click.argument('cube')
 @click.option('--output', '-o', metavar='OUTPUT', default=DEFAULT_OUTPUT_PATH,
               help=f'Output path. Defaults to {DEFAULT_OUTPUT_PATH!r}')
-@click.option('--format', '-f', metavar='FORMAT', type=click.Choice(['zarr', 'netcdf']),
+@click.option('--format', '-f', metavar='FORMAT',
+              type=click.Choice(['zarr', 'netcdf']),
               help="Format of the output. If not given, guessed from OUTPUT.")
 @click.option('--params', '-p', metavar='PARAMS',
               help="Parameters specific for the output format."
@@ -40,7 +44,15 @@ DEFAULT_OUTPUT_PATH = 'out.zarr'
               help='Chunk sizes for each dimension.'
                    ' Comma-separated list of <dim>=<size> pairs,'
                    ' e.g. "time=1,lat=270,lon=270"')
-def chunk(cube, output, format=None, params=None, chunks=None):
+@cli_option_quiet
+@cli_option_verbosity
+def chunk(cube,
+          output,
+          format=None,
+          params=None,
+          chunks=None,
+          quiet=None,
+          verbosity=None):
     """
     (Re-)chunk xcube dataset.
     Changes the external chunking of all variables of CUBE according to CHUNKS and writes
@@ -49,6 +61,8 @@ def chunk(cube, output, format=None, params=None, chunks=None):
     Note: There is a possibly more efficient way to (re-)chunk datasets through the
     dedicated tool "rechunker", see https://rechunker.readthedocs.io.
     """
+    configure_cli_output(quiet=quiet, verbosity=verbosity)
+
     chunk_sizes = None
     if chunks:
         chunk_sizes = parse_cli_kwargs(chunks, metavar="CHUNKS")

--- a/xcube/cli/common.py
+++ b/xcube/cli/common.py
@@ -51,7 +51,8 @@ def cli_option_quiet(func):
     return click.option(
         '--quiet', '-q',
         is_flag=True,
-        help="Disable output of log messages to the console.",
+        help="Disable output of log messages to the console entirely."
+             " Note, this will also suppress error and warning messages.",
         callback=_callback
     )(func)
 
@@ -74,10 +75,12 @@ def cli_option_verbosity(func):
         '--verbose', '-v', 'verbosity',
         count=True,
         help="Enable output of log messages to the console."
-             " May be given multiple times (-vv, -vvv) to control the level"
+             " Has no effect if --quiet/-q is used."
+             " May be given multiple times to control the level"
              " of log messages, i.e.,"
              " -v refers to level INFO, -vv to DETAIL, -vvv to DEBUG,"
-             " -vvvv to TRACE.",
+             " -vvvv to TRACE."
+             " If omitted, the log level of the console is WARNING.",
         callback=_callback
     )(func)
 

--- a/xcube/cli/common.py
+++ b/xcube/cli/common.py
@@ -2,6 +2,8 @@ from typing import Dict, Any, Optional, Union, Sequence, Type, Tuple
 
 import click
 
+from xcube.constants import LOG
+
 
 def new_cli_ctx_obj():
     return {
@@ -185,6 +187,7 @@ def handle_cli_exception(e: BaseException, exit_code: int = None, traceback_mode
     else:
         print(f'Internal error: {e}', file=sys.stderr)
         exit_code = exit_code or 3
+    LOG.error('Exit with code %d', exit_code, exc_info=not traceback_mode)
     if traceback_mode:
         import traceback
         traceback.print_exc(file=sys.stderr)

--- a/xcube/cli/common.py
+++ b/xcube/cli/common.py
@@ -299,7 +299,8 @@ def configure_cli_output(quiet: Optional[bool] = None,
 
     logger.setLevel(level)
 
-    if not isinstance(_general_handler, logging.StreamHandler):
+    if isinstance(_general_handler,
+                  (logging.FileHandler, logging.NullHandler)):
         # Only if we do not already redirect output of general logging
         # to stderr, install a new handler with a simple message format
         # for the console.

--- a/xcube/cli/edit.py
+++ b/xcube/cli/edit.py
@@ -21,6 +21,8 @@
 
 import click
 
+from xcube.constants import LOG
+
 DEFAULT_OUTPUT_PATH = '{input}-edited.zarr'
 
 
@@ -54,4 +56,4 @@ def edit(cube,
                   metadata_path=metadata,
                   update_coords=coords,
                   in_place=in_place,
-                  monitor=print)
+                  monitor=LOG.info)

--- a/xcube/cli/gen.py
+++ b/xcube/cli/gen.py
@@ -23,10 +23,12 @@ from typing import List, Sequence
 
 import click
 
-from xcube.constants import EXTENSION_POINT_DATASET_IOS
+from xcube.constants import (EXTENSION_POINT_DATASET_IOS,
+                             LOG)
 from xcube.constants import EXTENSION_POINT_INPUT_PROCESSORS
 from xcube.constants import RESAMPLING_METHOD_NAMES
-from xcube.core.gen.defaults import DEFAULT_OUTPUT_PATH, DEFAULT_OUTPUT_RESAMPLING
+from xcube.core.gen.defaults import DEFAULT_OUTPUT_PATH, \
+    DEFAULT_OUTPUT_RESAMPLING
 from xcube.util.extension import Extension
 
 resampling_methods = sorted(RESAMPLING_METHOD_NAMES)
@@ -123,11 +125,8 @@ def gen(input: Sequence[str],
         no_sort_mode=no_sort,
     )
 
-    def flushing_monitor(*args, **kwargs):
-        print(*args, flush=True, **kwargs)
-
     gen_cube(dry_run=dry_run,
-             monitor=flushing_monitor,
+             monitor=LOG.info,
              **config)
 
     return 0

--- a/xcube/cli/gen2.py
+++ b/xcube/cli/gen2.py
@@ -22,8 +22,14 @@
 import json
 import sys
 import traceback
+from typing import Dict, Any
 
 import click
+
+from xcube.cli.common import (cli_option_quiet,
+                              cli_option_verbosity,
+                              configure_cli_output)
+from xcube.constants import LOG
 
 
 @click.command(name="gen2", hidden=True)
@@ -50,16 +56,14 @@ import click
               help='Write cube information or generation result into JSON'
                    ' file RESULT.'
                    ' If omitted, the JSON is dumped to stdout.')
-@click.option('--verbose', '-v', 'verbosity',
-              count=True,
-              help='Control amount of information dumped to stdout.'
-                   ' May be given multiple time to output more details,'
-                   ' e.g. "-vvv".')
+@cli_option_quiet
+@cli_option_verbosity
 def gen2(request_path: str,
          stores_config_path: str = None,
          service_config_path: str = None,
          output_file: str = None,
          info: bool = False,
+         quiet: bool = False,
          verbosity: int = 0):
     """
     Generator tool for data cubes.
@@ -123,7 +127,11 @@ def gen2(request_path: str,
     from xcube.core.gen2 import CubeGeneratorRequest
     from xcube.util.versions import get_xcube_versions
 
+    configure_cli_output(quiet=quiet, verbosity=verbosity)
+
     error = None
+
+    result: Dict[str, Any]
 
     # noinspection PyBroadException
     try:
@@ -161,8 +169,7 @@ def gen2(request_path: str,
     if output_file is not None:
         with open(output_file, 'w') as fp:
             json.dump(result, fp, indent=2)
-        if verbosity:
-            print(f'Result written to {output_file}')
+        LOG.info(f'Result written to {output_file}')
     else:
         json.dump(result, sys.stdout, indent=2)
 

--- a/xcube/cli/io.py
+++ b/xcube/cli/io.py
@@ -25,7 +25,7 @@ from typing import List, Sequence, Optional, Dict, AbstractSet, Set, Any
 
 import click
 
-from xcube.constants import EXTENSION_POINT_DATA_OPENERS
+from xcube.constants import EXTENSION_POINT_DATA_OPENERS, LOG
 from xcube.constants import EXTENSION_POINT_DATA_STORES
 from xcube.constants import EXTENSION_POINT_DATA_WRITERS
 from xcube.util.plugin import get_extension_registry
@@ -340,9 +340,11 @@ def dump(output_file_path: Optional[str],
                 for row in rows:
                     fp.write(sep.join(map(format_cell_value,
                                           tuple(row.get(k)
-                                                for k in column_names))) + '\n')
+                                                for k in
+                                                column_names))) + '\n')
 
-        print(f'Dumped {len(rows)} store entry/ies to {output_file_path}.')
+        LOG.info(f'Dumped {len(rows)} store entry/ies'
+                 f' to {output_file_path}.')
 
     else:
         last_store_dict = None
@@ -372,7 +374,8 @@ def dump(output_file_path: Optional[str],
             else:
                 yaml.dump(dict(stores=store_list), fp, indent=2)
 
-        print(f'Dumped entries of {len(store_list)} store(s) to {output_file_path}.')
+        LOG.info(f'Dumped entries of {len(store_list)} store(s)'
+                 f' to {output_file_path}.')
 
 
 def _get_store_data_var_tuples(store_pool, data_type, include_props, exclude_props):
@@ -399,13 +402,15 @@ def _get_store_data_var_tuples(store_pool, data_type, include_props, exclude_pro
             try:
                 store_instance = store_pool.get_store(store_instance_id)
             except BaseException as error:
-                print(f'error: cannot open store "{store_instance_id}": {error}', file=sys.stderr)
+                LOG.error(f'Cannot open store'
+                          f' "{store_instance_id}": {error}')
                 continue
 
             try:
                 data_descriptors = store_instance.search_data(data_type=data_type)
             except BaseException as error:
-                print(f'error: cannot search store "{store_instance_id}": {error}', file=sys.stderr)
+                LOG.error(f'Cannot search store'
+                          f' "{store_instance_id}": {error}')
                 continue
 
             for data_descriptor in data_descriptors:

--- a/xcube/cli/level.py
+++ b/xcube/cli/level.py
@@ -23,6 +23,11 @@ from typing import Optional, Tuple
 
 import click
 
+from xcube.cli.common import (configure_cli_output,
+                              cli_option_quiet,
+                              cli_option_verbosity)
+from xcube.constants import LOG
+
 DEFAULT_TILE_SIZE = 512
 DEFAULT_AGG_METHOD = 'first'
 
@@ -64,6 +69,8 @@ DEFAULT_AGG_METHOD = 'first'
 @click.option('--anon', '-a', is_flag=True, flag_value=True,
               help=f'For S3 inputs or outputs, whether the access'
                    f' is anonymous. By default, credentials are required.')
+@cli_option_quiet
+@cli_option_verbosity
 def level(input: str,
           output: Optional[str],
           link: bool,
@@ -71,7 +78,9 @@ def level(input: str,
           num_levels_max: int,
           agg_methods: str,
           replace: bool,
-          anon: bool):
+          anon: bool,
+          quiet: bool,
+          verbosity: int):
     """
     Generate multi-resolution levels.
 
@@ -89,6 +98,8 @@ def level(input: str,
     from xcube.cli.common import assert_positive_int_item
     from xcube.core.store import new_fs_data_store
     from xcube.core.subsampling import assert_valid_agg_methods
+
+    configure_cli_output(quiet=quiet, verbosity=verbosity)
 
     input_path = input
     output_path = output
@@ -159,8 +170,8 @@ def level(input: str,
             f"output {output_path!r} already exists"
         ) from e
 
-    print(f"Multi-level dataset written to {output_path}"
-          f" after {time.time() - start_time} seconds")
+    LOG.info(f"Multi-level dataset written to {output_path}"
+             f" after {time.time() - start_time} seconds")
 
 
 def _split_protocol_and_path(path) -> Tuple[str, str]:

--- a/xcube/cli/main.py
+++ b/xcube/cli/main.py
@@ -28,18 +28,14 @@ from xcube.cli.common import (cli_option_scheduler,
                               cli_option_traceback,
                               handle_cli_exception,
                               new_cli_ctx_obj)
+from xcube.constants import DEFAULT_LOG_FORMAT
+from xcube.constants import DEFAULT_LOG_LEVEL
 from xcube.constants import EXTENSION_POINT_CLI_COMMANDS
+from xcube.constants import LOG_LEVELS
+from xcube.constants import OFF_LOG_LEVEL
+from xcube.constants import OFF_LOG_LEVEL_NAME
 from xcube.util.plugin import get_extension_registry
 from xcube.version import version
-
-LOG_LEVELS = [
-    'CRITICAL',
-    'ERROR',
-    'WARNING',
-    'INFO',
-    'DEBUG'
-]
-DEFAULT_LOG_LEVEL = 'WARNING'
 
 
 # noinspection PyShadowingBuiltins,PyUnusedLocal
@@ -63,10 +59,14 @@ def cli(traceback=False, scheduler=None, loglevel=None, warnings=None):
     xcube Toolkit
     """
 
+    # Configure logging for all xcube CLI tools (#659)
+    loglevel = loglevel or DEFAULT_LOG_LEVEL
+    if loglevel == OFF_LOG_LEVEL_NAME:
+        loglevel = OFF_LOG_LEVEL
     logging.basicConfig(
-        format='[%(levelname).1s %(asctime)s %(name)s] %(message)s',
+        format=DEFAULT_LOG_FORMAT,
         stream=sys.stderr,
-        level=loglevel or DEFAULT_LOG_LEVEL,
+        level=loglevel,
         force=True
     )
 

--- a/xcube/cli/main.py
+++ b/xcube/cli/main.py
@@ -48,9 +48,10 @@ from xcube.version import version
               help=f'Log level.'
                    f' Must be one of {", ".join(LOG_LEVELS)}.'
                    f' Defaults to {LOG_LEVEL_OFF_NAME}.'
-                   f' If LOG_LEVEL is not {LOG_LEVEL_OFF_NAME},'
-                   f' any log messages will be written either'
-                   f' to the console (stderr) or LOG_FILE, if provided.')
+                   f' If the level is not {LOG_LEVEL_OFF_NAME},'
+                   f' any log messages up to the given level will be'
+                   f' written either to the console (stderr)'
+                   f' or LOG_FILE, if provided.')
 @click.option('--logfile', 'log_file',
               metavar='LOG_FILE',
               help=f'Log file path.'

--- a/xcube/cli/main.py
+++ b/xcube/cli/main.py
@@ -31,8 +31,7 @@ from xcube.cli.common import (cli_option_scheduler,
                               configure_warnings)
 from xcube.constants import (EXTENSION_POINT_CLI_COMMANDS,
                              LOG_LEVELS,
-                             LOG_LEVEL_OFF_NAME,
-                             DEFAULT_GENERAL_LOG_LEVEL)
+                             LOG_LEVEL_OFF_NAME)
 from xcube.util.plugin import get_extension_registry
 from xcube.version import version
 
@@ -48,16 +47,18 @@ from xcube.version import version
               default=LOG_LEVEL_OFF_NAME,
               help=f'Log level.'
                    f' Must be one of {", ".join(LOG_LEVELS)}.'
-                   f' Defaults to {DEFAULT_GENERAL_LOG_LEVEL}.'
-                   f' If {LOG_LEVEL_OFF_NAME}, only progress messages'
-                   f' are displayed.'
-                   f' If not {LOG_LEVEL_OFF_NAME}, all log messages will be'
-                   f' written either to stderr or LOG_FILE, if given.')
+                   f' Defaults to {LOG_LEVEL_OFF_NAME}.'
+                   f' If LOG_LEVEL is not {LOG_LEVEL_OFF_NAME},'
+                   f' any log messages will be written either'
+                   f' to the console (stderr) or LOG_FILE, if provided.')
 @click.option('--logfile', 'log_file',
               metavar='LOG_FILE',
               help=f'Log file path.'
                    f' If given, any log messages will redirected into'
-                   f' LOG_FILE. Effective only if LOG_LEVEL'
+                   f' LOG_FILE. Disables console output'
+                   f' unless otherwise enabled, e.g.,'
+                   f' using the --verbose flag.'
+                   f' Effective only if LOG_LEVEL'
                    f' is not {LOG_LEVEL_OFF_NAME}.')
 @click.option('--warnings', '-w',
               is_flag=True,

--- a/xcube/cli/rectify.py
+++ b/xcube/cli/rectify.py
@@ -25,8 +25,13 @@ from typing import Sequence, Optional, Tuple
 
 import click
 
-from xcube.cli.common import parse_cli_sequence, assert_positive_int_item
-from xcube.constants import FORMAT_NAME_ZARR, FORMAT_NAME_NETCDF4, FORMAT_NAME_MEM
+from xcube.cli.common import (parse_cli_sequence,
+                              assert_positive_int_item,
+                              cli_option_quiet,
+                              cli_option_verbosity, configure_cli_output)
+from xcube.constants import FORMAT_NAME_ZARR, FORMAT_NAME_NETCDF4, \
+    FORMAT_NAME_MEM
+from xcube.constants import LOG
 
 OUTPUT_FORMAT_NAMES = [FORMAT_NAME_ZARR, FORMAT_NAME_NETCDF4, FORMAT_NAME_MEM]
 
@@ -72,6 +77,8 @@ DEFAULT_CRS = 'EPSG:4326'
 @click.option('--delta', '-d', type=float, default=DEFAULT_DELTA,
               help='Relative maximum delta for detection whether a '
                    'target pixel center is within a source pixel\'s boundary.')
+@cli_option_quiet
+@cli_option_verbosity
 @click.option('--dry-run', default=DEFAULT_DRY_RUN, is_flag=True,
               help='Just read and process INPUT, but don\'t produce any outputs.')
 def rectify(dataset: str,
@@ -85,10 +92,13 @@ def rectify(dataset: str,
             output_res: float = None,
             output_crs: str = None,
             delta: float = DEFAULT_DELTA,
+            quiet: bool = False,
+            verbosity: int = 0,
             dry_run: bool = DEFAULT_DRY_RUN):
     """
     Rectify a dataset to WGS-84 using its per-pixel geo-locations.
     """
+    configure_cli_output(quiet=quiet, verbosity=verbosity)
 
     input_path = dataset
 
@@ -99,7 +109,8 @@ def rectify(dataset: str,
                                          metavar='VARIABLES',
                                          item_plural_name='names')
                       for var_name_specifier in var_names]
-    var_name_flat_list = functools.reduce(operator.iconcat, var_name_lists, [])
+    var_name_flat_list = functools.reduce(operator.iconcat, var_name_lists,
+                                          [])
 
     output_size = parse_cli_sequence(output_size,
                                      metavar='SIZE', num_items=2, item_plural_name='sizes',
@@ -124,7 +135,7 @@ def rectify(dataset: str,
              output_crs,
              delta,
              dry_run=dry_run,
-             monitor=print)
+             monitor=LOG.info)
 
     return 0
 

--- a/xcube/cli/resample.py
+++ b/xcube/cli/resample.py
@@ -22,10 +22,17 @@ from typing import Sequence, Dict, Any
 
 import click
 
-from xcube.constants import FORMAT_NAME_ZARR, FORMAT_NAME_NETCDF4, FORMAT_NAME_MEM
+from xcube.cli.common import (configure_cli_output,
+                              cli_option_quiet,
+                              cli_option_verbosity)
+from xcube.constants import FORMAT_NAME_ZARR, FORMAT_NAME_NETCDF4, \
+    FORMAT_NAME_MEM
+from xcube.constants import LOG
 
-UPSAMPLING_METHODS = ['asfreq', 'ffill', 'bfill', 'pad', 'nearest', 'interpolate']
-DOWNSAMPLING_METHODS = ['count', 'first', 'last', 'min', 'max', 'sum', 'prod', 'mean', 'median', 'std', 'var']
+UPSAMPLING_METHODS = ['asfreq', 'ffill', 'bfill', 'pad', 'nearest',
+                      'interpolate']
+DOWNSAMPLING_METHODS = ['count', 'first', 'last', 'min', 'max', 'sum', 'prod',
+                        'mean', 'median', 'std', 'var']
 RESAMPLING_METHODS = UPSAMPLING_METHODS + DOWNSAMPLING_METHODS
 
 SPLINE_INTERPOLATION_KINDS = ['zero', 'slinear', 'quadratic', 'cubic']
@@ -92,6 +99,8 @@ DEFAULT_INTERPOLATION_KIND = 'linear'
                    'If the time delta exceeds the tolerance, '
                    'fill values (NaN) will be used. '
                    'Defaults to the given frequency.')
+@cli_option_quiet
+@cli_option_verbosity
 @click.option('--dry-run', default=False, is_flag=True,
               help='Just read and process inputs, but don\'t produce any outputs.')
 def resample(cube,
@@ -105,10 +114,13 @@ def resample(cube,
              base,
              kind,
              tolerance,
+             quiet,
+             verbosity,
              dry_run):
     """
     Resample data along the time dimension.
     """
+    configure_cli_output(quiet=quiet, verbosity=verbosity)
 
     input_path = cube
     config_files = config
@@ -155,7 +167,7 @@ def resample(cube,
                 raise click.ClickException(f'invalid resampling method {method!r}')
 
     # noinspection PyBroadException
-    _resample_in_time(**config, dry_run=dry_run, monitor=print)
+    _resample_in_time(**config, dry_run=dry_run, monitor=LOG.info)
 
     return 0
 

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -23,8 +23,12 @@ from typing import List
 
 import click
 
-from xcube.webapi.defaults import DEFAULT_PORT, DEFAULT_ADDRESS, DEFAULT_UPDATE_PERIOD, \
-    DEFAULT_TILE_CACHE_SIZE, DEFAULT_TILE_COMP_MODE
+from xcube.constants import LOG
+from xcube.webapi.defaults import (DEFAULT_PORT,
+                                   DEFAULT_ADDRESS,
+                                   DEFAULT_UPDATE_PERIOD,
+                                   DEFAULT_TILE_CACHE_SIZE,
+                                   DEFAULT_TILE_COMP_MODE)
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
@@ -133,7 +137,7 @@ def serve(cube: List[str],
 
     from xcube.version import version
     from xcube.webapi.defaults import SERVER_NAME, SERVER_DESCRIPTION
-    print(f'{SERVER_NAME}: {SERVER_DESCRIPTION}, version {version}')
+    LOG.info(f'{SERVER_NAME}: {SERVER_DESCRIPTION}, version {version}')
 
     if show:
         _run_viewer()

--- a/xcube/cli/serve.py
+++ b/xcube/cli/serve.py
@@ -196,11 +196,11 @@ def _run_viewer():
                                f"must be a directory: " + viewer_dir)
 
     def _run():
-        LOG.info("starting web server...")
+        LOG.info("Starting web server...")
         with subprocess.Popen(['python', '-m', 'http.server', '--directory', viewer_dir],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE):
-            LOG.info("opening viewer...")
+            LOG.info("Opening viewer...")
             webbrowser.open("http://localhost:8000/index.html")
 
     threading.Thread(target=_run, name="xcube-viewer-runner").start()

--- a/xcube/cli/tile.py
+++ b/xcube/cli/tile.py
@@ -215,7 +215,7 @@ def tile(cube: str,
         tile_width, tile_height = tile_size
     else:
         if verbosity:
-            LOG.warning(f'using default tile sizes derived from CUBE')
+            LOG.warning(f'Using default tile sizes derived from CUBE')
         tile_width, tile_height = tile_grid.tile_size
 
     indexers = None

--- a/xcube/cli/tile.py
+++ b/xcube/cli/tile.py
@@ -23,7 +23,10 @@ from typing import List, Optional, Mapping, Any
 
 import click
 
-__author__ = "Norman Fomferra (Brockmann Consult GmbH)"
+from xcube.cli.common import (cli_option_quiet,
+                              cli_option_verbosity,
+                              configure_cli_output)
+from xcube.constants import LOG
 
 DEFAULT_OUTPUT_PATH = 'out.tiles'
 DEFAULT_CONFIG_PATH = 'config.yml'
@@ -46,13 +49,15 @@ DEFAULT_STYLE_ID = 'default'
                    f'display the default tile sizes for CUBE.')
 @click.option('--config', '-c', 'config_path', metavar='CONFIG',
               help=f'Configuration file in YAML format.')
-@click.option('--style', '-s', 'style_id', metavar='STYLE', default=DEFAULT_STYLE_ID,
+@click.option('--style', '-s', 'style_id', metavar='STYLE',
+              default=DEFAULT_STYLE_ID,
               help=f'Name of a style identifier in CONFIG file. Only used if CONFIG is given.'
                    f' Defaults to {DEFAULT_STYLE_ID!r}.')
-@click.option('--output', '-o', 'output_path', metavar='OUTPUT', default=DEFAULT_OUTPUT_PATH,
+@click.option('--output', '-o', 'output_path', metavar='OUTPUT',
+              default=DEFAULT_OUTPUT_PATH,
               help=f'Output path. Defaults to {DEFAULT_OUTPUT_PATH!r}')
-@click.option('--verbose', '-v', 'verbosity', count=True,
-              help=f'Use -vv to report all files generated, -v to report less.')
+@cli_option_quiet
+@cli_option_verbosity
 @click.option('--dry-run', 'dry_run', is_flag=True,
               help=f'Generate all tiles but don\'t write any files.')
 def tile(cube: str,
@@ -62,6 +67,7 @@ def tile(cube: str,
          config_path: Optional[str],
          style_id: Optional[str],
          output_path: Optional[str],
+         quiet: bool,
          verbosity: int,
          dry_run: bool):
     """
@@ -110,6 +116,8 @@ def tile(cube: str,
     from xcube.cli.common import assert_positive_int_item
     from xcube.util.tilegrid import TileGrid
     from xcube.util.tiledimage import DEFAULT_COLOR_MAP_NUM_COLORS
+
+    configure_cli_output(quiet=quiet, verbosity=verbosity)
 
     # noinspection PyShadowingNames
     def write_tile_map_resource(path: str,
@@ -190,12 +198,12 @@ def tile(cube: str,
     config = {}
     if config_path:
         if verbosity:
-            print(f'Opening {config_path}...')
+            LOG.info(f'Opening {config_path}...')
         with open(config_path, 'r') as fp:
             config = yaml.safe_load(fp)
 
     if verbosity:
-        print(f'Opening {cube}...')
+        LOG.info(f'Opening {cube}...')
 
     ml_dataset = open_ml_dataset(cube, chunks='auto')
     tile_grid = ml_dataset.tile_grid
@@ -207,7 +215,7 @@ def tile(cube: str,
         tile_width, tile_height = tile_size
     else:
         if verbosity:
-            print(f'Warning: using default tile sizes derived from CUBE')
+            LOG.warning(f'using default tile sizes derived from CUBE')
         tile_width, tile_height = tile_grid.tile_size
 
     indexers = None
@@ -239,10 +247,11 @@ def tile(cube: str,
                    for z in range(num_levels)]
 
     if verbosity:
-        print(f'Writing tile sets...')
-        print(f'  Zoom levels: {num_levels}')
-        print(f'  Resolutions: {", ".join(map(str, resolutions))} units/pixel')
-        print(f'  Tile size:   {tile_width} x {tile_height} pixels')
+        LOG.info(f'Writing tile sets...')
+        LOG.info(f'  Zoom levels: {num_levels}')
+        LOG.info(f'  Resolutions: {", ".join(map(str, resolutions))}'
+                 f' units/pixel')
+        LOG.info(f'  Tile size:   {tile_width} x {tile_height} pixels')
 
     image_cache = {}
 
@@ -272,7 +281,7 @@ def tile(cube: str,
                         coordinates={name: _convert_coord_var(coord_var)
                                      for name, coord_var in var.coords.items() if coord_var.ndim == 1})
         if verbosity:
-            print(f'Writing {metadata_path}')
+            LOG.info(f'Writing {metadata_path}')
         if not dry_run:
             os.makedirs(var_path, exist_ok=True)
             with open(metadata_path, 'w') as fp:
@@ -283,7 +292,7 @@ def tile(cube: str,
             tilemap_path = os.path.join(var_path, *[str(l) for l in label_index])
             tilemap_resource_path = os.path.join(tilemap_path, 'tilemapresource.xml')
             if verbosity > 1:
-                print(f'Writing {tilemap_resource_path}')
+                LOG.info(f'Writing {tilemap_resource_path}')
             if not dry_run:
                 os.makedirs(tilemap_path, exist_ok=True)
                 write_tile_map_resource(tilemap_resource_path, resolutions, tile_grid, title=f'{var_name}')
@@ -309,9 +318,9 @@ def tile(cube: str,
                                                          exception_type=click.ClickException)
                         tile_path = os.path.join(tile_zx_path, f'{num_tiles_y - 1 - y}.png')
                         if verbosity > 2:
-                            print(f'Writing tile {tile_path}')
+                            LOG.info(f'Writing tile {tile_path}')
                         if not dry_run:
                             with open(tile_path, 'wb') as fp:
                                 fp.write(tile_bytes)
 
-    print(f'Done writing tile sets.')
+    LOG.info(f'Done writing tile sets.')

--- a/xcube/cli/verify.py
+++ b/xcube/cli/verify.py
@@ -22,7 +22,7 @@
 import sys
 
 import click
-
+from xcube.constants import LOG
 
 # noinspection PyShadowingBuiltins
 @click.command(name='verify')
@@ -53,7 +53,7 @@ def _verify(input_path: str = None, monitor=None):
     from xcube.core.dsio import open_dataset
     from xcube.core.verify import verify_cube
 
-    monitor(f'Opening cube from {input_path!r}...')
+    LOG.info(f'Opening cube from {input_path!r}...')
     with open_dataset(input_path) as cube:
         report = verify_cube(cube)
 

--- a/xcube/constants.py
+++ b/xcube/constants.py
@@ -87,5 +87,20 @@ RESAMPLING_METHOD_NAMES = {
     'Q3',
 }
 
+OFF_LOG_LEVEL = logging.CRITICAL + 1
+OFF_LOG_LEVEL_NAME = 'OFF'
+
+LOG_LEVELS = [
+    OFF_LOG_LEVEL_NAME,
+    'CRITICAL',
+    'ERROR',
+    'WARNING',
+    'INFO',
+    'DEBUG'
+]
+
+DEFAULT_LOG_LEVEL = OFF_LOG_LEVEL_NAME
+DEFAULT_LOG_FORMAT = '[%(levelname).1s %(asctime)s %(name)s] %(message)s'
+
 # xcube's standard logger
 LOG = logging.getLogger('xcube')

--- a/xcube/constants.py
+++ b/xcube/constants.py
@@ -87,20 +87,35 @@ RESAMPLING_METHOD_NAMES = {
     'Q3',
 }
 
-OFF_LOG_LEVEL = logging.CRITICAL + 1
-OFF_LOG_LEVEL_NAME = 'OFF'
+LOG_LEVEL_OFF_NAME = 'OFF'
+LOG_LEVEL_OFF = logging.CRITICAL + 5
+
+LOG_LEVEL_DETAIL_NAME = 'DETAIL'
+LOG_LEVEL_DETAIL = logging.DEBUG + 5
+
+LOG_LEVEL_TRACE_NAME = 'TRACE'
+LOG_LEVEL_TRACE = logging.DEBUG - 5
+
+logging.addLevelName(LOG_LEVEL_DETAIL, LOG_LEVEL_DETAIL_NAME)
+logging.addLevelName(LOG_LEVEL_TRACE, LOG_LEVEL_TRACE_NAME)
 
 LOG_LEVELS = [
-    OFF_LOG_LEVEL_NAME,
+    LOG_LEVEL_OFF_NAME,
     'CRITICAL',
     'ERROR',
     'WARNING',
     'INFO',
-    'DEBUG'
+    LOG_LEVEL_DETAIL_NAME,
+    'DEBUG',
+    LOG_LEVEL_TRACE_NAME
 ]
 
-DEFAULT_LOG_LEVEL = OFF_LOG_LEVEL_NAME
-DEFAULT_LOG_FORMAT = '[%(levelname).1s %(asctime)s %(name)s] %(message)s'
+DEFAULT_GENERAL_LOG_LEVEL = LOG_LEVEL_OFF
+DEFAULT_XCUBE_LOG_LEVEL = logging.WARNING
 
-# xcube's standard logger
+GENERAL_LOG_FORMAT = '[%(levelname).1s %(asctime)s %(name)s] %(message)s'
+XCUBE_LOG_FORMAT = '%(levelname)s: %(message)s'
+
+# xcube logger
 LOG = logging.getLogger('xcube')
+LOG.setLevel(DEFAULT_XCUBE_LOG_LEVEL)

--- a/xcube/core/gen/gen.py
+++ b/xcube/core/gen/gen.py
@@ -24,6 +24,7 @@ import glob
 import io
 import os
 import pstats
+import sys
 import time
 import traceback
 import warnings
@@ -203,7 +204,7 @@ def _process_input(input_processor: InputProcessor,
         monitor(f'Dataset read:\n{input_dataset}')
     except Exception as e:
         monitor(f'Error: cannot read input: {e}: skipping...')
-        traceback.print_exc()
+        traceback.print_exc(file=sys.stderr)
         return False
 
     time_range = input_processor.get_time_range(input_dataset)
@@ -360,7 +361,7 @@ def _process_input(input_processor: InputProcessor,
         monitor(f'{num_steps} steps took {total_t2 - total_t1} seconds to complete')
     except RuntimeError as e:
         monitor(f'Error: something went wrong during processing, skipping input slice: {e}')
-        traceback.print_exc()
+        traceback.print_exc(file=sys.stderr)
         status = False
     finally:
         input_dataset.close()

--- a/xcube/core/gen2/progress.py
+++ b/xcube/core/gen2/progress.py
@@ -31,6 +31,7 @@ from xcube.util.assertions import assert_true
 from xcube.util.progress import ProgressObserver
 from xcube.util.progress import ProgressState
 from .config import CallbackConfig
+from ...constants import LOG
 
 
 def _format_time(t):
@@ -208,7 +209,7 @@ class TerminalProgressCallbackObserver(_ThreadedProgressObserver):
         )
 
         if prt:
-            print(msg)
+            LOG.info(msg)
 
         return msg
 
@@ -216,16 +217,19 @@ class TerminalProgressCallbackObserver(_ThreadedProgressObserver):
 class ConsoleProgressObserver(ProgressObserver):
 
     def on_begin(self, state_stack: Sequence[ProgressState]):
-        print(self._format_progress(state_stack, status_label='...'))
+        LOG.info(self._format_progress(state_stack,
+                                       status_label='...'))
 
     def on_update(self, state_stack: Sequence[ProgressState]):
-        print(self._format_progress(state_stack))
+        LOG.info(self._format_progress(state_stack))
 
     def on_end(self, state_stack: Sequence[ProgressState]):
         if state_stack[0].exc_info:
-            print(self._format_progress(state_stack, status_label='error!'))
+            LOG.info(self._format_progress(state_stack,
+                                           status_label='error!'))
         else:
-            print(self._format_progress(state_stack, status_label='done.'))
+            LOG.info(self._format_progress(state_stack,
+                                           status_label='done.'))
 
     @classmethod
     def _format_progress(cls,

--- a/xcube/core/gen2/request.py
+++ b/xcube/core/gen2/request.py
@@ -39,6 +39,7 @@ from .config import CubeConfig
 from .config import InputConfig
 from .config import OutputConfig
 from .error import CubeGeneratorError
+from ...constants import LOG
 
 CubeGeneratorRequestLike = Union[str, Dict, 'CubeGeneratorRequest']
 
@@ -200,8 +201,8 @@ class CubeGeneratorRequest(JsonObject):
         request_dict = cls._load_request_file(request_file,
                                               verbosity=verbosity)
         if verbosity:
-            print(f'Cube generator request loaded '
-                  f'from {request_file or "TTY"}.')
+            LOG.info(f'Cube generator request loaded '
+                     f'from {request_file or "TTY"}.')
         return cls.from_dict(request_dict)
 
     @classmethod
@@ -218,8 +219,8 @@ class CubeGeneratorRequest(JsonObject):
             if gen_config_file is None:
                 if not sys.stdin.isatty():
                     if verbosity:
-                        print('Awaiting generator'
-                              ' request JSON from TTY...')
+                        LOG.info('Awaiting generator'
+                                 ' request JSON from TTY...')
                     return json.load(sys.stdin)
             else:
                 with open(gen_config_file, 'r') as fp:

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -386,7 +386,7 @@ class FileStorageMultiLevelDataset(LazyMultiLevelDataset):
                 if not os.path.isabs(level_path):
                     base_dir = os.path.dirname(self._dir_path)
                     level_path = os.path.join(base_dir, level_path)
-        with measure_time(tag=f"opened local dataset {level_path} for level {index}"):
+        with measure_time(tag=f"Opened local dataset {level_path} for level {index}"):
             return assert_cube(xr.open_zarr(level_path, **parameters), name=level_path)
 
     def _get_tile_grid_lazily(self) -> TileGrid:
@@ -491,7 +491,7 @@ class ObjectStorageMultiLevelDataset(LazyMultiLevelDataset):
         max_size = self.get_chunk_cache_capacity(index)
         if max_size:
             store = zarr.LRUStoreCache(store, max_size=max_size)
-        with measure_time(tag=f"opened remote dataset {level_path} for level {index}"):
+        with measure_time(tag=f"Opened remote dataset {level_path} for level {index}"):
             consolidated = self._s3_file_system.exists(f'{level_path}/.zmetadata')
             return assert_cube(xr.open_zarr(store, consolidated=consolidated, **parameters), name=level_path)
 
@@ -645,7 +645,7 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
         input_datasets = [self._input_ml_dataset_getter(ds_id).get_dataset(index)
                           for ds_id in self._input_ml_dataset_ids]
         try:
-            with measure_time(tag=f"computed in-memory dataset {self.ds_id!r} at level {index}"):
+            with measure_time(tag=f"Computed in-memory dataset {self.ds_id!r} at level {index}"):
                 computed_value = self._callable_obj(*input_datasets, **parameters)
         except Exception as e:
             raise self._exception_type(f"Failed to compute in-memory dataset {self.ds_id!r} at level {index} "
@@ -718,12 +718,12 @@ def open_ml_dataset_from_object_storage(path: str,
         store = s3fs.S3Map(root=root, s3=s3, check=False)
         if chunk_cache_capacity:
             store = zarr.LRUStoreCache(store, max_size=chunk_cache_capacity)
-        with measure_time(tag=f"opened remote zarr dataset {path}"):
+        with measure_time(tag=f"Opened remote zarr dataset {path}"):
             consolidated = s3.exists(f'{root}/.zmetadata')
             ds = assert_cube(xr.open_zarr(store, consolidated=consolidated, **kwargs))
         return BaseMultiLevelDataset(ds, ds_id=ds_id)
     elif data_format == FORMAT_NAME_LEVELS:
-        with measure_time(tag=f"opened remote levels dataset {path}"):
+        with measure_time(tag=f"Opened remote levels dataset {path}"):
             return ObjectStorageMultiLevelDataset(s3,
                                                   root,
                                                   zarr_kwargs=kwargs,
@@ -745,15 +745,15 @@ def open_ml_dataset_from_local_fs(path: str,
     data_format = data_format or guess_ml_dataset_format(path)
 
     if data_format == FORMAT_NAME_NETCDF4:
-        with measure_time(tag=f"opened local NetCDF dataset {path}"):
+        with measure_time(tag=f"Opened local NetCDF dataset {path}"):
             ds = assert_cube(xr.open_dataset(path, **kwargs))
             return BaseMultiLevelDataset(ds, ds_id=ds_id)
     elif data_format == FORMAT_NAME_ZARR:
-        with measure_time(tag=f"opened local zarr dataset {path}"):
+        with measure_time(tag=f"Opened local zarr dataset {path}"):
             ds = assert_cube(xr.open_zarr(path, **kwargs))
             return BaseMultiLevelDataset(ds, ds_id=ds_id)
     elif data_format == FORMAT_NAME_LEVELS:
-        with measure_time(tag=f"opened local levels dataset {path}"):
+        with measure_time(tag=f"Opened local levels dataset {path}"):
             return FileStorageMultiLevelDataset(path, ds_id=ds_id, zarr_kwargs=kwargs)
 
     raise exception_type(f'Unrecognized multi-level dataset format {data_format!r} for path {path!r}')
@@ -766,7 +766,7 @@ def open_ml_dataset_from_python_code(script_path: str,
                                      input_parameters: Mapping[str, Any] = None,
                                      ds_id: str = None,
                                      exception_type: type = ValueError) -> MultiLevelDataset:
-    with measure_time(tag=f"opened memory dataset {script_path}"):
+    with measure_time(tag=f"Opened memory dataset {script_path}"):
         return ComputedMultiLevelDataset(script_path,
                                          callable_name,
                                          input_ml_dataset_ids,
@@ -783,7 +783,7 @@ def augment_ml_dataset(ml_dataset: MultiLevelDataset,
                        input_ml_dataset_setter: Callable[[MultiLevelDataset], None],
                        input_parameters: Mapping[str, Any] = None,
                        exception_type: type = ValueError):
-    with measure_time(tag=f"added augmentation from {script_path}"):
+    with measure_time(tag=f"Added augmentation from {script_path}"):
         orig_id = ml_dataset.ds_id
         aug_id = uuid.uuid4()
         aug_inp_id = f'aug-input-{aug_id}'

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -30,7 +30,7 @@ import xarray as xr
 import zarr
 from deprecated import deprecated
 
-from xcube.constants import FORMAT_NAME_LEVELS
+from xcube.constants import FORMAT_NAME_LEVELS, LOG
 from xcube.constants import FORMAT_NAME_NETCDF4
 from xcube.constants import FORMAT_NAME_SCRIPT
 from xcube.constants import FORMAT_NAME_ZARR
@@ -813,10 +813,10 @@ def write_levels(ml_dataset: MultiLevelDataset,
     for level in range(ml_dataset.num_levels):
         level_dataset = ml_dataset.get_dataset(level)
         level_dataset = level_dataset.chunk(chunks)
-        print(f'writing level {level + 1}...')
+        LOG.info(f'writing level {level + 1}...')
         write_cube(level_dataset,
                    f'{levels_path}/{level}.zarr',
                    'zarr',
                    s3_kwargs=s3_kwargs,
                    s3_client_kwargs=s3_client_kwargs)
-        print(f'written level {level + 1}')
+        LOG.info(f'written level {level + 1}')

--- a/xcube/util/cache.py
+++ b/xcube/util/cache.py
@@ -31,6 +31,8 @@ from typing import Optional
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
+from xcube.constants import LOG
+
 _DEBUG_CACHE = False
 
 
@@ -412,7 +414,7 @@ class Cache:
 
 
 def _debug_print(msg):
-    print("Cache:", msg)
+    LOG.debug("Cache:", msg)
 
 
 def _compute_object_size(obj):

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -122,7 +122,7 @@ def get_cmap(cmap_name: str, default_cmap_name='viridis', num_colors: int = None
         cmap = cm.get_cmap(cmap_name, num_colors)
     except ValueError as e:
         LOG.warning(str(e))
-        LOG.warning(f'color map name {cmap_name!r} undefined, falling back to {default_cmap_name!r}')
+        LOG.warning(f'Color map name {cmap_name!r} undefined, falling back to {default_cmap_name!r}')
         cmap_name = default_cmap_name
         cmap = cm.get_cmap(cmap_name, num_colors)
     return cmap_name, cmap
@@ -170,7 +170,7 @@ def ensure_cmaps_loaded():
                         else:
                             cmap = cm.get_cmap(cmap_name)
                     except ValueError:
-                        LOG.warning('detected invalid colormap "%s"' % cmap_name)
+                        LOG.warning('Detected invalid colormap "%s"' % cmap_name)
                         continue
                     # Add extra colormaps with alpha gradient
                     # see http://matplotlib.org/api/colors_api.html
@@ -204,7 +204,7 @@ def ensure_cmaps_loaded():
                         cm.register_cmap(cmap=new_cmap)
                     else:
                         new_name = cmap.name + '_alpha' if hasattr(cmap, 'name') else 'unknown'
-                        LOG.warning('could not create colormap "{}" because "{}" is of unknown type {}'
+                        LOG.warning('Could not create colormap "{}" because "{}" is of unknown type {}'
                                     .format(new_name, cmap.name, type(cmap)))
 
                     cbar_list.append((cmap_name, _get_cbar_png_bytes(cmap)))

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -22,6 +22,7 @@
 import abc
 import importlib
 import pkgutil
+import sys
 import time
 import traceback
 import warnings
@@ -135,7 +136,7 @@ def load_plugins(entry_points=None, ext_registry=None):
 def _handle_error(entry_point, e):
     # We use warning and not raise to allow loading xcube despite a broken plugin. Raise would stop xcube.
     warnings.warn(f'Unexpected exception while loading xcube plugin {entry_point.name!r}: {e}')
-    traceback.print_exc()
+    traceback.print_exc(file=sys.stderr)
 
 
 class _ModuleEntryPoint:

--- a/xcube/util/plugin.py
+++ b/xcube/util/plugin.py
@@ -69,7 +69,8 @@ def discover_plugin_modules(module_prefixes=None):
     entry_points = []
     for module_finder, module_name, ispkg in pkgutil.iter_modules():
         if any([module_name.startswith(module_prefix) for module_prefix in module_prefixes]):
-            # TODO (forman): Consider turning this into debug log:
+            # Note: Consider turning this into debug log,
+            #  but logging is not yet configured at this point.
             # print(f'xcube plugin module found: {module_name}')
             entry_points.append(_ModuleEntryPoint(module_name))
     return entry_points
@@ -87,7 +88,8 @@ def load_plugins(entry_points=None, ext_registry=None):
     plugins = {}
 
     for entry_point in entry_points:
-        # TODO (forman): Consider turning this into debug log:
+        # Note: Consider turning this into debug log,
+        #  but logging is not yet configured at this point.
         # print(f'loading xcube plugin {entry_point.name!r}')
 
         t0 = time.perf_counter()

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -424,7 +424,7 @@ class ServiceContext:
 
         all_dataset_configs: List[DatasetConfigDict] = []
         for store_instance_id in data_store_pool.store_instance_ids:
-            LOG.info(f'scanning store {store_instance_id!r}')
+            LOG.info(f'Scanning store {store_instance_id!r}')
             data_store_config = data_store_pool.get_store_config(
                 store_instance_id
             )
@@ -460,7 +460,7 @@ class ServiceContext:
                         else:
                             dataset_config_base = None
                 if dataset_config_base is not None:
-                    LOG.debug(f'selected dataset {store_dataset_id!r}')
+                    LOG.debug(f'Selected dataset {store_dataset_id!r}')
                     dataset_config = dict(
                         StoreInstanceId=store_instance_id,
                         **dataset_config_base
@@ -475,7 +475,7 @@ class ServiceContext:
         debug_file = 'all_dataset_configs.json'
         with open(debug_file, 'w') as stream:
             json.dump(all_dataset_configs, stream)
-            LOG.debug(f'wrote file {debug_file!r}')
+            LOG.debug(f'Wrote file {debug_file!r}')
 
         return all_dataset_configs
 
@@ -490,9 +490,9 @@ class ServiceContext:
         if dataset_metadata.crs is not None:
             crs = pyproj.CRS.from_string(dataset_metadata.crs)
             if not crs.is_geographic:
-                LOG.warn(f'ignoring dataset {dataset_id!r} from'
-                         f' store instance {store_instance_id!r}'
-                         f' because it uses a non-geographic CRS')
+                LOG.warning(f'Ignoring dataset {dataset_id!r} from'
+                            f' store instance {store_instance_id!r}'
+                            f' because it uses a non-geographic CRS')
                 return None
         # noinspection PyTypeChecker
         return dataset_metadata
@@ -647,7 +647,7 @@ class ServiceContext:
                          or data_id.endswith('.levels')) \
                     and 'cache_size' not in open_params:
                 open_params['cache_size'] = chunk_cache_capacity
-            with self.measure_time(tag=f"opened dataset {ds_id!r}"
+            with self.measure_time(tag=f"Opened dataset {ds_id!r}"
                                        f" from data store"
                                        f" {store_instance_id!r}"):
                 dataset = data_store.open_data(data_id, **open_params)
@@ -666,7 +666,7 @@ class ServiceContext:
                 raise ServiceConfigError(f"Invalid FileSystem {fs_type!r}"
                                          f" in dataset configuration"
                                          f" {ds_id!r}")
-            with self.measure_time(tag=f"opened dataset {ds_id!r}"
+            with self.measure_time(tag=f"Opened dataset {ds_id!r}"
                                        f" from {fs_type!r}"):
                 ml_dataset = _open_ml_dataset_from_python_code(self,
                                                                dataset_config)

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -116,7 +116,7 @@ def get_datasets(ctx: ServiceContext,
                         )
                     filtered_dataset_dicts.append(dataset_dict)
                 except (DatasetIsNotACubeError, CubeIsNotDisplayable) as e:
-                    LOG.warning(f'skipping dataset {ds_id}: {e}')
+                    LOG.warning(f'Skipping dataset {ds_id}: {e}')
             dataset_dicts = filtered_dataset_dicts
     if point:
         is_point_in_dataset_bbox = functools.partial(

--- a/xcube/webapi/defaults.py
+++ b/xcube/webapi/defaults.py
@@ -20,14 +20,13 @@
 # SOFTWARE.
 
 SERVER_NAME = 'xcube Server'
-SERVER_DESCRIPTION = f'WMTS, catalogue, data access, tile, feature, time-series services for' \
-                     ' xarray-enabled data cubes'
+SERVER_DESCRIPTION = f'WMTS, catalogue, data access, tile, feature,' \
+                     f' time-series services for xarray-enabled data cubes'
 
 DEFAULT_ADDRESS = 'localhost'
 DEFAULT_PORT = 8080
 DEFAULT_TILE_CACHE_SIZE = "512M"
 DEFAULT_UPDATE_PERIOD = 2.
-DEFAULT_LOG_PREFIX = 'xcube-serve.log'
 DEFAULT_TILE_COMP_MODE = 0
 DEFAULT_TRACE_PERF = False
 

--- a/xcube/webapi/handlers.py
+++ b/xcube/webapi/handlers.py
@@ -126,7 +126,7 @@ class GetWMTSCapabilitiesXmlHandler(ServiceRequestHandler):
 class GetDatasetsHandler(ServiceRequestHandler, AuthMixin):
 
     def get(self):
-        with measure_time('get granted scopes'):
+        with measure_time('Get granted scopes'):
             granted_scopes = self.granted_scopes
         details = bool(int(self.params.get_query_argument('details', '0')))
         tile_client = self.params.get_query_argument('tiles', None)
@@ -145,7 +145,7 @@ class GetDatasetsHandler(ServiceRequestHandler, AuthMixin):
 class GetDatasetHandler(ServiceRequestHandler, AuthMixin):
 
     def get(self, ds_id: str):
-        with measure_time('get granted scopes'):
+        with measure_time('Get granted scopes'):
             granted_scopes = self.granted_scopes
         tile_client = self.params.get_query_argument('tiles', None)
         response = get_dataset(self.service_context,

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -22,12 +22,14 @@
 import asyncio
 import configparser
 import json
+import logging
 import os
 import os.path
 import signal
 import sys
 import time
 import traceback
+import warnings
 from datetime import datetime
 from json import JSONDecodeError
 from typing import Optional, Dict, List, Tuple, Mapping
@@ -35,7 +37,6 @@ from typing import Optional, Dict, List, Tuple, Mapping
 import tornado.escape
 import tornado.options
 from tornado.ioloop import IOLoop
-from tornado.log import enable_pretty_logging
 from tornado.web import Application
 from tornado.web import RequestHandler
 
@@ -50,7 +51,6 @@ from xcube.util.undefined import UNDEFINED
 from xcube.version import version
 from xcube.webapi.context import ServiceContext
 from xcube.webapi.defaults import DEFAULT_ADDRESS
-from xcube.webapi.defaults import DEFAULT_LOG_PREFIX
 from xcube.webapi.defaults import DEFAULT_PORT
 from xcube.webapi.defaults import DEFAULT_TILE_CACHE_SIZE
 from xcube.webapi.defaults import DEFAULT_TILE_COMP_MODE
@@ -82,8 +82,8 @@ class Service:
                  tile_comp_mode: int = DEFAULT_TILE_COMP_MODE,
                  update_period: Optional[float] = DEFAULT_UPDATE_PERIOD,
                  trace_perf: bool = DEFAULT_TRACE_PERF,
-                 log_file_prefix: str = DEFAULT_LOG_PREFIX,
-                 log_to_stderr: bool = False,
+                 log_file_prefix: str = None,
+                 log_to_stderr: bool = None,
                  aws_prof: str = None,
                  aws_env: bool = False) -> None:
 
@@ -108,34 +108,46 @@ class Service:
         :return: service information dictionary
         """
         if config_file and cube_paths:
-            raise ValueError("config_file and cube_paths cannot be given both")
+            raise ValueError(
+                "config_file and cube_paths cannot be given both")
         if config_file and styles:
             raise ValueError("config_file and styles cannot be given both")
         if config_file and aws_prof:
-            raise ValueError("config_file and aws_profile cannot be given both")
+            raise ValueError(
+                "config_file and aws_profile cannot be given both")
         if config_file and aws_env:
             raise ValueError("config_file and aws_env cannot be given both")
+        if log_to_stderr is not None:
+            warnings.warn('log_to_stderr has been deprecated.'
+                          ' xcube now always logs to stderr.',
+                          DeprecationWarning)
+        if log_file_prefix is not None:
+            warnings.warn('log_file_prefix has been deprecated.'
+                          ' xcube now always logs to stderr.',
+                          DeprecationWarning)
 
         global SNAP_CPD_LIST
         if config_file:
             SNAP_CPD_LIST = _get_custom_color_list(config_file)
 
-        log_dir = os.path.dirname(log_file_prefix)
-        if log_dir and not os.path.isdir(log_dir):
-            os.makedirs(log_dir, exist_ok=True)
-
-        options = tornado.options.options
-        options.log_file_prefix = log_file_prefix or DEFAULT_LOG_PREFIX
-        options.log_to_stderr = log_to_stderr
-        enable_pretty_logging()
-
         tile_cache_capacity = parse_mem_size(tile_cache_size)
+
+        # Configure Tornado logger to use (xcube) root handlers
+        tornado_logger = logging.getLogger('tornado')
+        for h in list(tornado_logger.handlers):
+            tornado_logger.removeHandler(h)
+            h.close()
+        for h in list(logging.root.handlers):
+            tornado_logger.addHandler(h)
+        tornado_logger.setLevel(logging.INFO)
 
         config = None
         if cube_paths:
-            config = new_default_config(cube_paths, styles, aws_prof=aws_prof, aws_env=aws_env)
+            config = new_default_config(cube_paths, styles, aws_prof=aws_prof,
+                                        aws_env=aws_env)
 
-        self.config_file = os.path.abspath(config_file) if config_file else None
+        self.config_file = os.path.abspath(
+            config_file) if config_file else None
         self.update_period = update_period
         self.update_timer = None
         self.config_error = None

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -139,7 +139,7 @@ class Service:
             h.close()
         for h in list(logging.root.handlers):
             tornado_logger.addHandler(h)
-        tornado_logger.setLevel(logging.INFO)
+        tornado_logger.setLevel(logging.root.level)
 
         config = None
         if cube_paths:

--- a/xcube/webapi/service.py
+++ b/xcube/webapi/service.py
@@ -114,16 +114,16 @@ class Service:
             raise ValueError("config_file and styles cannot be given both")
         if config_file and aws_prof:
             raise ValueError(
-                "config_file and aws_profile cannot be given both")
+                "config_file and aws_prof cannot be given both")
         if config_file and aws_env:
             raise ValueError("config_file and aws_env cannot be given both")
         if log_to_stderr is not None:
             warnings.warn('log_to_stderr has been deprecated.'
-                          ' xcube now always logs to stderr.',
+                          ' Configure "root" or "xcube" loggers instead.',
                           DeprecationWarning)
         if log_file_prefix is not None:
             warnings.warn('log_file_prefix has been deprecated.'
-                          ' xcube now always logs to stderr.',
+                          ' Configure "root" or "xcube" loggers instead.',
                           DeprecationWarning)
 
         global SNAP_CPD_LIST
@@ -132,7 +132,9 @@ class Service:
 
         tile_cache_capacity = parse_mem_size(tile_cache_size)
 
-        # Configure Tornado logger to use (xcube) root handlers
+        # Configure Tornado logger to use configured root handlers.
+        # For some reason, Tornado's log records will not arrive at
+        # the root logger.
         tornado_logger = logging.getLogger('tornado')
         for h in list(tornado_logger.handlers):
             tornado_logger.removeHandler(h)
@@ -183,11 +185,11 @@ class Service:
         address = self.service_info['address']
         port = self.service_info['port']
         test_url = self.context.get_service_url(f"http://{address}:{port}", "datasets")
-        LOG.info(f'service running, listening on {address}:{port}, try {test_url}')
-        LOG.info(f'press CTRL+C to stop service')
+        LOG.info(f'Service running, listening on {address}:{port}, try {test_url}')
+        LOG.info(f'Press CTRL+C to stop service')
         if not self.context.config.get('Datasets', []) \
                 and not self.context.config.get('DataStores', []):
-            LOG.warning('no datasets or data stores configured')
+            LOG.warning('No datasets or data stores configured')
         tornado.ioloop.PeriodicCallback(self._try_shutdown, 100).start()
         IOLoop.current().start()
 
@@ -202,7 +204,7 @@ class Service:
 
     def _on_shutdown(self):
 
-        LOG.info('stopping service...')
+        LOG.info('Stopping service...')
 
         # noinspection PyUnresolvedReferences,PyBroadException
         try:
@@ -215,7 +217,7 @@ class Service:
             self.server = None
 
         IOLoop.current().stop()
-        LOG.info('service stopped.')
+        LOG.info('Service stopped.')
 
     def _try_shutdown(self):
         if self._shutdown_requested:
@@ -223,7 +225,7 @@ class Service:
 
     # noinspection PyUnusedLocal
     def _sig_handler(self, sig, frame):
-        LOG.warning(f'caught signal {sig}')
+        LOG.warning(f'Caught signal {sig}')
         self._shutdown_requested = True
 
     def _maybe_install_update_check(self):
@@ -244,7 +246,7 @@ class Service:
             stat = os.stat(config_file)
         except OSError as e:
             if self.config_error is None:
-                LOG.error(f'configuration file {config_file!r}: {e}')
+                LOG.error(f'Configuration file {config_file!r}: {e}')
                 self.config_error = e
             return
 
@@ -253,10 +255,10 @@ class Service:
             try:
                 self.context.config = load_json_or_yaml_config(config_file)
                 self.config_error = None
-                LOG.info(f'configuration file {config_file!r} successfully loaded')
+                LOG.info(f'Configuration file {config_file!r} successfully loaded')
             except ValueError as e:
                 if self.config_error is None:
-                    LOG.error(f'configuration file {config_file!r}: {e}')
+                    LOG.error(f'Configuration file {config_file!r}: {e}')
                     self.config_error = e
 
 


### PR DESCRIPTION
Closes #659 

However, the implementation enhances and details the original proposal in #659.
This is was has been implemented in this PR:

---

The xcube package now consistently makes use of logging.
We distinguish general logging and xcube logging.
General logging refers to the log messages of any Python module while
xcube logging only refers to log messages emitted by xcube modules.

* The output of general logging from xcube CLI tools can now be 
  configured with two new CLI options: 
    
  - `--loglevel LEVEL`: Can be one of `CRITICAL`, `ERROR`,
    `WARNING`, `INFO`, `DETAIL`, `DEBUG`, `TRACE`, or `OFF` (the default).
  - `--logfile PATH`: Effective only if log level is not `OFF`.
    If given, log messages will be written into the file
    given by PATH. If omitted, log messages will be redirected 
    to standard error (`sys.stderr`).

  The output of general logging from xcube CLI is disabled by default.
  If enabled, the log message format includes the level, date-time,
  logger name, and message.

* All xcube modules use the logger named `xcube` 
  (i.e. `LOG = logging.getLogger("xcube")`) to emit 
  messages regarding progress, debugging, errors. Packages that extend
  the xcube package should use a dot suffix for their logger names, e.g.
  `xcube.cci` for the xcube plugin package `xcube-cci`.
  
* All xcube CLI tools will output log messages, if any, 
  on standard error (`sys.stderr`). 
  Only the actual result, if any, 
  is written to standard out (`sys.stdout`).

* Some xcube CLI tools have a `--quiet`/`-q` option to disable output
  of log messages on the console and a `--verbose`/`-v` option to enable 
  it and control the log level. For this purpose the option `-v` 
  can be given multiple times and even be combined: `-v` = `INFO`, 
  `-vv` = `DETAIL`, `-vvv` = `DEBUG`, `-vvvv` = `TRACE`.
  The `quiet` and `verbose` settings only affect the logger named `xcube`
  and its children. 
  If enabled, a simple message format will be used, unless the general 
  logging is redirected to stdout.

---

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
