### PR TITLE
New zarrstore package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-* Added a new package `xcube.core.zarrstore` that export a number
+* Added a new package `xcube.core.zarrstore` that exports a number
   of useful 
   [Zarr store](https://zarr.readthedocs.io/en/stable/api/storage.html) 
   implementations: 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 * Added a new package `xcube.core.zarrstore` that exports a number
   of useful 
   [Zarr store](https://zarr.readthedocs.io/en/stable/api/storage.html) 
-  implementations: 
+  implementations and Zarr store utilities: 
   * `xcube.core.zarrstore.GenericZarrStore` comprises 
     user-defined, generic array definitions. Arrays will compute 
     their chunks either from a function or a static data array. 
@@ -14,16 +14,15 @@
     runtime optimisation and debugging. 
   * `xcube.core.zarrstore.DiagnosticZarrStore` is used for testing
     Zarr store implementations. 
-  
-  In turn, the classes of module `xcube.core.chunkstore` have been
-  deprecated.
+  * Added a xarray dataset accessor 
+    `xcube.core.zarrstore.ZarrStoreHolder` that enhances instances of
+    `xarray.Dataset` by a new property `zarr_store`. It holds a Zarr store
+    instance that represents the datasets as a key-value mapping.
+    This will prepare later versions of xcube Server for publishing all 
+    datasets via an emulated S3 API.
 
-* Added a xarray dataset accessor 
-  `xcube.core.zarrstore.DatasetZarrStoreHolder` that enhances instances of
-  `xarray.Dataset` by a new property `zarr_store`. It holds a Zarr store
-  instance that represents the datasets as a key-value mapping.
-  This prepares later versions of xcube Server for publishing all datasets
-  via an emulated S3 API.
+    In turn, the classes of module `xcube.core.chunkstore` have been
+    deprecated.
 
 * Added a new function `xcube.core.select.select_label_subset()` that 
   is used to select dataset labels along a given dimension using

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,13 @@
   In turn, the classes of module `xcube.core.chunkstore` have been
   deprecated.
 
+* Added a xarray dataset accessor 
+  `xcube.core.zarrstore.DatasetZarrStoreHolder` that enhances instances of
+  `xarray.Dataset` by a new property `zarr_store`. It holds a Zarr store
+  instance that represents the datasets as a key-value mapping.
+  This prepares later versions of xcube Server for publishing all datasets
+  via an emulated S3 API.
+
 * Added a new function `xcube.core.select.select_label_subset()` that 
   is used to select dataset labels along a given dimension using
   user-defined predicate functions.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,21 @@
 
 ### Enhancements
 
-* Added a new 
+* Added a new package `xcube.core.zarrstore` that export a number
+  of useful 
   [Zarr store](https://zarr.readthedocs.io/en/stable/api/storage.html) 
-  implementation 
-  `xcube.core.zarrstore.GenericZarrStore` that comprises 
-  user-defined, generic array definitions. Arrays will compute 
-  their chunks either from a function or a static data array. 
+  implementations: 
+  * `xcube.core.zarrstore.GenericZarrStore` comprises 
+    user-defined, generic array definitions. Arrays will compute 
+    their chunks either from a function or a static data array. 
+  * `xcube.core.zarrstore.LoggingZarrStore` is used to log 
+    Zarr store access performance and therefore useful for 
+    runtime optimisation and debugging. 
+  * `xcube.core.zarrstore.DiagnosticZarrStore` is used for testing
+    Zarr store implementations. 
+  
+  In turn, the classes of module `xcube.core.chunkstore` have been
+  deprecated.
 
 * Added a new function `xcube.core.select.select_label_subset()` that 
   is used to select dataset labels along a given dimension using

--- a/environment.yml
+++ b/environment.yml
@@ -42,8 +42,8 @@ dependencies:
   - tornado >=6.0
   - urllib3 >=1.26
   - werkzeug < 2.2
-  - xarray >=0.19
-  - zarr >=2.8
+  - xarray >=2022.6
+  - zarr >=2.11
   # Required by Coiled
   # These are very likely transitive deps anyway
   - lz4

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -246,15 +246,15 @@ class FsDataStoresTestMixin(ABC):
     def _assert_zarr_store_direct_ok(self, dataset):
         self.assertIsInstance(dataset, xr.Dataset)
         self.assertTrue(hasattr(dataset, 'zarr_store'))
-        self.assertIsInstance(dataset.zarr_store(),
+        self.assertIsInstance(dataset.zarr_store.get(),
                               collections.abc.MutableMapping)
-        self.assertNotIsInstance(dataset.zarr_store(),
+        self.assertNotIsInstance(dataset.zarr_store.get(),
                                  GenericZarrStore)
 
     def _assert_zarr_store_generic_ok(self, dataset):
         self.assertIsInstance(dataset, xr.Dataset)
         self.assertTrue(hasattr(dataset, 'zarr_store'))
-        self.assertIsInstance(dataset.zarr_store(),
+        self.assertIsInstance(dataset.zarr_store.get(),
                               GenericZarrStore)
 
     def _assert_multi_level_dataset_data_ok(self, ml_dataset):
@@ -294,8 +294,10 @@ class FsDataStoresTestMixin(ABC):
                              dataset.var_c.encoding.get('_FillValue'))
 
             self.assertTrue(hasattr(dataset, 'zarr_store'))
-            self.assertIsInstance(dataset.zarr_store(),
+            self.assertIsInstance(dataset.zarr_store.get(),
                                   collections.abc.MutableMapping)
+            self.assertNotIsInstance(dataset.zarr_store.get(),
+                                     GenericZarrStore)
 
     def _assert_multi_level_dataset_format_with_tile_size(
             self,

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -1,3 +1,4 @@
+import collections.abc
 import os.path
 import shutil
 import unittest
@@ -23,6 +24,7 @@ from xcube.core.store import MultiLevelDatasetDescriptor
 from xcube.core.store import MutableDataStore
 from xcube.core.store.fs.registry import new_fs_data_store
 from xcube.core.store.fs.store import FsDataStore
+from xcube.core.zarrstore import GenericZarrStore
 from xcube.util.temp import new_temp_dir
 from xcube.util.tilegrid import TileGrid
 
@@ -144,7 +146,8 @@ class FsDataStoresTestMixin(ABC):
             requested_dtype_alias=None,
             expected_dtype_aliases={'dataset'},
             expected_return_type=xr.Dataset,
-            expected_descriptor_type=DatasetDescriptor
+            expected_descriptor_type=DatasetDescriptor,
+            assert_data_ok=self._assert_zarr_store_direct_ok
         )
 
     def test_dataset_netcdf(self):
@@ -155,7 +158,8 @@ class FsDataStoresTestMixin(ABC):
             requested_dtype_alias=None,
             expected_dtype_aliases={'dataset'},
             expected_return_type=xr.Dataset,
-            expected_descriptor_type=DatasetDescriptor
+            expected_descriptor_type=DatasetDescriptor,
+            assert_data_ok=self._assert_zarr_store_generic_ok
         )
 
     def test_dataset_levels(self):
@@ -166,7 +170,8 @@ class FsDataStoresTestMixin(ABC):
             requested_dtype_alias='dataset',
             expected_dtype_aliases={'mldataset', 'dataset'},
             expected_return_type=xr.Dataset,
-            expected_descriptor_type=None
+            expected_descriptor_type=None,
+            assert_data_ok=self._assert_zarr_store_direct_ok
         )
 
     # TODO: add assertGeoDataFrameSupport
@@ -238,10 +243,23 @@ class FsDataStoresTestMixin(ABC):
 
         data_store.delete_data(base_dataset_id)
 
-    def _assert_multi_level_dataset_data_ok(
-            self,
-            ml_dataset: xcube.core.mldataset.MultiLevelDataset
-    ):
+    def _assert_zarr_store_direct_ok(self, dataset):
+        self.assertIsInstance(dataset, xr.Dataset)
+        self.assertTrue(hasattr(dataset, 'zarr_store'))
+        self.assertIsInstance(dataset.zarr_store(),
+                              collections.abc.MutableMapping)
+        self.assertNotIsInstance(dataset.zarr_store(),
+                                 GenericZarrStore)
+
+    def _assert_zarr_store_generic_ok(self, dataset):
+        self.assertIsInstance(dataset, xr.Dataset)
+        self.assertTrue(hasattr(dataset, 'zarr_store'))
+        self.assertIsInstance(dataset.zarr_store(),
+                              GenericZarrStore)
+
+    def _assert_multi_level_dataset_data_ok(self, ml_dataset):
+        self.assertIsInstance(ml_dataset,
+                              xcube.core.mldataset.MultiLevelDataset)
         self.assertEqual(2, ml_dataset.num_levels)
         self.assertIsInstance(ml_dataset.tile_grid, TileGrid)
         self.assertIsInstance(ml_dataset.grid_mapping, GridMapping)
@@ -274,6 +292,10 @@ class FsDataStoresTestMixin(ABC):
                              dataset.var_b.encoding.get('_FillValue'))
             self.assertEqual(None,
                              dataset.var_c.encoding.get('_FillValue'))
+
+            self.assertTrue(hasattr(dataset, 'zarr_store'))
+            self.assertIsInstance(dataset.zarr_store(),
+                                  collections.abc.MutableMapping)
 
     def _assert_multi_level_dataset_format_with_tile_size(
             self,
@@ -436,4 +458,3 @@ class S3FsDataStoresTest(FsDataStoresTestMixin, S3Test):
                                  root=root,
                                  max_depth=3,
                                  storage_options=storage_options)
-

--- a/test/core/zarrstore/test_cached.py
+++ b/test/core/zarrstore/test_cached.py
@@ -1,0 +1,92 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import unittest
+
+import pytest
+import zarr.storage
+
+from xcube.core.zarrstore import CachedZarrStore
+from xcube.core.zarrstore import DiagnosticZarrStore
+
+
+class CachedZarrStoreTest(unittest.TestCase):
+
+    def get_store(self) -> CachedZarrStore:
+        self.store = {
+            "chl/.zarray": b"",
+            "chl/.zattrs": b"",
+            "chl/0.0.0": b"",
+            "chl/0.0.1": b"",
+            "chl/0.1.0": b"",
+            "chl/0.1.1": b"",
+        }
+        self.cache = DiagnosticZarrStore({})
+        return CachedZarrStore(self.store, self.cache)
+
+    def test_props(self):
+        store = self.get_store()
+        self.assertIsInstance(store.store, zarr.storage.BaseStore)
+        self.assertIsInstance(store.cache, zarr.storage.BaseStore)
+
+    def test_getitem(self):
+        store = self.get_store()
+
+        self.assertEqual(b"", store["chl/0.1.1"])
+        self.assertEqual(["__getitem__('chl/0.1.1')",
+                          "__setitem__('chl/0.1.1', bytes)"],
+                         self.cache.records)
+        self.assertIn("chl/0.1.1", self.store)
+        self.assertIn("chl/0.1.1", self.cache)
+
+        self.cache.records = []
+        self.assertEqual(b"", store["chl/0.1.1"])
+        self.assertEqual(["__getitem__('chl/0.1.1')"],
+                         self.cache.records)
+
+    def test_len(self):
+        store = self.get_store()
+        self.assertEqual(6, len(store))
+
+    def test_iter(self):
+        store = self.get_store()
+        self.assertEqual(['chl/.zarray',
+                          'chl/.zattrs',
+                          'chl/0.0.0',
+                          'chl/0.0.1',
+                          'chl/0.1.0',
+                          'chl/0.1.1'],
+                         list(iter(store)))
+
+    def test_contains(self):
+        store = self.get_store()
+        self.assertIn('chl/.zarray', store)
+        self.assertNotIn('chl', store)
+
+    def test_setitem(self):
+        store = self.get_store()
+        with pytest.raises(NotImplementedError):
+            store['chl/0.0.1'] = b""
+
+    def test_delitem(self):
+        store = self.get_store()
+        with pytest.raises(NotImplementedError):
+            del store['chl/0.0.1']

--- a/test/core/zarrstore/test_generic.py
+++ b/test/core/zarrstore/test_generic.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2022 by the xcube team and contributors
+# Copyright (c) 2022 by the xcube development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,17 +24,21 @@ from typing import Dict, Any
 
 import numpy as np
 import pytest
+import s3fs
 import xarray as xr
 
-from xcube.core.zarrstore import GenericArray
-from xcube.core.zarrstore import GenericZarrStore
-from xcube.core.zarrstore import dict_to_bytes
-from xcube.core.zarrstore import get_array_slices
-from xcube.core.zarrstore import get_chunk_indexes
-from xcube.core.zarrstore import get_chunk_padding
-from xcube.core.zarrstore import get_chunk_shape
-from xcube.core.zarrstore import ndarray_to_bytes
-from xcube.core.zarrstore import str_to_bytes
+from test.s3test import MOTO_SERVER_ENDPOINT_URL
+from test.s3test import S3Test
+from xcube.core.new import new_cube
+from xcube.core.zarrstore.diagnostic import DiagnosticZarrStore
+from xcube.core.zarrstore.generic import GenericArray
+from xcube.core.zarrstore.generic import GenericZarrStore
+from xcube.core.zarrstore.generic import dict_to_bytes
+from xcube.core.zarrstore.generic import get_array_slices
+from xcube.core.zarrstore.generic import get_chunk_indexes
+from xcube.core.zarrstore.generic import get_chunk_padding
+from xcube.core.zarrstore.generic import get_chunk_shape
+from xcube.core.zarrstore.generic import ndarray_to_bytes
 
 
 # noinspection PyMethodMayBeStatic
@@ -395,6 +399,9 @@ class GenericZarrStoreTest(unittest.TestCase):
                         dtype=np.dtype(np.float32).str,
                         get_data=get_data)
 
+        store.add_array(name="spatial_ref", dims=(),
+                        data=np.array(0))
+
         return store
 
     def setUp(self) -> None:
@@ -449,13 +456,13 @@ class GenericZarrStoreTest(unittest.TestCase):
             '.zmetadata',
             '.zgroup',
             '.zattrs',
-            'x', 'x/.zarray', 'x/.zattrs',
+            'x/.zarray', 'x/.zattrs',
             'x/0',
-            'y', 'y/.zarray', 'y/.zattrs',
+            'y/.zarray', 'y/.zattrs',
             'y/0',
-            'time', 'time/.zarray', 'time/.zattrs',
+            'time/.zarray', 'time/.zattrs',
             'time/0',
-            'chl', 'chl/.zarray', 'chl/.zattrs',
+            'chl/.zarray', 'chl/.zattrs',
             'chl/0.0.0', 'chl/0.0.1',
             'chl/0.1.0', 'chl/0.1.1',
             'chl/0.2.0', 'chl/0.2.1',
@@ -465,11 +472,14 @@ class GenericZarrStoreTest(unittest.TestCase):
             'chl/2.0.0', 'chl/2.0.1',
             'chl/2.1.0', 'chl/2.1.1',
             'chl/2.2.0', 'chl/2.2.1',
+            'spatial_ref/0',
+            'spatial_ref/.zarray',
+            'spatial_ref/.zattrs',
         }, set(store.keys()))
 
     def test_store_override_listdir(self):
         store = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
