### PR TITLE
Fixed writing ML datasets with use_saved_levels=True

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,12 @@
 
 * Fixed typo in metadata of demo cubes in `examples/serve/demo`. 
   Demo cubes now all have consolidated metadata.
+* When writing multi-level datasets with file data stores, i.e.,
+  ```python
+  store.write_data(dataset, data_id="test.levels", use_saved_levels=True)
+  ``` 
+  and where `dataset` has different spatial resolutions in x and y, 
+  an exception was raised. This is no longer the case. 
 
 ## Changes in 0.11.2
 

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -167,7 +167,6 @@ class MultiLevelDatasetLevelsFsDataAccessor(DatasetZarrFsDataAccessor):
             ml_dataset = BaseMultiLevelDataset(
                 ml_dataset.get_dataset(0),
                 grid_mapping=ml_dataset.grid_mapping,
-                tile_grid=ml_dataset.tile_grid,
                 agg_methods=agg_methods
             )
 


### PR DESCRIPTION
When writing multi-level datasets with file data stores, i.e.,
```python
store.write_data(dataset, data_id="test.levels", use_saved_levels=True)
``` 
and where `dataset` has different spatial resolutions in x and y, an exception was raised. This is no longer the case. 

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
