### PR TITLE
Patched demo cubes to fix typo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 * Removed all upper version bounds of package dependencies.
   This increases compatibility with existing Python environments.
 
+### Fixes
+
+* Fixed typo in metadata of demo cubes in `examples/serve/demo`. 
+  Demo cubes now all have consolidated metadata.
+
 ## Changes in 0.11.2
 
 ### Enhancements

--- a/examples/serve/demo/cube-1-250-250.levels/0.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.levels/0.zarr/.zmetadata
@@ -465,16 +465,6 @@
             "long_name": "time",
             "standard_name": "time",
             "units": "days since 1970-01-01"
-        },
-        "title/.zarray": {
-            "chunks": [],
-            "compressor": null,
-            "dtype": "<U13",
-            "fill_value": "",
-            "filters": null,
-            "order": "C",
-            "shape": [],
-            "zarr_format": 2
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-1-250-250.levels/0.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.levels/0.zarr/.zmetadata
@@ -143,7 +143,7 @@
                 30.0,
                 40.0
             ],
-            "long_name": "Chlorophylll concentration",
+            "long_name": "Chlorophyll concentration",
             "units": "mg m^-3",
             "valid_pixel_expression": "c2rcc_flags.Valid_PE"
         },
@@ -465,6 +465,16 @@
             "long_name": "time",
             "standard_name": "time",
             "units": "days since 1970-01-01"
+        },
+        "title/.zarray": {
+            "chunks": [],
+            "compressor": null,
+            "dtype": "<U13",
+            "fill_value": "",
+            "filters": null,
+            "order": "C",
+            "shape": [],
+            "zarr_format": 2
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-1-250-250.levels/0.zarr/conc_chl/.zattrs
+++ b/examples/serve/demo/cube-1-250-250.levels/0.zarr/conc_chl/.zattrs
@@ -52,7 +52,7 @@
         30.0,
         40.0
     ],
-    "long_name": "Chlorophylll concentration",
+    "long_name": "Chlorophyll concentration",
     "units": "mg m^-3",
     "valid_pixel_expression": "c2rcc_flags.Valid_PE"
 }

--- a/examples/serve/demo/cube-1-250-250.levels/1.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.levels/1.zarr/.zmetadata
@@ -370,16 +370,6 @@
             "long_name": "time",
             "standard_name": "time",
             "units": "days since 1970-01-01"
-        },
-        "title/.zarray": {
-            "chunks": [],
-            "compressor": null,
-            "dtype": "<U13",
-            "fill_value": "",
-            "filters": null,
-            "order": "C",
-            "shape": [],
-            "zarr_format": 2
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-1-250-250.levels/1.zarr/conc_chl/.zattrs
+++ b/examples/serve/demo/cube-1-250-250.levels/1.zarr/conc_chl/.zattrs
@@ -52,7 +52,7 @@
         30.0,
         40.0
     ],
-    "long_name": "Chlorophylll concentration",
+    "long_name": "Chlorophyll concentration",
     "units": "mg m^-3",
     "valid_pixel_expression": "c2rcc_flags.Valid_PE"
 }

--- a/examples/serve/demo/cube-1-250-250.levels/2.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.levels/2.zarr/.zmetadata
@@ -370,16 +370,6 @@
             "long_name": "time",
             "standard_name": "time",
             "units": "days since 1970-01-01"
-        },
-        "title/.zarray": {
-            "chunks": [],
-            "compressor": null,
-            "dtype": "<U13",
-            "fill_value": "",
-            "filters": null,
-            "order": "C",
-            "shape": [],
-            "zarr_format": 2
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-1-250-250.levels/2.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.levels/2.zarr/.zmetadata
@@ -142,7 +142,7 @@
                 30.0,
                 40.0
             ],
-            "long_name": "Chlorophylll concentration",
+            "long_name": "Chlorophyll concentration",
             "units": "mg m^-3",
             "valid_pixel_expression": "c2rcc_flags.Valid_PE"
         },
