### PR TITLE
Allow custom identifiers for DataStore Datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   
 * In the configuration for `xcube server`, datasets defined in `DataStores` 
   may now have user-defined identifiers. In case the path does not unambiguously 
-  define a dataset (because, e.g., it contains wildcards, providing a 
+  define a dataset (because it contains wildcards), providing a 
   user-defined identifier will raise an error. 
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
   supported by [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) 
   including the protocols "s3" and "file". It also allows patching
   xcube multi-level datasets (`*.levels` format).
+  
+* In configuration for `xcube server`, datasets defined in datastores may now
+  have user-set identifiers, in case their path unambiguously defines a dataset
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,10 @@
   including the protocols "s3" and "file". It also allows patching
   xcube multi-level datasets (`*.levels` format).
   
-* In configuration for `xcube server`, datasets defined in datastores may now
-  have user-set identifiers, in case their path unambiguously defines a dataset
+* In the configuration for `xcube server`, datasets defined in `DataStores` 
+  may now have user-defined identifiers. In case the path does not unambiguously 
+  define a dataset (because, e.g., it contains wildcards, providing a 
+  user-defined identifier will raise an error. 
 
 ### Fixes
 

--- a/test/webapi/res/test/config-datastores-double-ids.yml
+++ b/test/webapi/res/test/config-datastores-double-ids.yml
@@ -1,0 +1,9 @@
+DataStores:
+  - Identifier: test
+    StoreId: file
+    StoreParams:
+      root: examples/serve/demo
+    Datasets:
+      - Path: "cube-*.zarr"
+        Identifier: "Cube"
+        Style: "default"

--- a/test/webapi/res/test/config-datastores.yml
+++ b/test/webapi/res/test/config-datastores.yml
@@ -5,8 +5,10 @@ DataStores:
       root: examples/serve/demo
     Datasets:
       - Path: "cube-1-250-250.zarr"
+        Identifier: "Cube 1"
         Style: "default"
       - Path: "cube-5-100-200.zarr"
+        Identifier: "Cube 5"
         Style: "default"
       - Path: "*.levels"
         Style: "default"

--- a/test/webapi/test_context.py
+++ b/test/webapi/test_context.py
@@ -7,6 +7,7 @@ from test.webapi.helpers import new_test_service_context
 from xcube.core.mldataset import MultiLevelDataset
 from xcube.webapi.context import normalize_prefix
 from xcube.webapi.errors import ServiceResourceNotFoundError
+from xcube.webapi.errors import ServiceConfigError
 
 
 class ServiceContextTest(unittest.TestCase):
@@ -79,14 +80,11 @@ class ServiceContextTest(unittest.TestCase):
             config_file_name='config-datastores-double-ids.yml'
         )
 
-        dataset_configs_from_stores = ctx.get_dataset_configs_from_stores(
-            ctx.get_data_store_pool()
-        )
-        self.assertIsNotNone(dataset_configs_from_stores)
-        self.assertEqual(2, len(dataset_configs_from_stores))
-        ids = [config['Identifier'] for config in dataset_configs_from_stores]
-        self.assertIn('test~cube-1-250-250.zarr', ids)
-        self.assertIn('test~cube-5-100-200.zarr', ids)
+        with self.assertRaises(ServiceConfigError) as sce:
+            ctx.get_dataset_configs_from_stores(ctx.get_data_store_pool())
+        self.assertEqual(sce.exception.reason,
+                         'User-defined identifiers can only be assigned to '
+                         'datasets with non-wildcard paths.')
 
     def test_config_and_dataset_cache(self):
         ctx = new_test_service_context()

--- a/test/webapi/test_context.py
+++ b/test/webapi/test_context.py
@@ -70,9 +70,23 @@ class ServiceContextTest(unittest.TestCase):
         self.assertIsNotNone(dataset_configs_from_stores)
         self.assertEqual(3, len(dataset_configs_from_stores))
         ids = [config['Identifier'] for config in dataset_configs_from_stores]
+        self.assertIn('Cube 1', ids)
+        self.assertIn('Cube 5', ids)
+        self.assertIn('test~cube-1-250-250.levels', ids)
+
+    def test_get_dataset_configs_with_duplicate_ids_from_stores(self):
+        ctx = new_test_service_context(
+            config_file_name='config-datastores-double-ids.yml'
+        )
+
+        dataset_configs_from_stores = ctx.get_dataset_configs_from_stores(
+            ctx.get_data_store_pool()
+        )
+        self.assertIsNotNone(dataset_configs_from_stores)
+        self.assertEqual(2, len(dataset_configs_from_stores))
+        ids = [config['Identifier'] for config in dataset_configs_from_stores]
         self.assertIn('test~cube-1-250-250.zarr', ids)
         self.assertIn('test~cube-5-100-200.zarr', ids)
-        self.assertIn('test~cube-1-250-250.levels', ids)
 
     def test_config_and_dataset_cache(self):
         ctx = new_test_service_context()

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -461,9 +461,9 @@ class ServiceContext:
                             # we will use the preconfigured identifier
                             all_dataset_configs.append(dataset_config)
                             continue
-                        LOG.info('Pre-configured identifier is ignored as '
-                                 'the configured path does not unambiguously '
-                                 'denote a dataset')
+                        raise ServiceConfigError(
+                            'User-defined identifiers can only be assigned to '
+                            'datasets with unambiguous paths.')
                     dataset_config['Path'] = store_dataset_id
                     dataset_config['Identifier'] = \
                         f'{store_instance_id}{STORE_DS_ID_SEPARATOR}' \

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -455,6 +455,14 @@ class ServiceContext:
                         StoreInstanceId=store_instance_id,
                         **dataset_config_base
                     )
+                    if dataset_config.get('Identifier') is not None:
+                        if dataset_config['Path'] == store_dataset_id:
+                            # we will use the preconfigured identifier
+                            all_dataset_configs.append(dataset_config)
+                            continue
+                        LOG.info('Pre-configured identifier is ignored as '
+                                 'the configured path does not unambiguously '
+                                 'denote a dataset')
                     dataset_config['Path'] = store_dataset_id
                     dataset_config['Identifier'] = \
                         f'{store_instance_id}{STORE_DS_ID_SEPARATOR}' \

--- a/xcube/webapi/context.py
+++ b/xcube/webapi/context.py
@@ -463,7 +463,7 @@ class ServiceContext:
                             continue
                         raise ServiceConfigError(
                             'User-defined identifiers can only be assigned to '
-                            'datasets with unambiguous paths.')
+                            'datasets with non-wildcard paths.')
                     dataset_config['Path'] = store_dataset_id
                     dataset_config['Identifier'] = \
                         f'{store_instance_id}{STORE_DS_ID_SEPARATOR}' \


### PR DESCRIPTION
Solves #701 
Checklist:

* [x] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
