### PR TITLE
Fix broken JSON encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,13 +32,13 @@
   `xarray >= 2022.6` and `zarr >= 2.11` to ensure sparse 
   Zarr datasets can be written using `dataset.to_zarr(store)`. (#688)
 
-* Added new module `xcube.util.jsonencoder` that 
-  offers class `NumpyJSONEncoder` that  used to serialize 
-  numpy-like scalar values to JSON. It also offers the function 
-  `to_json_value()` to convert Python objects into JSON-serializable 
-  versions. The new functionality is required to ensure dataset
-  attributes that are JSON-serializable. For example, latest
-  `rioxarray` generates a `_FillValue` attribute with datatype `np.uint8`. 
+* Added new module `xcube.util.jsonencoder` that offers the class 
+  `NumpyJSONEncoder` used to serialize numpy-like scalar values to JSON. 
+  It also offers the function `to_json_value()` to convert Python objects 
+  into JSON-serializable versions. The new functionality is required 
+  to ensure dataset attributes that are JSON-serializable. For example,
+  the latest version of the `rioxarray` package generates a `_FillValue` 
+  attribute with datatype `np.uint8`. 
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,13 @@
   is used to select dataset labels along a given dimension using
   user-defined predicate functions.
 
+* The xcube Python environment is now requiring 
+  `xarray >= 2022.6` and `zarr >= 2.11` to ensure sparse 
+  Zarr datasets can be written using `dataset.to_zarr(store)`. (#688)
+
+* Added new class `xcube.util.jsonencoder.NumpyJSONEncoder` that 
+  is used to serialize numpy-like scalar values to JSON.
+
 ### Fixes
 
 * The filesystem-based data stores for the "s3", "file", and "memory"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 
 * Added new class `xcube.util.jsonencoder.NumpyJSONEncoder` that 
   is used to serialize numpy-like scalar values to JSON.
+  The new encoder is required because `xcube io dump` was broken 
+  due to the updated env.
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,10 +32,13 @@
   `xarray >= 2022.6` and `zarr >= 2.11` to ensure sparse 
   Zarr datasets can be written using `dataset.to_zarr(store)`. (#688)
 
-* Added new class `xcube.util.jsonencoder.NumpyJSONEncoder` that 
-  is used to serialize numpy-like scalar values to JSON.
-  The new encoder is required because `xcube io dump` was broken 
-  due to the updated env.
+* Added new module `xcube.util.jsonencoder` that 
+  offers class `NumpyJSONEncoder` that  used to serialize 
+  numpy-like scalar values to JSON. It also offers the function 
+  `to_json_value()` to convert Python objects into JSON-serializable 
+  versions. The new functionality is required to ensure dataset
+  attributes that are JSON-serializable. For example, latest
+  `rioxarray` generates a `_FillValue` attribute with datatype `np.uint8`. 
 
 ### Fixes
 

--- a/test/util/test_jsonencoder.py
+++ b/test/util/test_jsonencoder.py
@@ -1,0 +1,85 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import json
+import unittest
+
+import numpy as np
+import pytest
+
+from xcube.util.jsonencoder import NumpyJSONEncoder
+
+
+class NumpyJSONEncoderTest(unittest.TestCase):
+    TEST_DATA = {
+        "np_bool": np.bool(True),
+        "np_int8": np.int8(1),
+        "np_uint8": np.uint8(2),
+        "np_int16": np.int16(3),
+        "np_uint16": np.uint8(4),
+        "np_int32": np.int32(5),
+        "np_uint32": np.uint32(6),
+        "np_int64": np.int64(7),
+        "np_uint64": np.uint64(8),
+        "np_float32": np.float32(9.1),
+        "np_float64": np.float64(9.2),
+        "py_bool": True,
+        "py_int": 11,
+        "py_float": 12.3,
+        "py_str": "Hallo",
+        "py_null": None,
+    }
+
+    def test_fail_without_encoder(self):
+        with pytest.raises(TypeError):
+            json.dumps(
+                self.TEST_DATA,
+                indent=2,
+            )
+
+    def test_encoder_encodes_all(self):
+        text = json.dumps(
+            self.TEST_DATA,
+            indent=2,
+            cls=NumpyJSONEncoder
+        )
+        data = json.loads(text)
+        self.assertEqual(
+            {
+                "np_bool": bool(np.bool(True)),
+                "np_int8": int(np.int8(1)),
+                "np_uint8": int(np.uint8(2)),
+                "np_int16": int(np.int16(3)),
+                "np_uint16": int(np.uint8(4)),
+                "np_int32": int(np.int32(5)),
+                "np_uint32": int(np.uint32(6)),
+                "np_int64": int(np.int64(7)),
+                "np_uint64": int(np.uint64(8)),
+                "np_float32": float(np.float32(9.1)),
+                "np_float64": float(np.float64(9.2)),
+                "py_bool": True,
+                "py_int": 11,
+                "py_float": 12.3,
+                "py_str": "Hallo",
+                "py_null": None,
+            },
+            data
+        )

--- a/test/util/test_jsonencoder.py
+++ b/test/util/test_jsonencoder.py
@@ -59,15 +59,7 @@ INPUT = {
     **NP_INPUT,
 }
 
-EXPECTED_PY_OUTPUT = {
-    'py_bool': True,
-    'py_int': 11,
-    'py_float': 12.3,
-    'py_str': 'Hallo',
-    'py_null': None,
-    'py_list': [1, 2, 3],
-    'py_dict': {'x': 'A', 'y': 'B'},
-}
+EXPECTED_PY_OUTPUT = {**PY_INPUT}
 
 EXPECTED_NP_OUTPUT = {
     'np_bool': bool(np.bool(True)),

--- a/test/util/test_jsonencoder.py
+++ b/test/util/test_jsonencoder.py
@@ -124,6 +124,11 @@ class ToJsonValueTest(unittest.TestCase):
         self.assertEqual(dict(a=EXPECTED_OUTPUT, b=EXPECTED_OUTPUT),
                          to_json_value(input_dict))
 
+        with pytest.raises(TypeError,
+                           match='Property names of JSON objects'
+                                 ' must be strings, but got bool'):
+            to_json_value({True: 13})
+
     def test_list(self):
         input_list = [PY_INPUT, PY_INPUT]
         self.assertIs(input_list,

--- a/test/util/test_jsonencoder.py
+++ b/test/util/test_jsonencoder.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 by the xcube development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
+# copy of this software and associated documentation files (the 'Software'),
 # to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
@@ -11,7 +11,7 @@
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -26,60 +26,147 @@ import numpy as np
 import pytest
 
 from xcube.util.jsonencoder import NumpyJSONEncoder
+from xcube.util.jsonencoder import to_json_value
+
+PY_INPUT = {
+    'py_bool': True,
+    'py_int': 11,
+    'py_float': 12.3,
+    'py_str': 'Hallo',
+    'py_null': None,
+    'py_list': [1, 2, 3],
+    'py_dict': {'x': 'A', 'y': 'B'},
+}
+
+NP_INPUT = {
+    'np_bool': np.bool(True),
+    'np_int8': np.int8(1),
+    'np_uint8': np.uint8(2),
+    'np_int16': np.int16(3),
+    'np_uint16': np.uint8(4),
+    'np_int32': np.int32(5),
+    'np_uint32': np.uint32(6),
+    'np_int64': np.int64(7),
+    'np_uint64': np.uint64(8),
+    'np_float32': np.float32(9.1),
+    'np_float64': np.float64(9.2),
+    'np_uint8_array': np.array([1, 2, 3], dtype=np.uint8),
+    'np_float64_array': np.array([0.1, 0.2, 0.3], dtype=np.float64),
+}
+
+INPUT = {
+    **PY_INPUT,
+    **NP_INPUT,
+}
+
+EXPECTED_PY_OUTPUT = {
+    'py_bool': True,
+    'py_int': 11,
+    'py_float': 12.3,
+    'py_str': 'Hallo',
+    'py_null': None,
+    'py_list': [1, 2, 3],
+    'py_dict': {'x': 'A', 'y': 'B'},
+}
+
+EXPECTED_NP_OUTPUT = {
+    'np_bool': bool(np.bool(True)),
+    'np_int8': int(np.int8(1)),
+    'np_uint8': int(np.uint8(2)),
+    'np_int16': int(np.int16(3)),
+    'np_uint16': int(np.uint8(4)),
+    'np_int32': int(np.int32(5)),
+    'np_uint32': int(np.uint32(6)),
+    'np_int64': int(np.int64(7)),
+    'np_uint64': int(np.uint64(8)),
+    'np_float32': float(np.float32(9.1)),
+    'np_float64': float(np.float64(9.2)),
+    'np_uint8_array': [1, 2, 3],
+    'np_float64_array': [0.1, 0.2, 0.3],
+}
+
+EXPECTED_OUTPUT = {
+    **EXPECTED_PY_OUTPUT,
+    **EXPECTED_NP_OUTPUT
+}
 
 
 class NumpyJSONEncoderTest(unittest.TestCase):
-    TEST_DATA = {
-        "np_bool": np.bool(True),
-        "np_int8": np.int8(1),
-        "np_uint8": np.uint8(2),
-        "np_int16": np.int16(3),
-        "np_uint16": np.uint8(4),
-        "np_int32": np.int32(5),
-        "np_uint32": np.uint32(6),
-        "np_int64": np.int64(7),
-        "np_uint64": np.uint64(8),
-        "np_float32": np.float32(9.1),
-        "np_float64": np.float64(9.2),
-        "py_bool": True,
-        "py_int": 11,
-        "py_float": 12.3,
-        "py_str": "Hallo",
-        "py_null": None,
-    }
 
+    # noinspection PyMethodMayBeStatic
     def test_fail_without_encoder(self):
         with pytest.raises(TypeError):
-            json.dumps(
-                self.TEST_DATA,
-                indent=2,
-            )
+            json.dumps(INPUT, indent=2)
 
     def test_encoder_encodes_all(self):
-        text = json.dumps(
-            self.TEST_DATA,
-            indent=2,
-            cls=NumpyJSONEncoder
-        )
+        text = json.dumps(INPUT, indent=2, cls=NumpyJSONEncoder)
         data = json.loads(text)
-        self.assertEqual(
-            {
-                "np_bool": bool(np.bool(True)),
-                "np_int8": int(np.int8(1)),
-                "np_uint8": int(np.uint8(2)),
-                "np_int16": int(np.int16(3)),
-                "np_uint16": int(np.uint8(4)),
-                "np_int32": int(np.int32(5)),
-                "np_uint32": int(np.uint32(6)),
-                "np_int64": int(np.int64(7)),
-                "np_uint64": int(np.uint64(8)),
-                "np_float32": float(np.float32(9.1)),
-                "np_float64": float(np.float64(9.2)),
-                "py_bool": True,
-                "py_int": 11,
-                "py_float": 12.3,
-                "py_str": "Hallo",
-                "py_null": None,
-            },
-            data
-        )
+        self.assertEqual(EXPECTED_OUTPUT, data)
+
+
+class ToJsonValueTest(unittest.TestCase):
+    def test_items(self):
+        for k in PY_INPUT.keys():
+            self.assertIs(PY_INPUT[k],
+                          to_json_value(PY_INPUT[k]))
+        for k in INPUT.keys():
+            self.assertEqual(EXPECTED_OUTPUT[k],
+                             to_json_value(INPUT[k]))
+
+    def test_dict(self):
+        self.assertIs(PY_INPUT,
+                      to_json_value(PY_INPUT))
+
+        self.assertIsNot(INPUT,
+                         to_json_value(INPUT))
+        self.assertEqual(EXPECTED_OUTPUT,
+                         to_json_value(INPUT))
+
+        input_dict = dict(a=PY_INPUT, b=PY_INPUT)
+        self.assertIs(input_dict,
+                      to_json_value(input_dict))
+
+        input_dict = dict(a=INPUT, b=INPUT)
+        self.assertIsNot(input_dict,
+                         to_json_value(input_dict))
+        self.assertEqual(dict(a=EXPECTED_OUTPUT, b=EXPECTED_OUTPUT),
+                         to_json_value(input_dict))
+
+    def test_list(self):
+        input_list = [PY_INPUT, PY_INPUT]
+        self.assertIs(input_list,
+                      to_json_value(input_list))
+
+        input_list = [INPUT, INPUT]
+        self.assertIsNot(input_list,
+                         to_json_value(input_list))
+        self.assertEqual([EXPECTED_OUTPUT,
+                          EXPECTED_OUTPUT],
+                         to_json_value(input_list))
+
+        input_tuple = (INPUT, INPUT)
+        self.assertEqual([EXPECTED_OUTPUT,
+                          EXPECTED_OUTPUT],
+                         to_json_value(input_tuple))
+
+    def test_numpy_arrays(self):
+        import numpy
+
+        array = numpy.array([1, 2, 3])
+        self.assertIsNot(array, to_json_value(array))
+        self.assertEqual([1, 2, 3], to_json_value(array))
+
+        array = numpy.array([[1, 2], [3, 4]], dtype=np.uint8)
+        self.assertIsNot(array, to_json_value(array))
+        self.assertEqual([[1, 2], [3, 4]], to_json_value(array))
+
+        array = numpy.array([], dtype=np.float32)
+        self.assertIsNot(array, to_json_value(array))
+        self.assertEqual([], to_json_value(array))
+
+    # noinspection PyMethodMayBeStatic
+    def test_fails_correctly(self):
+        with pytest.raises(TypeError,
+                           match='Object of type object'
+                                 ' is not JSON serializable'):
+            to_json_value(object())

--- a/xcube/cli/io.py
+++ b/xcube/cli/io.py
@@ -370,7 +370,9 @@ def dump(output_file_path: Optional[str],
 
         with open(output_file_path, 'w') as fp:
             if output_format == 'json':
-                json.dump(dict(stores=store_list), fp, indent=2)
+                from xcube.util.jsonencoder import NumpyJSONEncoder
+                json.dump(dict(stores=store_list), fp, indent=2,
+                          cls=NumpyJSONEncoder)
             else:
                 yaml.dump(dict(stores=store_list), fp, indent=2)
 

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -29,13 +29,14 @@ import s3fs
 import xarray as xr
 import zarr
 
+from xcube.core.zarrstore import LoggingZarrStore
 # Note, we need the following reference to register the
 # xarray property accessor
 # noinspection PyUnresolvedReferences
 from xcube.core.zarrstore import ZarrStoreHolder
-from xcube.core.zarrstore import LoggingZarrStore
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
+from xcube.util.jsonencoder import to_json_value
 from xcube.util.jsonschema import JsonArraySchema
 from xcube.util.jsonschema import JsonBooleanSchema
 from xcube.util.jsonschema import JsonIntegerSchema
@@ -448,6 +449,11 @@ class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
             for data_var in dataset.data_vars.values():
                 data_var.attrs['grid_mapping'] = 'spatial_ref'
 
+        # rioxarray may return non-JSON-serializable metadata
+        # attribute values.
+        # We have seen _FillValue of type np.uint8
+        cls._sanitize_dataset_attrs(dataset)
+
         return dataset
 
     def get_write_data_params_schema(self) -> JsonObjectSchema:
@@ -459,3 +465,9 @@ class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
                    replace=False,
                    **write_params) -> str:
         raise NotImplementedError("Writing of GeoTIFF not yet supported")
+
+    @classmethod
+    def _sanitize_dataset_attrs(cls, dataset):
+        dataset.attrs.update(to_json_value(dataset.attrs))
+        for var in dataset.variables.values():
+            var.attrs.update(to_json_value(var.attrs))

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -1,0 +1,45 @@
+# The MIT License (MIT)
+# Copyright (c) 2022 by the xcube development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import json
+
+import numpy as np
+
+
+class NumpyJSONEncoder(json.JSONEncoder):
+    """A JSON encoder that converty numpy-like
+    scalars into corresponding serializable Python objects.
+    """
+
+    def default(self, obj):
+        if hasattr(obj, 'dtype') and hasattr(obj, 'ndim'):
+            if obj.ndim == 0:
+                # For time being just handle scalars.
+                if np.issubdtype(obj.dtype, np.bool):
+                    return bool(obj)
+                if np.issubdtype(obj.dtype, np.integer):
+                    return int(obj)
+                elif np.issubdtype(obj.dtype, np.floating):
+                    return float(obj)
+                else:
+                    return str(obj)
+            # We may add serialization for N-D arrays here.
+        return json.JSONEncoder.default(self, obj)

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -20,8 +20,13 @@
 # DEALINGS IN THE SOFTWARE.
 
 import json
+from typing import Any, Union, List, Dict
 
 import numpy as np
+
+JsonArray = List["JsonValue"]
+JsonObject = Dict[str, "JsonValue"]
+JsonValue = Union[None, bool, int, float, str, JsonArray, JsonObject]
 
 
 class NumpyJSONEncoder(json.JSONEncoder):
@@ -29,17 +34,80 @@ class NumpyJSONEncoder(json.JSONEncoder):
     scalars into corresponding serializable Python objects.
     """
 
-    def default(self, obj):
-        if hasattr(obj, 'dtype') and hasattr(obj, 'ndim'):
-            if obj.ndim == 0:
-                # For time being just handle scalars.
-                if np.issubdtype(obj.dtype, np.bool):
-                    return bool(obj)
-                if np.issubdtype(obj.dtype, np.integer):
-                    return int(obj)
-                elif np.issubdtype(obj.dtype, np.floating):
-                    return float(obj)
-                else:
-                    return str(obj)
-            # We may add serialization for N-D arrays here.
+    def default(self, obj: Any) -> JsonValue:
+        converted_obj = _convert_default(obj)
+        if converted_obj is not obj:
+            return converted_obj
         return json.JSONEncoder.default(self, obj)
+
+
+_PRIMITIVE_JSON_TYPES = {
+    type(None),
+    bool,
+    int,
+    float,
+    str
+}
+
+
+def to_json_value(obj: Any) -> Union[Any, JsonValue]:
+    """Convert *obj* into a JSON-serializable object.
+
+    :param obj: A Python object.
+    :return: A JSON-serializable version of *obj*, or *obj*
+        if *obj* is already JSON-serializable.
+    :raises TypeError: If *obj* cannot be made JSON-serializable
+    """
+    converted_obj = _convert_default(obj)
+    if converted_obj is not obj:
+        return converted_obj
+
+    obj_type = type(obj)
+
+    if obj_type in _PRIMITIVE_JSON_TYPES:
+        return obj
+
+    for t in _PRIMITIVE_JSON_TYPES:
+        if isinstance(obj, t):
+            return t(obj)
+
+    if obj_type is dict:
+        converted_obj = {k: to_json_value(v) for k, v in obj.items()}
+        if any(converted_obj[k] is not obj[k] for k in obj.keys()):
+            return converted_obj
+        else:
+            return obj
+
+    if obj_type is list:
+        converted_obj = [to_json_value(item) for item in obj]
+        if any(o1 is not o2 for o1, o2 in zip(converted_obj, obj)):
+            return converted_obj
+        else:
+            return obj
+
+    try:
+        return {k: to_json_value(v) for k, v in obj.items()}
+    except AttributeError:
+        try:
+            return [to_json_value(item) for item in obj]
+        except TypeError:
+            # Same as json.JSONEncoder.default(self, obj)
+            raise TypeError(f'Object of type {obj.__class__.__name__} '
+                            f'is not JSON serializable')
+
+
+def _convert_default(obj: Any) -> Any:
+    if hasattr(obj, 'dtype') and hasattr(obj, 'ndim'):
+        if obj.ndim == 0:
+            if np.issubdtype(obj.dtype, np.bool):
+                return bool(obj)
+            elif np.issubdtype(obj.dtype, np.integer):
+                return int(obj)
+            elif np.issubdtype(obj.dtype, np.floating):
+                return float(obj)
+            elif np.issubdtype(obj.dtype, np.str):
+                return str(obj)
+        else:
+            return [_convert_default(item) for item in obj]
+    # We may handle other non-sJSON-serializable datatypes here
+    return obj

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -72,7 +72,7 @@ def to_json_value(obj: Any) -> JsonValue:
             return t(obj)
 
     if obj_type is dict:
-        converted_obj = {k: to_json_value(v) for k, v in obj.items()}
+        converted_obj = {_key(k): to_json_value(v) for k, v in obj.items()}
         if any(converted_obj[k] is not obj[k] for k in obj.keys()):
             return converted_obj
         else:
@@ -86,14 +86,22 @@ def to_json_value(obj: Any) -> JsonValue:
             return obj
 
     try:
-        return {k: to_json_value(v) for k, v in obj.items()}
+        return {_key(k): to_json_value(v) for k, v in obj.items()}
     except AttributeError:
         try:
             return [to_json_value(item) for item in obj]
         except TypeError:
             # Same as json.JSONEncoder.default(self, obj)
-            raise TypeError(f'Object of type {obj.__class__.__name__} '
-                            f'is not JSON serializable')
+            raise TypeError(f'Object of type'
+                            f' {obj.__class__.__name__}'
+                            f' is not JSON serializable')
+
+
+def _key(key: Any) -> str:
+    if not isinstance(key, str):
+        raise TypeError(f'Property names of JSON objects must be strings,'
+                        f' but got {key.__class__.__name__}')
+    return key
 
 
 def _convert_default(obj: Any) -> Any:

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -25,7 +25,7 @@ import numpy as np
 
 
 class NumpyJSONEncoder(json.JSONEncoder):
-    """A JSON encoder that converty numpy-like
+    """A JSON encoder that converts numpy-like
     scalars into corresponding serializable Python objects.
     """
 

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -50,7 +50,7 @@ _PRIMITIVE_JSON_TYPES = {
 }
 
 
-def to_json_value(obj: Any) -> Union[Any, JsonValue]:
+def to_json_value(obj: Any) -> JsonValue:
     """Convert *obj* into a JSON-serializable object.
 
     :param obj: A Python object.

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -109,5 +109,5 @@ def _convert_default(obj: Any) -> Any:
                 return str(obj)
         else:
             return [_convert_default(item) for item in obj]
-    # We may handle other non-sJSON-serializable datatypes here
+    # We may handle other non-JSON-serializable datatypes here
     return obj


### PR DESCRIPTION
* The xcube Python environment is now requiring  `xarray >= 2022.6` and `zarr >= 2.11` to ensure sparse Zarr datasets can be written using `dataset.to_zarr(store)`. (#688)
* Added new module `xcube.util.jsonencoder` that offers the class `NumpyJSONEncoder` used to serialize numpy-like scalar values to JSON. It also offers the function `to_json_value()` to convert Python objects into JSON-serializable versions. The new functionality is required to ensure dataset attributes that are JSON-serializable. For example, the latest version of the `rioxarray` package generates a `_FillValue` attribute with datatype `np.uint8`. 

Closes #688.

**EDIT**

**It is likely that other places where we `json.dump()` are affected too!** In particular, where numeric metadata attributes are serialized such as `_FillValue`, `add_offset`, `valid_max`, etc.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
