### PR TITLE
adjusting xcube viewer link

### DIFF
--- a/docs/source/viewer.rst
+++ b/docs/source/viewer.rst
@@ -1,4 +1,4 @@
-.. _`xcube viewer demo`: https://xcube-viewer.s3.eu-central-1.amazonaws.com/index.html
+.. _`xcube viewer demo`: https://bc-viewer.brockmann-consult.de/
 .. _`xcube-viewer`: https://github.com/dcs4cop/xcube-viewer
 .. _`DCS4COP Demo viewer`: https://eodatabee-viewer.brockmann-consult.de
 .. _`README`: https://github.com/dcs4cop/xcube-viewer/blob/master/README.md
@@ -15,10 +15,8 @@ The xcube viewer app is a simple, single-page web application to be used with th
 Demo
 ====
 
-To test the viewer app, you can use the `xcube viewer demo`_.
-When you open the page a message "cannot reach server" will appear. This is normal as the demo is configured to
-run with an xcube server started locally on default port 8080, see :doc:`webapi`. Hence, you can either run an xcube
-server instance locally then reload the viewer page, or configure the viewer with an an existing xcube server.
+To test the viewer app, you can use the `xcube viewer demo`_. This is our Brockmann Consult Demo xcube viewer.
+Via the viewer's settings it is possible to change the xcube server url which is used for displaying data.
 To do so open the viewer's settings panels, select "Server". A "Select Server" panel is opened, click the "+"
 button to add a new server. Here are two demo servers that you may add for testing:
 


### PR DESCRIPTION
[Description of PR]
No code has changed, only link pointing to xcube demo viewer. 
Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