-        self.assertEqual([
+        self.assertEqual({
             '.zmetadata',
             '.zgroup',
             '.zattrs',
@@ -477,7 +487,8 @@ class GenericZarrStoreTest(unittest.TestCase):
             'y',
             'time',
             'chl',
-        ], store.listdir(''))
+            'spatial_ref',
+        }, set(store.listdir('')))
 
         self.assertEqual([
             'time/.zarray',
@@ -501,14 +512,18 @@ class GenericZarrStoreTest(unittest.TestCase):
     def test_store_override_rmdir(self):
         store = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
         store.rmdir("chl")
-        self.assertEqual([
-            '.zmetadata',
-            '.zgroup',
-            '.zattrs',
-            'x',
-            'y',
-            'time',
-        ], store.listdir(""))
+        self.assertEqual(
+            [
+                '.zattrs',
+                '.zgroup',
+                '.zmetadata',
+                'spatial_ref',
+                'time',
+                'x',
+                'y'
+            ],
+            store.listdir("")
+        )
 
         # Also remove dimension sizes from object
         store.rmdir("x")
@@ -522,15 +537,19 @@ class GenericZarrStoreTest(unittest.TestCase):
     def test_store_override_rename(self):
         store = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
         store.rename("chl", "chl_old")
-        self.assertEqual([
-            '.zmetadata',
-            '.zgroup',
-            '.zattrs',
-            'x',
-            'y',
-            'time',
-            'chl_old',
-        ], store.listdir(""))
+        self.assertEqual(
+            [
+                '.zattrs',
+                '.zgroup',
+                '.zmetadata',
+                'chl_old',
+                'spatial_ref',
+                'time',
+                'x',
+                'y'
+            ],
+            store.listdir("")
+        )
 
         with pytest.raises(ValueError,
                            match="can only rename arrays,"
@@ -574,9 +593,7 @@ class GenericZarrStoreTest(unittest.TestCase):
 
     def test_store_override_len(self):
         store = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
-        self.assertEqual(3  # 3 top-level items
-                         + 3 * 4  # 3 x coordinate array items
-                         + 3 + 3 * 3 * 2,  # 1 x "chl" data array items
+        self.assertEqual(len(list(store.keys())),
                          len(store))
 
     def test_store_override_contains(self):
@@ -584,7 +601,7 @@ class GenericZarrStoreTest(unittest.TestCase):
         self.assertTrue(".zmetadata" in store)
         self.assertTrue(".zattrs" in store)
         self.assertTrue(".zgroup" in store)
-        self.assertTrue("x" in store)
+        self.assertFalse("x" in store)
         self.assertTrue("x/.zarray" in store)
         self.assertTrue("x/.zattrs" in store)
         self.assertTrue("x/0" in store)
@@ -595,19 +612,20 @@ class GenericZarrStoreTest(unittest.TestCase):
     def test_store_override_getitem(self):
         store = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
         self.assertIsInstance(store[".zattrs"], bytes)
-        self.assertIsInstance(store["x"], bytes)
         self.assertIsInstance(store["x/.zarray"], bytes)
         self.assertIsInstance(store["x/0"], bytes)
 
-        with pytest.raises(KeyError, match="a"):
+        with pytest.raises(KeyError, match="x"):
             # noinspection PyUnusedLocal
-            a = store["a"]
+            a = store["x"]
 
     def test_store_override_setitem(self):
         store = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
-        with pytest.raises(TypeError,
-                           match="xcube.core.zarrstore.GenericZarrStore"
-                                 " is read-only"):
+        with pytest.raises(
+                TypeError,
+                match="xcube.core.zarrstore.generic.GenericZarrStore"
+                      " is read-only"
+        ):
             store["tsm/0.0.0"] = np.zeros((1, 2, 4)).tobytes()
 
     def test_store_override_delitem(self):
@@ -624,7 +642,7 @@ class GenericZarrStoreTest(unittest.TestCase):
         ds = xr.open_zarr(store)
 
         self.assertEqual({'x', 'y', 'time'}, set(ds.coords))
-        self.assertEqual({'chl'}, set(ds.data_vars))
+        self.assertEqual({'spatial_ref', 'chl'}, set(ds.data_vars))
 
         self.assertEqual(np.float32, ds.chl.dtype)
         self.assertEqual(shape, ds.chl.shape)
@@ -698,7 +716,7 @@ class GenericZarrStoreTest(unittest.TestCase):
         ds = xr.open_zarr(store)
 
         self.assertEqual({'x', 'y', 'time'}, set(ds.coords))
-        self.assertEqual({'chl'}, set(ds.data_vars))
+        self.assertEqual({'spatial_ref', 'chl'}, set(ds.data_vars))
 
         self.assertEqual(np.float32, ds.chl.dtype)
         self.assertEqual(shape, ds.chl.shape)
@@ -762,10 +780,26 @@ class GenericZarrStoreTest(unittest.TestCase):
             )
         )
 
+    def test_from_dataset(self):
+        store1 = self.new_zarr_store((3, 6, 8), (1, 2, 4), self.get_data)
+        dataset1: xr.Dataset = xr.open_zarr(store1)
+
+        store2 = GenericZarrStore.from_dataset(dataset1)
+        self.assertIsInstance(store2, GenericZarrStore)
+        self.assertIsNot(store2, store1)
+
+        dataset2: xr.Dataset = xr.open_zarr(store2)
+
+        xr.testing.assert_equal(dataset2, dataset1)
+
+        dataset1.load()
+        dataset2.load()
+        xr.testing.assert_equal(dataset2, dataset1)
+
 
 class GenericZarrStoreHelpersTest(unittest.TestCase):
     def test_get_chunk_indexes(self):
-        self.assertEqual([()],
+        self.assertEqual([(0,)],
                          list(get_chunk_indexes(())))
         self.assertEqual([(0,), (1,), (2,), (3,)],
                          list(get_chunk_indexes((4,))))
@@ -860,7 +894,6 @@ class CommonZarrStoreTest(unittest.TestCase):
             }),
             ".zattrs": dict_to_bytes({
             }),
-            "x": str_to_bytes(""),
             "x/.zarray": dict_to_bytes({
                 "zarr_format": 2,
                 "dtype": self.dtype.str,
@@ -869,12 +902,27 @@ class CommonZarrStoreTest(unittest.TestCase):
                 "order": "C",
                 "compressor": None,
                 "filters": None,
-                "fill_value": None,
+                "fill_value": 7,
             }),
             "x/.zattrs": dict_to_bytes({
                 "_ARRAY_DIMENSIONS": ["x"],
             }),
+            "x/0": ndarray_to_bytes(np.linspace(1, 4, 4, dtype=self.dtype)),
+            "x/1": ndarray_to_bytes(np.linspace(5, 8, 4, dtype=self.dtype)),
         }
