### PR TITLE
Webapi to provide dataset geometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Changes in 0.11.3 (in development)
+
+* xcube Server now provides a shorthand for the spatial reference 
+  in its dataset detail responses. The property `spatial_ref` now holds a
+  textual representation of the spatial CRS.
+
 ## Changes in 0.11.2
 
 ### Enhancements
@@ -38,8 +44,7 @@
   - `is_dataset_y_axis_inverted()` is no longer used;
   - `get_geometry_mask()` is no longer used;
   - `convert_geometry()` has been renamed to `normalize_geometry()`.
-
-
+  
 ## Changes in 0.11.1
 
 * Fixed broken generation of composite RGBA tiles. (#668)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,13 @@
-## Changes in 0.11.3 (in development)
+## Changes in 0.11.2 (in development)
 
-* xcube Server now provides new metadata details of a dataset:
+### Enhancements
+
+* `xcube serve` now provides new metadata details of a dataset:
   - The spatial reference is now given by property `spatialRef` 
     and provides a textual representation of the spatial CRS.
   - The dataset boundary is now given as property `geometry`
     and provides a GeoJSON Polygon in geographic coordinates. 
-
-## Changes in 0.11.2
-
-### Enhancements
-
+    
 * `xcube serve` now publishes the chunk size of a variable's 
   time dimension for either for an associated time-chunked dataset or the
   dataset itself (new variable integer property `timeChunkSize`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 ## Changes in 0.11.3 (in development)
 
-* xcube Server now provides a shorthand for the spatial reference 
-  in its dataset detail responses. The property `spatial_ref` now holds a
-  textual representation of the spatial CRS.
+* xcube Server now provides new metadata details of a dataset:
+  - The spatial reference is now given by property `spatialRef` 
+    and provides a textual representation of the spatial CRS.
+  - The dataset boundary is now given as property `geometry`
+    and provides a GeoJSON Polygon in geographic coordinates. 
 
 ## Changes in 0.11.2
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,14 +13,13 @@ dependencies:
   - dask-image >=0.6
   - deprecated >=1.2
   - distributed >=2021.6
-  - fiona <1.8.4  # fiona-1.8.4 requires click <8, but we want 8
+  - fiona >=1.8
   - fontconfig <2.13.96  # temporary workaround for Mac CI bug; see Issue #640
   - fsspec >=2021.6
   - gdal >=3.0
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
-  - libgdal <3.3  # ImportError: dlopen(/Users/appveyor/mamba-env/lib/python3.9
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/environment.yml
+++ b/environment.yml
@@ -13,14 +13,14 @@ dependencies:
   - dask-image >=0.6
   - deprecated >=1.2
   - distributed >=2021.6
-  - fiona >=1.8
+  - fiona <1.8.4  # fiona-1.8.4 requires click <8, but we want 8
   - fontconfig <2.13.96  # temporary workaround for Mac CI bug; see Issue #640
   - fsspec >=2021.6
   - gdal >=3.0
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
-  - libgdal <3.4
+  - libgdal <3.3  # ImportError: dlopen(/Users/appveyor/mamba-env/lib/python3.9
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
-  - libgdal <=3.2.2
+  - libgdal <3.4
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - geopandas >=0.8
   - jdcal >=1.4.1
   - jsonschema >=3.2.0
+  - libgdal <=3.2.2
   - matplotlib-base >=3.0
   - netcdf4 >=1.5.0
   - numba >=0.52

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -228,6 +228,7 @@ class CatalogueControllerTest(unittest.TestCase):
             self.assertIsInstance(dataset.get("variables"), (tuple, list))
             self.assertIsInstance(dataset.get("dimensions"), (tuple, list))
             self.assertIsInstance(dataset.get("bbox"), (tuple, list))
+            self.assertIsInstance(dataset.get("geometry"), dict)
             self.assertIsInstance(dataset.get("spatialRef"), str)
             self.assertNotIn("rgbSchema", dataset)
             if dataset["id"] == "demo":

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -228,7 +228,7 @@ class CatalogueControllerTest(unittest.TestCase):
             self.assertIsInstance(dataset.get("variables"), (tuple, list))
             self.assertIsInstance(dataset.get("dimensions"), (tuple, list))
             self.assertIsInstance(dataset.get("bbox"), (tuple, list))
-            self.assertIsInstance(dataset.get("spatial_ref"), str)
+            self.assertIsInstance(dataset.get("spatialRef"), str)
             self.assertNotIn("rgbSchema", dataset)
             if dataset["id"] == "demo":
                 demo_dataset = dataset

--- a/test/webapi/controllers/test_catalogue.py
+++ b/test/webapi/controllers/test_catalogue.py
@@ -222,11 +222,13 @@ class CatalogueControllerTest(unittest.TestCase):
         demo_1w_dataset = None
         for dataset in datasets:
             self.assertIsInstance(dataset, dict)
-            self.assertIn("id", dataset)
-            self.assertIn("title", dataset)
-            self.assertIn("attributions", dataset)
-            self.assertIn("variables", dataset)
-            self.assertIn("dimensions", dataset)
+            self.assertIsInstance(dataset.get("id"), str)
+            self.assertIsInstance(dataset.get("title"), str)
+            self.assertIsInstance(dataset.get("attributions"), (tuple, list))
+            self.assertIsInstance(dataset.get("variables"), (tuple, list))
+            self.assertIsInstance(dataset.get("dimensions"), (tuple, list))
+            self.assertIsInstance(dataset.get("bbox"), (tuple, list))
+            self.assertIsInstance(dataset.get("spatial_ref"), str)
             self.assertNotIn("rgbSchema", dataset)
             if dataset["id"] == "demo":
                 demo_dataset = dataset

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -26,7 +26,6 @@ from typing import Dict, Tuple, List, Set, Optional, Any, Callable
 import numpy as np
 import pyproj
 import xarray as xr
-
 from xcube.constants import LOG
 from xcube.core.geom import get_dataset_bounds
 from xcube.core.normalize import DatasetIsNotACubeError
@@ -45,6 +44,7 @@ from xcube.webapi.controllers.tiles import get_dataset_tile_url2
 from xcube.webapi.controllers.tiles import get_tile_source_options
 from xcube.webapi.errors import ServiceBadRequestError
 
+_CRS84 = pyproj.CRS.from_string('CRS84')
 
 def get_datasets(ctx: ServiceContext,
                  details: bool = False,
@@ -173,15 +173,19 @@ def get_dataset(ctx: ServiceContext,
     dataset_dict = dict(id=ds_id, title=ds_title)
 
     crs = ml_ds.grid_mapping.crs
+    transformer = pyproj.Transformer.from_crs(crs, _CRS84, always_xy=True)
+    dataset_bounds = get_dataset_bounds(ds)
 
     if "bbox" not in dataset_dict:
-        x1, y1, x2, y2 = get_dataset_bounds(ds)
         if not crs.is_geographic:
-            geo_crs = pyproj.CRS.from_string('CRS84')
-            t = pyproj.Transformer.from_crs(crs, geo_crs, always_xy=True)
-            (x1, x2), (y1, y2) = t.transform((x1, x2), (y1, y2))
-        dataset_dict["bbox"] = [x1, y1, x2, y2]
+            x1, y1, x2, y2 = dataset_bounds
+            (x1, x2), (y1, y2) = transformer.transform((x1, x2), (y1, y2))
+            dataset_dict["bbox"] = [x1, y1, x2, y2]
+        else:
+            dataset_dict["bbox"] = list(dataset_bounds)
 
+    dataset_dict['geometry'] = get_bbox_geometry(dataset_bounds,
+                                                 transformer)
     dataset_dict['spatialRef'] = crs.to_string()
 
     variable_dicts = []
@@ -317,6 +321,28 @@ def get_dataset(ctx: ServiceContext,
                                                            del_features=True)
 
     return dataset_dict
+
+
+def get_bbox_geometry(dataset_bounds: Tuple[float, float, float, float],
+                      transformer: pyproj.Transformer,
+                      n: int = 6):
+    x1, y1, x2, y2 = dataset_bounds
+    x_coords = []
+    y_coords = []
+    x_coords.extend(np.full(n - 1, x1))
+    y_coords.extend(np.linspace(y1, y2, n)[: n - 1])
+    x_coords.extend(np.linspace(x1, x2, n)[: n - 1])
+    y_coords.extend(np.full(n - 1, y2))
+    x_coords.extend(np.full(n - 1, x2))
+    y_coords.extend(np.linspace(y2, y1, n)[: n - 1])
+    x_coords.extend(np.linspace(x2, x1, n)[: n - 1])
+    y_coords.extend(np.full(n - 1, y1))
+    x_coords, y_coords = transformer.transform(x_coords, y_coords)
+    coordinates = list(map(list, zip(map(float, x_coords),
+                                     map(float, y_coords))))
+    coordinates.append(coordinates[0])
+    geometry = dict(type="Polygon", coordinates=[coordinates])
+    return geometry
 
 
 def get_time_chunk_size(ts_ds: Optional[xr.Dataset],

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -172,14 +172,17 @@ def get_dataset(ctx: ServiceContext,
                                                             ds_id)))
     dataset_dict = dict(id=ds_id, title=ds_title)
 
+    crs = ml_ds.grid_mapping.crs
+
     if "bbox" not in dataset_dict:
         x1, y1, x2, y2 = get_dataset_bounds(ds)
-        crs = ml_ds.grid_mapping.crs
         if not crs.is_geographic:
             geo_crs = pyproj.CRS.from_string('CRS84')
             t = pyproj.Transformer.from_crs(crs, geo_crs, always_xy=True)
             (x1, x2), (y1, y2) = t.transform((x1, x2), (y1, y2))
         dataset_dict["bbox"] = [x1, y1, x2, y2]
+
+    dataset_dict['spatial_ref'] = crs.to_string()
 
     variable_dicts = []
     dim_names = set()

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -46,6 +46,7 @@ from xcube.webapi.errors import ServiceBadRequestError
 
 _CRS84 = pyproj.CRS.from_string('CRS84')
 
+
 def get_datasets(ctx: ServiceContext,
                  details: bool = False,
                  client: Optional[str] = None,

--- a/xcube/webapi/controllers/catalogue.py
+++ b/xcube/webapi/controllers/catalogue.py
@@ -182,7 +182,7 @@ def get_dataset(ctx: ServiceContext,
             (x1, x2), (y1, y2) = t.transform((x1, x2), (y1, y2))
         dataset_dict["bbox"] = [x1, y1, x2, y2]
 
-    dataset_dict['spatial_ref'] = crs.to_string()
+    dataset_dict['spatialRef'] = crs.to_string()
 
     variable_dicts = []
     dim_names = set()


### PR DESCRIPTION
xcube Server now provides new metadata details of a dataset:
- The spatial reference is now given by property `spatialRef` and provides a textual representation of the spatial CRS.
- The dataset boundary is now given as property `geometry` and provides a GeoJSON Polygon in geographic coordinates. 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)

Required by https://github.com/dcs4cop/xcube-viewer/pull/232