### PR TITLE
xcube server to provide spatial reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in 0.11.3 (in development)
+
+* xcube Server now provides a shorthand for the spatial reference 
+  in its dataset detail responses. The property `spatial_ref` now holds a
+  textual representation of the spatial CRS.
+
 ## Changes in 0.11.2
 
 ### Enhancements
@@ -38,8 +44,7 @@
   - `is_dataset_y_axis_inverted()` is no longer used;
   - `get_geometry_mask()` is no longer used;
   - `convert_geometry()` has been renamed to `normalize_geometry()`.
-
-
+  
 ## Changes in 0.11.1
 
 * Fixed broken generation of composite RGBA tiles. (#668)

--- a/environment.yml
+++ b/environment.yml
@@ -13,14 +13,14 @@ dependencies:
   - dask-image >=0.6
   - deprecated >=1.2
   - distributed >=2021.6
-  - fiona >=1.8
+  - fiona <1.8.4  # fiona-1.8.4 requires click <8, but we want 8
   - fontconfig <2.13.96  # temporary workaround for Mac CI bug; see Issue #640
   - fsspec >=2021.6
   - gdal >=3.0
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
-  - libgdal <3.4
+  - libgdal <3.3  # ImportError: dlopen(/Users/appveyor/mamba-env/lib/python3.9
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
-  - libgdal <=3.2.2
+  - libgdal <3.4
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
+  - libgdal <=3.2.2
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -228,7 +228,7 @@ class CatalogueControllerTest(unittest.TestCase):
             self.assertIsInstance(dataset.get("variables"), (tuple, list))
             self.assertIsInstance(dataset.get("dimensions"), (tuple, list))
             self.assertIsInstance(dataset.get("bbox"), (tuple, list))
-            self.assertIsInstance(dataset.get("spatial_ref"), str)
+            self.assertIsInstance(dataset.get("spatialRef"), str)
             self.assertNotIn("rgbSchema", dataset)
             if dataset["id"] == "demo":
                 demo_dataset = dataset

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -222,11 +222,13 @@ class CatalogueControllerTest(unittest.TestCase):
         demo_1w_dataset = None
         for dataset in datasets:
             self.assertIsInstance(dataset, dict)
-            self.assertIn("id", dataset)
-            self.assertIn("title", dataset)
-            self.assertIn("attributions", dataset)
-            self.assertIn("variables", dataset)
-            self.assertIn("dimensions", dataset)
+            self.assertIsInstance(dataset.get("id"), str)
+            self.assertIsInstance(dataset.get("title"), str)
+            self.assertIsInstance(dataset.get("attributions"), (tuple, list))
+            self.assertIsInstance(dataset.get("variables"), (tuple, list))
+            self.assertIsInstance(dataset.get("dimensions"), (tuple, list))
+            self.assertIsInstance(dataset.get("bbox"), (tuple, list))
+            self.assertIsInstance(dataset.get("spatial_ref"), str)
             self.assertNotIn("rgbSchema", dataset)
             if dataset["id"] == "demo":
                 demo_dataset = dataset

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -172,14 +172,17 @@ def get_dataset(ctx: ServiceContext,
                                                             ds_id)))
     dataset_dict = dict(id=ds_id, title=ds_title)
 
+    crs = ml_ds.grid_mapping.crs
+
     if "bbox" not in dataset_dict:
         x1, y1, x2, y2 = get_dataset_bounds(ds)
-        crs = ml_ds.grid_mapping.crs
         if not crs.is_geographic:
             geo_crs = pyproj.CRS.from_string('CRS84')
             t = pyproj.Transformer.from_crs(crs, geo_crs, always_xy=True)
             (x1, x2), (y1, y2) = t.transform((x1, x2), (y1, y2))
         dataset_dict["bbox"] = [x1, y1, x2, y2]
+
+    dataset_dict['spatial_ref'] = crs.to_string()
 
     variable_dicts = []
     dim_names = set()

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -182,7 +182,7 @@ def get_dataset(ctx: ServiceContext,
             (x1, x2), (y1, y2) = t.transform((x1, x2), (y1, y2))
         dataset_dict["bbox"] = [x1, y1, x2, y2]
 
-    dataset_dict['spatial_ref'] = crs.to_string()
+    dataset_dict['spatialRef'] = crs.to_string()
 
     variable_dicts = []
     dim_names = set()


### PR DESCRIPTION
xcube Server now provides a shorthand for the spatial reference in its dataset detail responses. The property `spatial_ref` now holds a textual representation of the spatial CRS.

This PR is required to address https://github.com/dcs4cop/xcube-viewer/issues/225

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