+
+    def test_works_with_bytes_chunks(self):
+        ds = xr.open_zarr(self.store, consolidated=False, decode_cf=False)
+        self.assertEqual(
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            list(ds.x.values)
+        )
+
+        ds = xr.open_zarr(self.store, consolidated=False, decode_cf=True)
+        np.testing.assert_array_equal(
+            np.array([1., 2., 3., 4., 5., 6., float('nan'), 8.]),
+            ds.x.values
+        )
 
     def test_works_with_ndarray_chunks(self):
         # Here, x's chunks are numpy arrays rather than bytes!
@@ -883,21 +931,58 @@ class CommonZarrStoreTest(unittest.TestCase):
             "x/1": np.linspace(5, 8, 4, dtype=self.dtype),
         })
 
-        ds = xr.open_zarr(self.store, consolidated=False)
+        ds = xr.open_zarr(self.store, consolidated=False, decode_cf=False)
         self.assertEqual(
             [1, 2, 3, 4, 5, 6, 7, 8],
-            list(ds.x)
+            list(ds.x.values)
         )
 
-    def test_works_with_bytes_chunks(self):
-        # Here, x's chunks are numpy arrays rather than bytes!
-        self.store.update({
-            "x/0": ndarray_to_bytes(np.linspace(1, 4, 4, dtype=self.dtype)),
-            "x/1": ndarray_to_bytes(np.linspace(5, 8, 4, dtype=self.dtype)),
-        })
 