@@ -370,6 +370,16 @@
             "long_name": "time",
             "standard_name": "time",
             "units": "days since 1970-01-01"
+        },
+        "title/.zarray": {
+            "chunks": [],
+            "compressor": null,
+            "dtype": "<U13",
+            "fill_value": "",
+            "filters": null,
+            "order": "C",
+            "shape": [],
+            "zarr_format": 2
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-1-250-250.levels/2.zarr/conc_chl/.zattrs
+++ b/examples/serve/demo/cube-1-250-250.levels/2.zarr/conc_chl/.zattrs
@@ -52,7 +52,7 @@
         30.0,
         40.0
     ],
-    "long_name": "Chlorophylll concentration",
+    "long_name": "Chlorophyll concentration",
     "units": "mg m^-3",
     "valid_pixel_expression": "c2rcc_flags.Valid_PE"
 }

--- a/examples/serve/demo/cube-1-250-250.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.zarr/.zmetadata
@@ -465,16 +465,6 @@
             "long_name": "time",
             "standard_name": "time",
             "units": "days since 1970-01-01"
-        },
-        "title/.zarray": {
-            "chunks": [],
-            "compressor": null,
-            "dtype": "<U13",
-            "fill_value": "",
-            "filters": null,
-            "order": "C",
-            "shape": [],
-            "zarr_format": 2
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-1-250-250.zarr/.zmetadata
+++ b/examples/serve/demo/cube-1-250-250.zarr/.zmetadata
@@ -1,7 +1,8 @@
 {
     "metadata": {
         ".zattrs": {
-            "Conventions": "CF-1.7"
+            "Conventions": "CF-1.7",
+            "coordinates": "time_bnds lat_bnds lon_bnds"
         },
         ".zgroup": {
             "zarr_format": 2
@@ -25,8 +26,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -83,8 +84,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -165,8 +166,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -199,8 +200,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -216,7 +217,7 @@
         },
         "lat/.zarray": {
             "chunks": [
-                500
+                250
             ],
             "compressor": {
                 "blocksize": 0,
@@ -230,7 +231,7 @@
             "filters": null,
             "order": "C",
             "shape": [
-                500
+                1000
             ],
             "zarr_format": 2
         },
@@ -243,9 +244,10 @@
             "standard_name": "latitude",
             "units": "degrees_north"
         },
-        "lon/.zarray": {
+        "lat_bnds/.zarray": {
             "chunks": [
-                1000
+                250,
+                2
             ],
             "compressor": {
                 "blocksize": 0,
@@ -259,7 +261,37 @@
             "filters": null,
             "order": "C",
             "shape": [
-                1000
+                1000,
+                2
+            ],
+            "zarr_format": 2
+        },
+        "lat_bnds/.zattrs": {
+            "_ARRAY_DIMENSIONS": [
+                "lat",
+                "bnds"
+            ],
+            "long_name": "latitude",
+            "standard_name": "latitude",
+            "units": "degrees_north"
+        },
+        "lon/.zarray": {
+            "chunks": [
+                250
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 5,
+                "cname": "lz4",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f8",
+            "fill_value": "NaN",
+            "filters": null,
+            "order": "C",
+            "shape": [
+                2000
             ],
             "zarr_format": 2
         },
@@ -268,6 +300,37 @@
                 "lon"
             ],
             "bounds": "lon_bnds",
+            "long_name": "longitude",
+            "standard_name": "longitude",
+            "units": "degrees_east"
+        },
+        "lon_bnds/.zarray": {
+            "chunks": [
+                250,
+                2
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 5,
+                "cname": "lz4",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f8",
+            "fill_value": "NaN",
+            "filters": null,
+            "order": "C",
+            "shape": [
+                2000,
+                2
+            ],
+            "zarr_format": 2
+        },
+        "lon_bnds/.zattrs": {
+            "_ARRAY_DIMENSIONS": [
+                "lon",
+                "bnds"
+            ],
             "long_name": "longitude",
             "standard_name": "longitude",
             "units": "degrees_east"
@@ -291,8 +354,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -343,7 +406,7 @@
         },
         "time/.zarray": {
             "chunks": [
-                5
+                1
             ],
             "compressor": {
                 "blocksize": 0,
@@ -366,6 +429,38 @@
                 "time"
             ],
             "bounds": "time_bnds",
+            "calendar": "gregorian",
+            "long_name": "time",
+            "standard_name": "time",
+            "units": "days since 1970-01-01"
+        },
+        "time_bnds/.zarray": {
+            "chunks": [
+                1,
+                2
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 5,
+                "cname": "lz4",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f8",
+            "fill_value": "NaN",
+            "filters": null,
+            "order": "C",
+            "shape": [
+                5,
+                2
+            ],
+            "zarr_format": 2
+        },
+        "time_bnds/.zattrs": {
+            "_ARRAY_DIMENSIONS": [
+                "time",
+                "bnds"
+            ],
             "calendar": "gregorian",
             "long_name": "time",
             "standard_name": "time",

--- a/examples/serve/demo/cube-1-250-250.zarr/conc_chl/.zattrs
+++ b/examples/serve/demo/cube-1-250-250.zarr/conc_chl/.zattrs
@@ -52,7 +52,7 @@
         30.0,
         40.0
     ],
-    "long_name": "Chlorophylll concentration",
+    "long_name": "Chlorophyll concentration",
     "units": "mg m^-3",
     "valid_pixel_expression": "c2rcc_flags.Valid_PE"
 }

--- a/examples/serve/demo/cube-5-100-200.zarr/.zmetadata
+++ b/examples/serve/demo/cube-5-100-200.zarr/.zmetadata
@@ -1,16 +1,17 @@
 {
     "metadata": {
         ".zattrs": {
-            "Conventions": "CF-1.7"
+            "Conventions": "CF-1.7",
+            "coordinates": "time_bnds lon_bnds lat_bnds"
         },
         ".zgroup": {
             "zarr_format": 2
         },
         "c2rcc_flags/.zarray": {
             "chunks": [
-                1,
-                250,
-                250
+                5,
+                100,
+                200
             ],
             "compressor": {
                 "blocksize": 0,
@@ -25,8 +26,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -66,9 +67,9 @@
         },
         "conc_chl/.zarray": {
             "chunks": [
-                1,
-                250,
-                250
+                5,
+                100,
+                200
             ],
             "compressor": {
                 "blocksize": 0,
@@ -83,8 +84,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -148,9 +149,9 @@
         },
         "conc_tsm/.zarray": {
             "chunks": [
-                1,
-                250,
-                250
+                5,
+                100,
+                200
             ],
             "compressor": {
                 "blocksize": 0,
@@ -165,8 +166,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -182,9 +183,9 @@
         },
         "kd489/.zarray": {
             "chunks": [
-                1,
-                250,
-                250
+                5,
+                100,
+                200
             ],
             "compressor": {
                 "blocksize": 0,
@@ -199,8 +200,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -216,7 +217,7 @@
         },
         "lat/.zarray": {
             "chunks": [
-                500
+                100
             ],
             "compressor": {
                 "blocksize": 0,
@@ -230,7 +231,7 @@
             "filters": null,
             "order": "C",
             "shape": [
-                500
+                1000
             ],
             "zarr_format": 2
         },
@@ -243,9 +244,10 @@
             "standard_name": "latitude",
             "units": "degrees_north"
         },
-        "lon/.zarray": {
+        "lat_bnds/.zarray": {
             "chunks": [
-                1000
+                100,
+                2
             ],
             "compressor": {
                 "blocksize": 0,
@@ -259,7 +261,37 @@
             "filters": null,
             "order": "C",
             "shape": [
-                1000
+                1000,
+                2
+            ],
+            "zarr_format": 2
+        },
+        "lat_bnds/.zattrs": {
+            "_ARRAY_DIMENSIONS": [
+                "lat",
+                "bnds"
+            ],
+            "long_name": "latitude",
+            "standard_name": "latitude",
+            "units": "degrees_north"
+        },
+        "lon/.zarray": {
+            "chunks": [
+                200
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 5,
+                "cname": "lz4",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f8",
+            "fill_value": "NaN",
+            "filters": null,
+            "order": "C",
+            "shape": [
+                2000
             ],
             "zarr_format": 2
         },
@@ -272,11 +304,42 @@
             "standard_name": "longitude",
             "units": "degrees_east"
         },
+        "lon_bnds/.zarray": {
+            "chunks": [
+                200,
+                2
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 5,
+                "cname": "lz4",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f8",
+            "fill_value": "NaN",
+            "filters": null,
+            "order": "C",
+            "shape": [
+                2000,
+                2
+            ],
+            "zarr_format": 2
+        },
+        "lon_bnds/.zattrs": {
+            "_ARRAY_DIMENSIONS": [
+                "lon",
+                "bnds"
+            ],
+            "long_name": "longitude",
+            "standard_name": "longitude",
+            "units": "degrees_east"
+        },
         "quality_flags/.zarray": {
             "chunks": [
-                1,
-                250,
-                250
+                5,
+                100,
+                200
             ],
             "compressor": {
                 "blocksize": 0,
@@ -291,8 +354,8 @@
             "order": "C",
             "shape": [
                 5,
-                500,
-                1000
+                1000,
+                2000
             ],
             "zarr_format": 2
         },
@@ -371,15 +434,37 @@
             "standard_name": "time",
             "units": "days since 1970-01-01"
         },
-        "title/.zarray": {
-            "chunks": [],
-            "compressor": null,
-            "dtype": "<U13",
-            "fill_value": "",
+        "time_bnds/.zarray": {
+            "chunks": [
+                5,
+                2
+            ],
+            "compressor": {
+                "blocksize": 0,
+                "clevel": 5,
+                "cname": "lz4",
+                "id": "blosc",
+                "shuffle": 1
+            },
+            "dtype": "<f8",
+            "fill_value": "NaN",
             "filters": null,
             "order": "C",
-            "shape": [],
+            "shape": [
+                5,
+                2
+            ],
             "zarr_format": 2
+        },
+        "time_bnds/.zattrs": {
+            "_ARRAY_DIMENSIONS": [
+                "time",
+                "bnds"
+            ],
+            "calendar": "gregorian",
+            "long_name": "time",
+            "standard_name": "time",
+            "units": "days since 1970-01-01"
         }
     },
     "zarr_consolidated_format": 1

--- a/examples/serve/demo/cube-5-100-200.zarr/conc_chl/.zattrs
+++ b/examples/serve/demo/cube-5-100-200.zarr/conc_chl/.zattrs
@@ -52,7 +52,7 @@
         30.0,
         40.0
     ],
-    "long_name": "Chlorophylll concentration",
+    "long_name": "Chlorophyll concentration",
     "units": "mg m^-3",
     "valid_pixel_expression": "c2rcc_flags.Valid_PE"
 }

--- a/test/core/store/fs/impl/test_geotiff.py
+++ b/test/core/store/fs/impl/test_geotiff.py
@@ -31,7 +31,7 @@ import xarray as xr
 from xcube.core.store.fs.impl.dataset import DatasetGeoTiffFsDataAccessor
 from xcube.core.store.fs.impl.geotiff import GeoTIFFMultiLevelDataset
 from xcube.core.store.fs.impl.geotiff import \
-     MultiLevelDatasetGeoTiffFsDataAccessor
+    MultiLevelDatasetGeoTiffFsDataAccessor
 from xcube.util.jsonschema import JsonSchema
 
 
@@ -78,16 +78,9 @@ class RioXarrayTest(unittest.TestCase):
             rioxarray.open_rasterio(cog_path,
                                     overview_level=num_levels)
 
-        self.assertEqual(
-            (
-                'Cannot open overview level 2 of ' +
-                os.path.join(os.path.dirname(__file__),
-                             "..", "..", "..", "..", "..",
-                             "examples", "serve", "demo",
-                             "sample-cog.tif")
-                ,),
-            e.exception.args
-        )
+        self.assertTrue(f'{e.exception}'.startswith(
+            'Cannot open overview level 2 of '
+        ))
 
 
 class GeoTIFFMultiLevelDatasetTest(unittest.TestCase):

--- a/test/sampledata.py
+++ b/test/sampledata.py
@@ -152,7 +152,7 @@ def create_conc_chl():
                      [5, 10, 2, 21],
                      [16, 6, 20, 17]], dtype=np.float32)
     return (('y', 'x'), data, dict(
-        long_name="Chlorophylll concentration",
+        long_name="Chlorophyll concentration",
         units="mg m^-3",
         _FillValue=np.nan,
         valid_pixel_expression="c2rcc_flags.F1",

--- a/test/webapi/res/test/WMTSCapabilities-CRS84.xml
+++ b/test/webapi/res/test/WMTSCapabilities-CRS84.xml
@@ -109,7 +109,7 @@
     </Layer>
     <Layer>
       <ows:Identifier>demo.conc_chl</ows:Identifier>
-      <ows:Title>demo/Chlorophylll concentration</ows:Title>
+      <ows:Title>demo/Chlorophyll concentration</ows:Title>
       <ows:Abstract/>
       <ows:WGS84BoundingBox>
         <ows:LowerCorner>0 50</ows:LowerCorner>
@@ -544,7 +544,7 @@
       </Theme>
       <Theme>
         <ows:Identifier>demo.conc_chl</ows:Identifier>
-        <ows:Title>demo/Chlorophylll concentration</ows:Title>
+        <ows:Title>demo/Chlorophyll concentration</ows:Title>
         <ows:Abstract/>
         <LayerRef>demo.conc_chl</LayerRef>
       </Theme>

--- a/test/webapi/res/test/WMTSCapabilities-OSM.xml
+++ b/test/webapi/res/test/WMTSCapabilities-OSM.xml
@@ -109,7 +109,7 @@
     </Layer>
     <Layer>
       <ows:Identifier>demo.conc_chl</ows:Identifier>
-      <ows:Title>demo/Chlorophylll concentration</ows:Title>
+      <ows:Title>demo/Chlorophyll concentration</ows:Title>
       <ows:Abstract/>
       <ows:WGS84BoundingBox>
         <ows:LowerCorner>0 50</ows:LowerCorner>
@@ -544,7 +544,7 @@
       </Theme>
       <Theme>
         <ows:Identifier>demo.conc_chl</ows:Identifier>
-        <ows:Title>demo/Chlorophylll concentration</ows:Title>
+        <ows:Title>demo/Chlorophyll concentration</ows:Title>
         <ows:Abstract/>
         <LayerRef>demo.conc_chl</LayerRef>
       </Theme>


### PR DESCRIPTION
Used new `xcube patch` tool (see https://github.com/dcs4cop/xcube/pull/690) to fix demo cubes and consolidate their metadata.:

```bash
$ xcube patch examples/serve/demo/cube-1-250-250.levels --metadata patch.yml -vvv
$ xcube patch examples/serve/demo/cube-1-250-250.zarr --metadata patch.yml -vvv
$ xcube patch examples/serve/demo/cube-5-100-200.zarr --metadata patch.yml -vvv
```

with `patch.yml`:
```yaml
zarr_consolidated_format: 1
metadata:
  conc_chl/.zattrs:
    long_name: Chlorophyll concentration
``` 

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
