### PR TITLE
Publish dataset time chunks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Changes in 0.11.2 (in development)
 
+* `xcube serve` now publishes the chunk size of a variable's 
+  time dimension for either for an associated time-chunked dataset or the
+  dataset itself (new variable integer property `timeChunkSize`).
+  This helps clients (e.g. xcube Viewer) to improve the 
+  server performance for time-series requests.
+
 ## Changes in 0.11.1
 
 * Fixed broken generation of composite RGBA tiles. (#668)

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -3,10 +3,12 @@ import unittest
 from typing import Any, Optional
 
 from test.webapi.helpers import new_test_service_context
+from xcube.core.new import new_cube
 from xcube.webapi.context import ServiceContext
 from xcube.webapi.controllers.catalogue import get_color_bars
 from xcube.webapi.controllers.catalogue import get_dataset
 from xcube.webapi.controllers.catalogue import get_datasets
+from xcube.webapi.controllers.catalogue import get_time_chunk_size
 from xcube.webapi.errors import ServiceBadRequestError, ServiceAuthError
 
 
@@ -345,3 +347,42 @@ class CatalogueControllerTest(unittest.TestCase):
         if expected_count is not None:
             self.assertEqual(expected_count, len(datasets))
         return datasets
+
+
+class TimeChunkSizeTest(unittest.TestCase):
+
+    @staticmethod
+    def _get_cube(time_chunk_size: int = None):
+        ts_ds = new_cube(time_periods=10, variables=dict(CHL=10.2))
+        if time_chunk_size:
+            ts_ds = ts_ds.assign(
+                CHL=ts_ds.CHL.chunk(dict(time=time_chunk_size))
+            )
+        return ts_ds
+
+    def test_get_time_chunk_size_is_ok(self):
+        ts_ds = self._get_cube(time_chunk_size=1)
+        self.assertEqual(1, get_time_chunk_size(ts_ds, 'CHL', 'ds.zarr'))
+
+        ts_ds = self._get_cube(time_chunk_size=3)
+        self.assertEqual(3, get_time_chunk_size(ts_ds, 'CHL', 'ds.zarr'))
+
+        ts_ds = self._get_cube(time_chunk_size=5)
+        self.assertEqual(5, get_time_chunk_size(ts_ds, 'CHL', 'ds.zarr'))
+
+        ts_ds = self._get_cube(time_chunk_size=10)
+        self.assertEqual(10, get_time_chunk_size(ts_ds, 'CHL', 'ds.zarr'))
+
+    def test_get_time_chunk_size_fails(self):
+        # TS dataset not given
+        self.assertEqual(None, get_time_chunk_size(None, 'CHL', 'ds.zarr'))
+        # Variable not found
+        ts_ds = self._get_cube(time_chunk_size=5)
+        self.assertEqual(None, get_time_chunk_size(ts_ds, 'MCI', 'ds.zarr'))
+        # Time is not chunked
+        ts_ds = self._get_cube(time_chunk_size=None)
+        self.assertEqual(None, get_time_chunk_size(ts_ds, 'CHL', 'ds.zarr'))
+        # Variable has no dimension "time"
+        ts_ds = self._get_cube(time_chunk_size=5)
+        ts_ds['CHL0'] = ts_ds.CHL.isel(time=0)
+        self.assertEqual(None, get_time_chunk_size(ts_ds, 'CHL0', 'ds.zarr'))


### PR DESCRIPTION
In this PR:

`xcube serve` now publishes the chunk size of a variable's time dimension for either for an associated time-chunked dataset or the dataset itself (new variable integer property `timeChunkSize`). 
This helps clients (e.g. xcube Viewer) to improve the server performance for time-series requests.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