-        ds = xr.open_zarr(self.store, consolidated=False)
-        self.assertEqual(
-            [1, 2, 3, 4, 5, 6, 7, 8],
-            list(ds.x)
+class CommonS3ZarrStoreTest(S3Test):
+    """This test is used to assert that the s3fs Zarr store
+    behaves as expected with xarray.
+    """
+
+    def test_it(self):
+        cube = new_cube(variables=dict(conc_chl=0.5)).chunk(
+            dict(time=1, lat=90, lon=90)
         )
+
+        s3 = s3fs.S3FileSystem(
+            anon=False,
+            client_kwargs=dict(
+                endpoint_url=MOTO_SERVER_ENDPOINT_URL,
+            )
+        )
+
+        s3.mkdir("xcube-test")
+        s3.mkdir("xcube-test/cube.zarr")
+        zarr_store = s3.get_mapper("xcube-test/cube.zarr")
+        cube.to_zarr(zarr_store)
+
+        zarr_store = s3.get_mapper("xcube-test/cube.zarr")
+        zarr_store = DiagnosticZarrStore(zarr_store)
+
+        dataset = xr.open_zarr(zarr_store)
+        self.assertIsInstance(dataset, xr.Dataset)
+
+        # print(zarr_store.records)
+
+        self.assertIn("__getitem__('.zmetadata')", zarr_store.records)
+        self.assertIn("__getitem__('lon/0')", zarr_store.records)
+        self.assertIn("__getitem__('lat/0')", zarr_store.records)
+        self.assertIn("__getitem__('time/0')", zarr_store.records)
+
+        # Assert that Zarr used __getitem__ only
+        for r in zarr_store.records:
+            if not r.startswith("__getitem__"):
+                self.fail(f"Unexpected store call: {r}")
+
+        zarr_store.records = []
+        # noinspection PyUnusedLocal
+        values = dataset.conc_chl.isel(time=0).values
+
+        # Assert that Zarr used __getitem__ only
+        for r in zarr_store.records:
+            if not r.startswith("__getitem__"):
+                self.fail(f"Unexpected store call: {r}")

--- a/test/core/zarrstore/test_holder.py
+++ b/test/core/zarrstore/test_holder.py
@@ -25,14 +25,14 @@ import pytest
 import xarray as xr
 
 from xcube.core.zarrstore.generic import GenericZarrStore
-from xcube.core.zarrstore.xraccessor import DatasetZarrStoreHolder
+from xcube.core.zarrstore.holder import ZarrStoreHolder
 
 
-class DatasetZarrStoreHolderTest(unittest.TestCase):
+class ZarrStoreHolderTest(unittest.TestCase):
     def test_zarr_store_holder_present(self):
         dataset = xr.Dataset()
         self.assertIsNotNone(dataset.zarr_store)
-        self.assertIsInstance(dataset.zarr_store, DatasetZarrStoreHolder)
+        self.assertIsInstance(dataset.zarr_store, ZarrStoreHolder)
 
     def test_zarr_store_holder_default(self):
         dataset = xr.Dataset()

--- a/test/core/zarrstore/test_logging.py
+++ b/test/core/zarrstore/test_logging.py
@@ -1,0 +1,69 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+
+import unittest
+
+from zarr.storage import MemoryStore
+
+from xcube.core.zarrstore import LoggingZarrStore
+
+
+class LoggingZarrStoreTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.zattrs_value = bytes()
+        self.original_store = MemoryStore()
+        self.original_store.update({'chl/.zattrs': self.zattrs_value})
+
+    def test_read(self):
+        logging_store = LoggingZarrStore(self.original_store)
+
+        # noinspection PyUnresolvedReferences
+        self.assertEqual(['.zattrs'],
+                         logging_store.listdir('chl'))
+        # noinspection PyUnresolvedReferences
+        self.assertEqual(0,
+                         logging_store.getsize('chl'))
+        self.assertEqual({'chl/.zattrs'},
+                         set(logging_store.keys()))
+        self.assertEqual(['chl/.zattrs'],
+                         list(iter(logging_store)))
+        self.assertTrue('chl/.zattrs' in logging_store)
+        self.assertEqual(1,
+                         len(logging_store))
+        self.assertEqual(self.zattrs_value,
+                         logging_store.get('chl/.zattrs'))
+        # assert original_store not changed
+        self.assertEqual({'chl/.zattrs'},
+                         set(self.original_store.keys()))
+
+    def test_write(self):
+        logging_store = LoggingZarrStore(self.original_store)
+
+        zarray_value = bytes()
+        logging_store['chl/.zarray'] = zarray_value
+        self.assertEqual({'chl/.zattrs',
+                          'chl/.zarray'},
+                         set(self.original_store.keys()))
+        del logging_store['chl/.zarray']
+        self.assertEqual({'chl/.zattrs'},
+                         set(self.original_store.keys()))

--- a/test/core/zarrstore/test_xraccessor.py
+++ b/test/core/zarrstore/test_xraccessor.py
@@ -25,37 +25,37 @@ import pytest
 import xarray as xr
 
 from xcube.core.zarrstore.generic import GenericZarrStore
-from xcube.core.zarrstore.xraccessor import DatasetZarrStoreProperty
+from xcube.core.zarrstore.xraccessor import DatasetZarrStoreHolder
 
 
-class DatasetZarrStorePropertyTest(unittest.TestCase):
-    def test_zarr_store_accessor_present(self):
+class DatasetZarrStoreHolderTest(unittest.TestCase):
+    def test_zarr_store_holder_present(self):
         dataset = xr.Dataset()
         self.assertIsNotNone(dataset.zarr_store)
-        self.assertIsInstance(dataset.zarr_store, DatasetZarrStoreProperty)
+        self.assertIsInstance(dataset.zarr_store, DatasetZarrStoreHolder)
 
-    def test_zarr_store_accessor_default(self):
+    def test_zarr_store_holder_default(self):
         dataset = xr.Dataset()
-        self.assertIsInstance(dataset.zarr_store(), GenericZarrStore)
-        self.assertIs(dataset.zarr_store(),
-                      dataset.zarr_store())
+        self.assertIsInstance(dataset.zarr_store.get(), GenericZarrStore)
+        self.assertIs(dataset.zarr_store.get(),
+                      dataset.zarr_store.get())
 
-    def test_zarr_store_accessor_set(self):
+    def test_zarr_store_holder_set(self):
         dataset = xr.Dataset()
         zarr_store = dict()
         dataset.zarr_store.set(zarr_store)
-        self.assertIs(zarr_store, dataset.zarr_store())
-        self.assertIs(dataset.zarr_store(),
-                      dataset.zarr_store())
+        self.assertIs(zarr_store, dataset.zarr_store.get())
+        self.assertIs(dataset.zarr_store.get(),
+                      dataset.zarr_store.get())
 
-    def test_zarr_store_accessor_reset(self):
+    def test_zarr_store_holder_reset(self):
         dataset = xr.Dataset()
         zarr_store = dict()
         dataset.zarr_store.set(zarr_store)
         dataset.zarr_store.reset()
-        self.assertIsInstance(dataset.zarr_store(), GenericZarrStore)
-        self.assertIs(dataset.zarr_store(),
-                      dataset.zarr_store())
+        self.assertIsInstance(dataset.zarr_store.get(), GenericZarrStore)
+        self.assertIs(dataset.zarr_store.get(),
+                      dataset.zarr_store.get())
 
     # noinspection PyMethodMayBeStatic
     def test_zarr_store_type_check(self):

--- a/test/core/zarrstore/test_xraccessor.py
+++ b/test/core/zarrstore/test_xraccessor.py
@@ -1,0 +1,67 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import unittest
+
+import pytest
+import xarray as xr
+
+from xcube.core.zarrstore.generic import GenericZarrStore
+from xcube.core.zarrstore.xraccessor import DatasetZarrStoreProperty
+
+
+class DatasetZarrStorePropertyTest(unittest.TestCase):
+    def test_zarr_store_accessor_present(self):
+        dataset = xr.Dataset()
+        self.assertIsNotNone(dataset.zarr_store)
+        self.assertIsInstance(dataset.zarr_store, DatasetZarrStoreProperty)
+
+    def test_zarr_store_accessor_default(self):
+        dataset = xr.Dataset()
+        self.assertIsInstance(dataset.zarr_store(), GenericZarrStore)
+        self.assertIs(dataset.zarr_store(),
+                      dataset.zarr_store())
+
+    def test_zarr_store_accessor_set(self):
+        dataset = xr.Dataset()
+        zarr_store = dict()
+        dataset.zarr_store.set(zarr_store)
+        self.assertIs(zarr_store, dataset.zarr_store())
+        self.assertIs(dataset.zarr_store(),
+                      dataset.zarr_store())
+
+    def test_zarr_store_accessor_reset(self):
+        dataset = xr.Dataset()
+        zarr_store = dict()
+        dataset.zarr_store.set(zarr_store)
+        dataset.zarr_store.reset()
+        self.assertIsInstance(dataset.zarr_store(), GenericZarrStore)
+        self.assertIs(dataset.zarr_store(),
+                      dataset.zarr_store())
+
+    # noinspection PyMethodMayBeStatic
+    def test_zarr_store_type_check(self):
+        dataset = xr.Dataset()
+        with pytest.raises(TypeError,
+                           match="zarr_store must be an instance of"
+                                 " <class 'collections.abc.MutableMapping'>,"
+                                 " was <class 'int'>"):
+            dataset.zarr_store.set(42)

--- a/xcube/core/chunkstore.py
+++ b/xcube/core/chunkstore.py
@@ -1,45 +1,51 @@
 # The MIT License (MIT)
-# Copyright (c) 2020 by the xcube development team and contributors
+# Copyright (c) 2022 by the xcube development team and contributors
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is furnished to do
-# so, subject to the following conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
 
 import itertools
 import json
-from collections.abc import MutableMapping, Mapping
-from logging import Logger
-from typing import Iterator, Dict, Tuple, Iterable, \
-    KeysView, Callable, Any, Sequence, Optional
+from collections.abc import MutableMapping
+from typing import Dict, Tuple, Callable, Any, Sequence
 from typing import Union
 
 import numpy as np
 
-from xcube.util.assertions import assert_instance
-
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
-from xcube.util.perf import measure_time_cm
+from deprecated import deprecated
 from xcube.constants import LOG_LEVEL_TRACE
+from xcube.core.zarrstore import LoggingZarrStore
+import collections.abc
+from logging import Logger
+from typing import Iterator, Iterable, KeysView, Optional
+
 from xcube.constants import LOG
+from xcube.util.assertions import assert_instance
 
 GetChunk = Callable[['ChunkStore', str, Tuple[int, ...]], bytes]
 
 
+@deprecated(reason="This class shall no longer used."
+                   " If similar functionality is needed,"
+                   " use xcube.core.zarrstore.GenericZarrStore",
+            version="0.12.1")
 class ChunkStore(MutableMapping):
     """
     A Zarr Store that generates datasets by allowing data variables to
@@ -235,81 +241,30 @@ def _str_to_bytes(s: str):
     return bytes(s, encoding='utf-8')
 
 
-class LoggingStore(Mapping):
+@deprecated(reason="This class has been moved,"
+                   " use xcube.core.zarrstore.LoggingZarrStore"
+                   " instead.",
+            version="0.12.1")
+class LoggingStore(LoggingZarrStore):
     """
     A Zarr Store that logs all method calls on another store *other*
     including execution time.
     """
 
     @classmethod
-    def new(cls, other: Union[Mapping, MutableMapping],
+    def new(cls,
+            other: collections.abc.MutableMapping,
             logger: Logger = LOG,
             name: Optional[str] = None):
-        if isinstance(other, MutableMapping):
-            return MutableLoggingStore(other, logger=logger, name=name)
-        return LoggingStore(other, logger=logger, name=name)
-
-    def __init__(self,
-                 other: Union[Mapping, MutableMapping],
-                 logger: Logger = LOG,
-                 name: Optional[str] = None):
-        assert_instance(other, Mapping)
-        self._other = other
-        self._measure_time = measure_time_cm(logger=logger)
-        self._name = name or 'chunk_store'
-        if hasattr(other, 'listdir'):
-            setattr(self, 'listdir', self.__listdir)
-        if hasattr(other, 'getsize'):
-            setattr(self, 'getsize', self.__getsize)
-
-    def __listdir(self, key: str) -> Iterable[str]:
-        with self._measure_time(f'{self._name}.listdir({key!r})'):
-            # noinspection PyUnresolvedReferences
-            return self._other.listdir(key)
-
-    def __getsize(self, key: str) -> int:
-        with self._measure_time(f'{self._name}.getsize({key!r})'):
-            # noinspection PyUnresolvedReferences
-            return self._other.getsize(key)
-
-    def keys(self) -> KeysView[str]:
-        with self._measure_time(f'{self._name}.keys()'):
-            # noinspection PyTypeChecker
-            return self._other.keys()
-
-    def __iter__(self) -> Iterator[str]:
-        with self._measure_time(f'{self._name}.__iter__()'):
-            return self._other.__iter__()
-
-    def __len__(self) -> int:
-        with self._measure_time(f'{self._name}.__len__()'):
-            return self._other.__len__()
-
-    def __contains__(self, key) -> bool:
-        with self._measure_time(f'{self._name}.__contains__({key!r})'):
-            return self._other.__contains__(key)
-
-    def __getitem__(self, key: str) -> bytes:
-        with self._measure_time(f'{self._name}.__getitem__({key!r})'):
-            return self._other.__getitem__(key)
+        assert_instance(other, collections.abc.MutableMapping)
+        return cls(other, logger=logger, name=name)
 
 
-class MutableLoggingStore(LoggingStore, MutableMapping):
+@deprecated(reason="This class has been moved,"
+                   " use xcube.core.zarrstore.LoggingZarrStore"
+                   " instead.",
+            version="0.12.1")
+class MutableLoggingStore(LoggingStore):
     """
     Mutable version of :class:LoggingStore.
     """
-
-    def __init__(self,
-                 other: MutableMapping,
-                 logger: Logger = LOG,
-                 name: Optional[str] = None):
-        assert_instance(other, MutableMapping)
-        super().__init__(other, logger, name)
-
-    def __setitem__(self, key: str, value: bytes) -> None:
-        with self._measure_time(f'{self._name}.__setitem__({key!r}, <value>)'):
-            return self._other.__setitem__(key, value)
-
-    def __delitem__(self, key: str) -> None:
-        with self._measure_time(f'{self._name}.__delitem__({key!r})'):
-            return self._other.__delitem__(key)

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -32,7 +32,7 @@ import zarr
 # Note, we need the following reference to register the
 # xarray property accessor
 # noinspection PyUnresolvedReferences
-from xcube.core.zarrstore import DatasetZarrStoreProperty
+from xcube.core.zarrstore import DatasetZarrStoreHolder
 from xcube.core.zarrstore import LoggingZarrStore
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -32,7 +32,7 @@ import zarr
 # Note, we need the following reference to register the
 # xarray property accessor
 # noinspection PyUnresolvedReferences
-from xcube.core.zarrstore import DatasetZarrStoreHolder
+from xcube.core.zarrstore import ZarrStoreHolder
 from xcube.core.zarrstore import LoggingZarrStore
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -37,7 +37,7 @@ from xcube.core.subsampling import AGG_METHODS
 # Note, we need the following reference to register the
 # xarray property accessor
 # noinspection PyUnresolvedReferences
-from xcube.core.zarrstore import DatasetZarrStoreHolder
+from xcube.core.zarrstore import ZarrStoreHolder
 from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -37,7 +37,7 @@ from xcube.core.subsampling import AGG_METHODS
 # Note, we need the following reference to register the
 # xarray property accessor
 # noinspection PyUnresolvedReferences
-from xcube.core.zarrstore import DatasetZarrStoreProperty
+from xcube.core.zarrstore import DatasetZarrStoreHolder
 from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema

--- a/xcube/core/zarrstore/__init__.py
+++ b/xcube/core/zarrstore/__init__.py
@@ -25,4 +25,4 @@ from .generic import GenericArray
 from .generic import GenericArrayLike
 from .generic import GenericZarrStore
 from .logging import LoggingZarrStore
-from .xraccessor import DatasetZarrStoreProperty
+from .xraccessor import DatasetZarrStoreHolder

--- a/xcube/core/zarrstore/__init__.py
+++ b/xcube/core/zarrstore/__init__.py
@@ -24,5 +24,5 @@ from .diagnostic import DiagnosticZarrStore
 from .generic import GenericArray
 from .generic import GenericArrayLike
 from .generic import GenericZarrStore
+from .holder import ZarrStoreHolder
 from .logging import LoggingZarrStore
-from .xraccessor import DatasetZarrStoreHolder

--- a/xcube/core/zarrstore/__init__.py
+++ b/xcube/core/zarrstore/__init__.py
@@ -1,0 +1,28 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from .cached import CachedZarrStore
+from .diagnostic import DiagnosticZarrStore
+from .generic import GenericArray
+from .generic import GenericArrayLike
+from .generic import GenericZarrStore
+from .logging import LoggingZarrStore
+from .xraccessor import DatasetZarrStoreProperty

--- a/xcube/core/zarrstore/cached.py
+++ b/xcube/core/zarrstore/cached.py
@@ -1,0 +1,124 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import collections.abc
+import warnings
+from typing import Iterator, List
+
+import zarr.storage
+
+from xcube.util.assertions import assert_instance, assert_true
+
+
+class CachedZarrStore(zarr.storage.Store):
+    """A read-only Zarr store that is faster than
+    *store* because it uses a writable *cache* store.
+
+    The *cache* store is assumed to
+    read values for a given key much faster than *store*.
+
+    Note that iterating keys and containment checks are performed
+    on *store* only.
+
+    :param store: A Zarr store that is known
+        to be slow in reading values.
+    :param cache: A writable Zarr store that can
+        read values faster than *store*.
+    """
+
+    _readable = True  # Because the base class is readable
+    _listable = True  # Because the base class is listable
+    _writeable = False  # Because this is not yet supported
+    _erasable = False  # Because this is not yet supported
+
+    def __init__(self,
+                 store: collections.abc.MutableMapping,
+                 cache: collections.abc.MutableMapping):
+        assert_instance(store, collections.abc.MutableMapping, name="store")
+        assert_instance(cache, collections.abc.MutableMapping, name="cache")
+        if not isinstance(store, zarr.storage.BaseStore):
+            store = zarr.storage.KVStore(store)
+        if not isinstance(cache, zarr.storage.BaseStore):
+            cache = zarr.storage.KVStore(cache)
+        assert_true(store.is_readable(), message='store must be readable')
+        assert_true(cache.is_readable(), message='cache must be readable')
+        assert_true(cache.is_writeable(), message='cache must be writable')
+        self._store = store
+        self._cache = cache
+        self._implement_op('listdir')
+        self._implement_op('getsize')
+
+    @property
+    def store(self) -> zarr.storage.BaseStore:
+        return self._store
+
+    @property
+    def cache(self) -> zarr.storage.BaseStore:
+        return self._cache
+
+    def _implement_op(self, op: str):
+        if hasattr(self._store, op):
+            assert hasattr(self, "_" + op)
+            setattr(self, op, getattr(self, "_" + op))
+
+    def _listdir(self, path: str = "") -> List[str]:
+        # noinspection PyUnresolvedReferences
+        return self._store.listdir(path=path)
+
+    def _getsize(self, path: str) -> None:
+        # noinspection PyBroadException
+        try:
+            # noinspection PyUnresolvedReferences
+            size = self._cache.getsize(path)
+        except BaseException:
+            size = -1
+        if size < 0:
+            # noinspection PyUnresolvedReferences
+            size = self._store.getsize(path)
+        return size
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._store)
+
+    def __contains__(self, key: str):
+        return key in self._store
+
+    def __getitem__(self, key: str) -> bytes:
+        try:
+            return self._cache[key]
+        except KeyError:
+            pass
+        value = self._store[key]
+        # noinspection PyBroadException
+        try:
+            self._cache[key] = value
+        except BaseException as e:
+            warnings.warn(f"cache write failed for key {key!r}: {e}")
+        return value
+
+    def __setitem__(self, key: str, value: bytes) -> None:
+        raise NotImplementedError()
+
+    def __delitem__(self, key: str) -> None:
+        raise NotImplementedError()

--- a/xcube/core/zarrstore/diagnostic.py
+++ b/xcube/core/zarrstore/diagnostic.py
@@ -1,0 +1,78 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import collections.abc
+from typing import Iterator, List
+
+import zarr.storage
+
+
+class DiagnosticZarrStore(zarr.storage.Store):
+    """A diagnostic Zarr store used for testing and investigating
+    behaviour of Zarr and xarray's Zarr backend.
+
+    :param store: Wrapped Zarr store.
+    """
+
+    def __init__(self, store: collections.abc.MutableMapping):
+        self.store = store
+        self.records: List[str] = []
+        if hasattr(self.store, "listdir"):
+            self.listdir = self._listdir
+        if hasattr(self.store, "getsize"):
+            self.getsize = self._getsize
+
+    def _add_record(self, record: str):
+        self.records.append(record)
+
+    def _listdir(self, path: str = "") -> List[str]:
+        self._add_record(f"listdir({path!r})")
+        # noinspection PyUnresolvedReferences
+        return self.store.listdir(path=path)
+
+    def _getsize(self, key: str) -> int:
+        self._add_record(f"getsize({key!r})")
+        # noinspection PyUnresolvedReferences
+        return self.store.getsize(key)
+
+    def keys(self):
+        self._add_record("keys()")
+        return self.store.keys()
+
+    def __setitem__(self, key: str, value: bytes) -> None:
+        self._add_record(f"__setitem__({key!r}, {type(value).__name__})")
+        self.store.__setitem__(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        self._add_record(f"__delitem__({key!r})")
+        self.store.__delitem__(key)
+
+    def __getitem__(self, key: str) -> bytes:
+        self._add_record(f"__getitem__({key!r})")
+        return self.store.__getitem__(key)
+
+    def __len__(self) -> int:
+        self._add_record("__len__()")
+        return self.store.__len__()
+
+    def __iter__(self) -> Iterator[str]:
+        self._add_record("__iter__()")
+        return self.store.__iter__()

--- a/xcube/core/zarrstore/holder.py
+++ b/xcube/core/zarrstore/holder.py
@@ -31,7 +31,7 @@ from xcube.util.assertions import assert_instance
 
 
 @xr.register_dataset_accessor('zarr_store')
-class DatasetZarrStoreHolder:
+class ZarrStoreHolder:
     """Represents a xarray dataset property ``zarr_store``.
 
     It is used to permanently associate a dataset with its

--- a/xcube/core/zarrstore/logging.py
+++ b/xcube/core/zarrstore/logging.py
@@ -1,0 +1,90 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+
+import collections.abc
+from logging import Logger
+from typing import Iterator, Iterable, KeysView, Optional
+
+import zarr.storage
+
+from xcube.constants import LOG
+from xcube.util.assertions import assert_instance
+from xcube.util.perf import measure_time_cm
+
+
+class LoggingZarrStore(zarr.storage.BaseStore):
+    """
+    A Zarr Store that logs all method calls on another store *other*
+    including execution time.
+    """
+
+    def __init__(self,
+                 other: collections.abc.MutableMapping,
+                 logger: Logger = LOG,
+                 name: Optional[str] = None):
+        assert_instance(other, collections.abc.MutableMapping)
+        self._other = other
+        self._measure_time = measure_time_cm(logger=logger)
+        self._name = name or 'chunk_store'
+        if hasattr(other, 'listdir'):
+            setattr(self, 'listdir', self.__listdir)
+        if hasattr(other, 'getsize'):
+            setattr(self, 'getsize', self.__getsize)
+
+    def __listdir(self, key: str) -> Iterable[str]:
+        with self._measure_time(f'{self._name}.listdir({key!r})'):
+            # noinspection PyUnresolvedReferences
+            return self._other.listdir(key)
+
+    def __getsize(self, key: str) -> int:
+        with self._measure_time(f'{self._name}.getsize({key!r})'):
+            # noinspection PyUnresolvedReferences
+            return self._other.getsize(key)
+
+    def keys(self) -> KeysView[str]:
+        with self._measure_time(f'{self._name}.keys()'):
+            # noinspection PyTypeChecker
+            return self._other.keys()
+
+    def __iter__(self) -> Iterator[str]:
+        with self._measure_time(f'{self._name}.__iter__()'):
+            return self._other.__iter__()
+
+    def __len__(self) -> int:
+        with self._measure_time(f'{self._name}.__len__()'):
+            return self._other.__len__()
+
+    def __contains__(self, key) -> bool:
+        with self._measure_time(f'{self._name}.__contains__({key!r})'):
+            return self._other.__contains__(key)
+
+    def __getitem__(self, key: str) -> bytes:
+        with self._measure_time(f'{self._name}.__getitem__({key!r})'):
+            return self._other.__getitem__(key)
+
+    def __setitem__(self, key: str, value: bytes) -> None:
+        with self._measure_time(f'{self._name}.__setitem__({key!r}, <value>)'):
+            return self._other.__setitem__(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        with self._measure_time(f'{self._name}.__delitem__({key!r})'):
+            return self._other.__delitem__(key)

--- a/xcube/core/zarrstore/xraccessor.py
+++ b/xcube/core/zarrstore/xraccessor.py
@@ -1,0 +1,95 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import collections.abc
+import threading
+from typing import Optional
+
+import xarray as xr
+
+from xcube.util.assertions import assert_instance
+
+
+@xr.register_dataset_accessor('zarr_store')
+class DatasetZarrStoreProperty:
+    """Represents a xarray dataset property ``zarr_store``.
+
+    It is used to permanently associate a dataset with its
+    Zarr store, which would otherwise not be possible.
+
+    In xcube server, we use the new property to expose
+    datasets via the S3 emulation API.
+
+    For that concept to work, datasets must be associated
+    with their Zarr stores explicitly.
+    Therefore, the xcube data store framework sets the
+    Zarr stores of datasets after opening them ``xr.open_zarr()``:
+
+    ```python
+    dataset = xr.open_zarr(zarr_store, **open_params)
+    dataset.zarr_store.set(zarr_store)
+    ```
+
+    Note, that the dataset may change after the Zarr store has been set,
+    so that the dataset and its Zarr store are no longer in sync.
+    This may be an issue and limit the application of the new property.
+
+    :param dataset: The xarray dataset that is
+        associated with a Zarr store.
+    """
+
+    def __init__(self, dataset: xr.Dataset):
+        self._dataset = dataset
+        self._zarr_store: Optional[collections.abc.MutableMapping] = None
+        self._lock = threading.RLock()
+
+    def __call__(self) -> collections.abc.MutableMapping:
+        """Get the Zarr store of a dataset.
+        If no Zarr store has been set, the method will use
+        ``GenericZarrStore.from_dataset()`` to create and set
+        one.
+
+        :return: The Zarr store.
+        """
+        if self._zarr_store is None:
+            # Double-checked locking pattern
+            with self._lock:
+                if self._zarr_store is None:
+                    from xcube.core.zarrstore import GenericZarrStore
+                    self._zarr_store = GenericZarrStore.from_dataset(
+                        self._dataset
+                    )
+        return self._zarr_store
+
+    def set(self, zarr_store: collections.abc.MutableMapping) -> None:
+        """Set the Zarr store of a dataset.
+        :param zarr_store: The Zarr store.
+        """
+        assert_instance(zarr_store,
+                        collections.abc.MutableMapping,
+                        name='zarr_store')
+        with self._lock:
+            self._zarr_store = zarr_store
+
+    def reset(self) -> None:
+        """Resets the Zarr store."""
+        with self._lock:
+            self._zarr_store = None


### PR DESCRIPTION
Added a new package `xcube.core.zarrstore` that exports a number of useful [Zarr store](https://zarr.readthedocs.io/en/stable/api/storage.html) implementations: 
* `xcube.core.zarrstore.GenericZarrStore` comprises user-defined, generic array definitions. Arrays will compute their chunks either from a function or a static data array. 
* `xcube.core.zarrstore.LoggingZarrStore` is used to log Zarr store access performance and therefore useful for runtime optimisation and debugging. 
* `xcube.core.zarrstore.DiagnosticZarrStore` is used for testing Zarr store implementations. 
  
In turn, the classes of module `xcube.core.chunkstore` have been deprecated.

**Note:** the `xcube.core.zarrstore.GenericZarrStore` class is used by `xcube-smos` and will be used by `xcube-smos`.

Also added a xarray dataset accessor `xcube.core.zarrstore.ZarrStoreHolder` that enhances instances of `xarray.Dataset` by a new property `zarr_store`. It holds a Zarr store instance that represents the datasets as a key-value mapping. This prepares later versions of xcube Server for publishing all datasets via an emulated S3 API. This is therefore needed for larger PR #724. 

**Note:** existing data store implementations, like `xcube-cci`, `xcube-sh`, `xcube-cmems`, that utilise Zarr stores for fetching chunks from some data API **should call `dataset.zarr_store.set(zarr_store)` from now on**.

FYI @AliceBalfanz @pont-us @TonioF 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
