### PR TITLE
xcube Server to compute spatial 2D datasets on-the-fly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,8 @@
   ``` 
   and where `dataset` has different spatial resolutions in x and y, 
   an exception was raised. This is no longer the case. 
+* xcube Server can now also compute spatial 2D datasets from users' 
+  Python code. In former versions, spatio-temporal 3D cubes were enforced.
 
 ## Changes in 0.11.2
 

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -47,7 +47,6 @@ from xcube.core.subsampling import assert_valid_agg_methods
 from xcube.core.subsampling import subsample_dataset
 from xcube.core.tilingscheme import get_num_levels
 from xcube.core.tilingscheme import TilingScheme
-from xcube.core.verify import assert_cube
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
 from xcube.util.perf import measure_time


### PR DESCRIPTION
xcube Server can now also compute spatial 2D datasets on-the-fly from users' Python code. In former versions, spatio-temporal 3D cubes were enforced.

Basically, I removed all `assert_cube()` calls from all multi-level datasets factories. However, all but `ComputedMultiLevelDataset` are anyway deprecated.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
