### PR TITLE
Add function select_label_subset()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@
   define a dataset (because it contains wildcards), providing a 
   user-defined identifier will raise an error. 
 
+* Added a new function `xcube.core.select.select_label_subset()` that 
+  is used to select dataset labels along a given dimension using
+  user-defined predicate functions.
+
 ### Fixes
 
 * xcube Server did not find any grid mapping if a grid mapping variable

--- a/test/core/test_select.py
+++ b/test/core/test_select.py
@@ -2,11 +2,13 @@ import itertools
 import json
 import math
 import unittest
-from collections.abc import MutableMapping
-from typing import Dict, KeysView, Iterator, Sequence, Any
+from collections.abc import MutableMapping, Mapping
+from typing import Dict, KeysView, Iterator, Sequence, Any, Callable, \
+    Union
 
 import cftime
 import numpy as np
+import pytest
 import xarray as xr
 
 from test.sampledata import create_highroc_dataset
@@ -16,6 +18,7 @@ from xcube.core.select import select_spatial_subset
 from xcube.core.select import select_subset
 from xcube.core.select import select_temporal_subset
 from xcube.core.select import select_variables_subset
+from xcube.core.select import select_label_subset
 
 
 class SelectVariablesSubsetTest(unittest.TestCase):
@@ -200,7 +203,8 @@ class SelectSubsetTest(unittest.TestCase):
         self.assertIn('conc_chl', ds)
         self.assertEqual(('time', 'lat', 'lon'), ds.conc_chl.dims)
         self.assertEqual((5, 64800, 129600), ds.conc_chl.shape)
-        self.assertEqual((5 * (1,), 100 * (648,), 100 * (1296,)), ds.conc_chl.chunks)
+        self.assertEqual((5 * (1,), 100 * (648,), 100 * (1296,)),
+                         ds.conc_chl.chunks)
         return ds
 
     def _assert_large_dataset_subset(self, ds_subset):
@@ -209,7 +213,138 @@ class SelectSubsetTest(unittest.TestCase):
         self.assertIn('conc_chl', ds_subset)
         self.assertEqual(('time', 'lat', 'lon'), ds_subset.conc_chl.dims)
         self.assertEqual((5, 900, 1800), ds_subset.conc_chl.shape)
