### PR TITLE
Enhance xcube affine_transform_dataset()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,12 @@
 
 ### Other changes
 
+* `xcube.core.resampling.affine_transform_dataset()` has a new 
+  keyword argument `reuse_coords: bool = False`. If set to `True` 
+  the returned dataset will reuse the _same_ spatial coordinates 
+  as the target. This is a workaround for xarray issue 
+  https://github.com/pydata/xarray/issues/6573.
+
 * Deprecated following functions of module `xcube.core.geom`:
   - `is_dataset_y_axis_inverted()` is no longer used;
   - `get_geometry_mask()` is no longer used;

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -540,7 +540,9 @@ class GridMapping(abc.ABC):
     def to_coords(self,
                   xy_var_names: Tuple[str, str] = None,
                   xy_dim_names: Tuple[str, str] = None,
-                  exclude_bounds: bool = False) \
+                  exclude_bounds: bool = False,
+                  reuse_coords: bool = False,
+                  ) \
             -> Mapping[str, xr.DataArray]:
         """
         Get CF-compliant axis coordinate variables and cell boundary
@@ -554,6 +556,9 @@ class GridMapping(abc.ABC):
             names (x_dim_name, y_dim_name).
         :param exclude_bounds: If True, do not create bounds
             coordinates. Defaults to False.
+        :param reuse_coords: Whether to either reuse target
+            coordinate arrays from target_gm or to compute
+            new ones.
         :return: dictionary with coordinate variables
         """
         self._assert_regular()
@@ -561,7 +566,8 @@ class GridMapping(abc.ABC):
         return grid_mapping_to_coords(self,
                                       xy_var_names=xy_var_names,
                                       xy_dim_names=xy_dim_names,
-                                      exclude_bounds=exclude_bounds)
+                                      exclude_bounds=exclude_bounds,
+                                      reuse_coords=reuse_coords)
 
     def transform(self,
                   crs: Union[str, pyproj.crs.CRS],

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -40,7 +40,8 @@ def affine_transform_dataset(
         dataset: xr.Dataset,
         source_gm: GridMapping,
         target_gm: GridMapping,
-        var_configs: Mapping[Hashable, Mapping[str, Any]] = None
+        var_configs: Mapping[Hashable, Mapping[str, Any]] = None,
+        reuse_coords: bool = False,
 ) -> xr.Dataset:
     """
     Resample dataset according to an affine transformation.
@@ -52,6 +53,9 @@ def affine_transform_dataset(
         Must be regular. Must have same CRS as *source_gm*.
     :param var_configs: Optional resampling configurations
         for individual variables.
+    :param reuse_coords: Whether to either reuse target
+        coordinate arrays from target_gm or to compute
+        new ones.
     :return: The resampled target dataset.
     """
     if source_gm.crs != target_gm.crs:
@@ -73,7 +77,8 @@ def affine_transform_dataset(
     new_coords = target_gm.to_coords(
         xy_var_names=source_gm.xy_var_names,
         xy_dim_names=source_gm.xy_dim_names,
-        exclude_bounds=not has_bounds
+        exclude_bounds=not has_bounds,
+        reuse_coords=reuse_coords
     )
     return resampled_dataset.assign_coords(new_coords)
 


### PR DESCRIPTION
`xcube.core.resampling.affine_transform_dataset()` has a new keyword argument `reuse_coords: bool = False`. If set to `True` the returned dataset will reuse the _same_ spatial coordinates as the target. This is a workaround for xarray issue https://github.com/pydata/xarray/issues/6573.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
