### PR TITLE
xcube serve does not provide datasets after service configuration changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,8 @@
 * Fixed ESA CCI example notebook. (#680)
 
 * `xcube serve` now provides datasets after changes of the service 
-  configuration.
-  Previously, it was necessary to restart a service to load the changes. (#678)
+  configuration while the server is running.
+  Previously, it was necessary to restart the server to load the changes. (#678)
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-### Enhancements
-
 ## Changes in 0.11.2 (in development)
+
+### Enhancements
 
 * `xcube serve` now publishes the chunk size of a variable's 
   time dimension for either for an associated time-chunked dataset or the
@@ -17,6 +17,11 @@
   that have arbitrarily large spatial dimensions. 
   The spatial chunk sizes to be used can be specified using 
   keyword argument `tile_size`. (#666)
+
+### Fixes
+
+* xcube serve now provides datasets after changes of the service configuration.
+  Previously, it was necessary to restart a service to load the changes. (#678)
 
 ### Other changes
 

--- a/test/webapi/test_context.py
+++ b/test/webapi/test_context.py
@@ -64,7 +64,9 @@ class ServiceContextTest(unittest.TestCase):
     def test_get_dataset_configs_from_stores(self):
         ctx = new_test_service_context(config_file_name='config-datastores.yml')
 
-        dataset_configs_from_stores = ctx.get_dataset_configs_from_stores()
+        dataset_configs_from_stores = ctx.get_dataset_configs_from_stores(
+            ctx.get_data_store_pool()
+        )
         self.assertIsNotNone(dataset_configs_from_stores)
         self.assertEqual(3, len(dataset_configs_from_stores))
         ids = [config['Identifier'] for config in dataset_configs_from_stores]

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -302,9 +302,10 @@ class ServiceContext:
         return dataset[var_name]
 
     def get_dataset_configs(self) -> List[DatasetConfigDict]:
-        with self._lock:
-            if self._dataset_configs is None:
-                self._set_up_data_store_pool_and_dataset_configs()
+        if self._dataset_configs is None:
+            with self._lock:
+                if self._dataset_configs is None:
+                    self._set_up_data_store_pool_and_dataset_configs()
         return self._dataset_configs
 
     def _maybe_assign_store_instance_ids(self, data_store_pool: DataStorePool):
@@ -487,9 +488,10 @@ class ServiceContext:
         return dataset_metadata
 
     def get_data_store_pool(self) -> DataStorePool:
-        with self._lock:
-            if self._data_store_pool.is_empty:
-                self._set_up_data_store_pool_and_dataset_configs()
+        if self._data_store_pool.is_empty:
+            with self._lock:
+                if self._data_store_pool.is_empty:
+                    self._set_up_data_store_pool_and_dataset_configs()
         return self._data_store_pool
 
     def _set_up_data_store_pool_and_dataset_configs(self):


### PR DESCRIPTION
Solves #678. The changes in this PR ensure that there is always a DataStorePool in the service context, and that the dataset_configs correspond to its content. The DataStorePool is repopulated when it has been emptied, which usually happens after an external config change.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