-        self.assertEqual(((1, 1, 1, 1, 1), (648, 252), (1296, 504)), ds_subset.conc_chl.chunks)
+        self.assertEqual(((1, 1, 1, 1, 1), (648, 252), (1296, 504)),
+                         ds_subset.conc_chl.chunks)
+
+
+class SelectLabelSubsetTest(unittest.TestCase):
+    def test_predicate_callback(self):
+        ds = xr.Dataset(
+            {
+                "a": (["time", "y", "x"], np.zeros((3, 4, 8))),
+                "b": (["time", "y", "x"], np.ones((3, 4, 8))),
+                "time": (["time"], [2020, 2021, 2022])
+            }
+        )
+
+        actual_count = 0
+
+        def predicate(slice_array, slice_info):
+            nonlocal actual_count
+            actual_count += 1
+            self.assertIsInstance(slice_array, xr.DataArray)
+            self.assertIsInstance(slice_info, dict)
+            self.assertIn(slice_info.get('var'), ("a", "b"))
+            self.assertIsInstance(slice_info.get('index'), int)
+            self.assertIsInstance(slice_info.get('label'), xr.DataArray)
+            self.assertEqual("time", slice_info.get('dim'))
+            return True
+
+        select_label_subset(ds, "time", predicate)
+        self.assertEqual(3 * 2, actual_count)
+
+    def test_no_change(self):
+        ds = xr.Dataset(
+            {
+                "a": (["time", "y", "x"], np.zeros((3, 4, 8))),
+                "b": (["time", "y", "x"], np.ones((3, 4, 8))),
+                "time": (["time"], [2020, 2021, 2022])
+            }
+        )
+
+        # noinspection PyUnusedLocal
+        def predicate(slice_array, slice_info):
+            return True
+
+        result = select_label_subset(ds, "time", predicate)
+        self.assertIs(ds, result)
+        self.assertEqual({"a", "b", "time"}, set(result.variables.keys()))
+        self.assertEqual({'time': 3, 'y': 4, 'x': 8}, result.dims)
+
+    def test_select_by_slice_info(self):
+        ds = xr.Dataset(
+            {
+                "a": (["time", "y", "x"], np.zeros((3, 4, 8))),
+                "b": (["time", "y", "x"], np.ones((3, 4, 8))),
+                "time": (["time"], [2020, 2021, 2022])
+            }
+        )
+
+        # noinspection PyUnusedLocal
+        def predicate(slice_array, slice_info):
+            return slice_info.get('label') == 2022
+
+        result = select_label_subset(ds, "time", predicate)
+        self.assertIsInstance(result, xr.Dataset)
+        self.assertEqual({'time': 1, 'y': 4, 'x': 8}, result.dims)
+        self.assertEqual([2022], list(result.time))
+
+        # noinspection PyUnusedLocal
+        def predicate(slice_array, slice_info):
+            return slice_info.get('label') in (2020, 2022)
+
+        result = select_label_subset(ds, "time", predicate)
+        self.assertIsInstance(result, xr.Dataset)
+        self.assertEqual({'time': 2, 'y': 4, 'x': 8}, result.dims)
+        self.assertEqual([2020, 2022], list(result.time))
+
+    def test_select_by_slice(self):
+        ds = xr.Dataset(
+            {
+                "a": (["time", "y", "x"], np.stack([np.full((4, 8), 1),
+                                                    np.full((4, 8), 2),
+                                                    np.full((4, 8), 3)])),
+                "b": (["time", "y", "x"], np.stack([np.full((4, 8), 1),
+                                                    np.full((4, 8), 2),
+                                                    np.full((4, 8), 3)])),
+                "time": (["time"], [2020, 2021, 2022])
+            }
+        )
+
+        # noinspection PyUnusedLocal
+        def predicate(slice_array, slice_info):
+            return not np.all(slice_array == 2)
+
+        result = select_label_subset(ds, "time", predicate)
+        self.assertIsInstance(result, xr.Dataset)
+        self.assertEqual({'time': 2, 'y': 4, 'x': 8}, result.dims)
+        self.assertEqual([2020, 2022], list(result.time))
+
+        # noinspection PyUnusedLocal
+        def predicate_a(slice_array, slice_info):
+            return not np.all(slice_array == 2)
+
+        # noinspection PyUnusedLocal
+        def predicate_b(slice_array, slice_info):
+            return not np.all(slice_array == 2)
+
+        result = select_label_subset(ds, "time",
+                                     dict(a=predicate_a, b=predicate_b))
+        self.assertIsInstance(result, xr.Dataset)
+        self.assertEqual({'time': 2, 'y': 4, 'x': 8}, result.dims)
+        self.assertEqual([2020, 2022], list(result.time))
+
+    # noinspection PyMethodMayBeStatic
+    def test_invalid_call(self):
+        ds = xr.Dataset(
+            {
+                "a": (["time", "y", "x"], np.zeros((3, 4, 8))),
+                "b": (["time", "y", "x"], np.ones((3, 4, 8))),
+                "time": (["time"], [2020, 2021, 2022])
+            }
+        )
+
+        with pytest.raises(TypeError,
+                           match="predicate for variable 'a'"
+                                 " must be callable with signature"):
+            # noinspection PyTypeChecker
+            select_label_subset(ds, "time", dict(a=137))
+
+        with pytest.raises(TypeError,
+                           match="predicate"
+                                 " must be callable with signature"):
+            # noinspection PyTypeChecker
+            select_label_subset(ds, "time", 137)
 
 
 def new_virtual_dataset(lon_size: int = 360,

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -255,7 +255,7 @@ def select_label_subset(dataset: xr.Dataset,
             ...
     ```
 
-    Here, *slice_array* is a variable's array slice for given label.
+    Here, *slice_array* is a variable's array slice for the given label.
     The argument *slice_info* is a dictionary that contains the
     following keys:
 

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -279,7 +279,7 @@ def select_label_subset(dataset: xr.Dataset,
         For a large number of labels, very complex Dask
         graphs will result (every label is a node)
         whose overhead may compensate the performance gain.
-    :return: A new datasets with labels along *dim*
+    :return: A new dataset with labels along *dim*
         selected by the *predicate*.
         If all labels are selected, *dataset* is returned without change.
     """

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -26,6 +26,7 @@ from typing import Union
 
 import cftime
 import dask.array as da
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -267,6 +268,22 @@ def select_label_subset(dataset: xr.Dataset,
 
     Note, the value of "label" will be None, if *dataset*
     does not contain a 1D-coordinate variable named *dim*.
+
+    The following example selects only time labels
+    from a 3-D (time, y, x) cube where the 2-D (y, x) images
+    of variable "CHL" comprises more than 50% valid values:
+
+    ```
+    >>> chl_data = np.random.random((5, 10, 20))
+    >>> chl_data = np.where(chl_data > 0.5, chl_data, np.nan)
+    >>> ds = xr.Dataset({"CHL": (["time", "y", "x"], chl_data)})
+    >>>
+    >>> def is_valid_slice(slice_array, slice_label):
+    >>>     return np.sum(np.isnan(slice_array)) / slice_array.size <= 0.5
+    >>>
+    >>> ds_subset = select_label_subset(ds, "time",
+    >>>                                 predicate={"CHL": is_valid_slice})
+    ```
 
     :param dataset: The dataset.
     :param dim: The name of the dimension

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -261,7 +261,7 @@ def select_label_subset(dataset: xr.Dataset,
 
     * var: str - name of the current variable.
     * dim: str - value of *dim*.
-    * index: int: value for the current index within dimension *dim*.
+    * index: int - value for the current index within dimension *dim*.
     * label: Optional[xr.DataArray] - value for the current label
       within dimension *dim*.
 


### PR DESCRIPTION
Added a new function `xcube.core.select.select_label_subset()` that is used to select dataset labels along a given dimension using user-defined predicate functions.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
