### PR TITLE
Managing deprecations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,12 +52,21 @@
 ### Other
 
 * Deprecated CLI `xcube tile` has been removed.
-* Deprecated modules and their references have finally been removed:
-  - `xcube.core.tilegrid`
+* Deprecated modules, classes, methods, and functions
+  have finally been removed:
+  - `xcube.core.geom.get_geometry_mask()`
+  - `xcube.core.mldataset.FileStorageMultiLevelDataset`
+  - `xcube.core.mldataset.open_ml_dataset()`
+  - `xcube.core.mldataset.open_ml_dataset_from_local_fs()`
+  - `xcube.core.mldataset.open_ml_dataset_from_object_storage()`
+  - `xcube.core.subsampling.get_dataset_subsampling_slices()`
   - `xcube.core.tiledimage`
-* The following functions have been deprecated:
+  - `xcube.core.tilegrid`
+* The following classes, methods, and functions have been deprecated:
+  - `xcube.core.xarray.DatasetAccessor.levels()`
   - `xcube.util.cmaps.get_cmap()`
   - `xcube.util.cmaps.get_cmaps()`
+
 
 ## Changes in 0.12.1 
 

--- a/test/core/test_geom.py
+++ b/test/core/test_geom.py
@@ -12,7 +12,6 @@ from xcube.core.geom import clip_dataset_by_geometry
 from xcube.core.geom import convert_geometry
 from xcube.core.geom import get_dataset_bounds
 from xcube.core.geom import get_dataset_geometry
-from xcube.core.geom import get_geometry_mask
 from xcube.core.geom import is_dataset_y_axis_inverted
 from xcube.core.geom import is_lon_lat_dataset
 from xcube.core.geom import mask_dataset_by_geometry
@@ -373,82 +372,6 @@ class DatasetGeometryTest(unittest.TestCase):
             ' 101.25 -33.75, -33.75 -33.75))'
         )
         self.assertTrue(actual.difference(expected).is_empty)
-
-
-class GetGeometryMaskTest(unittest.TestCase):
-    # noinspection PyMethodMayBeStatic
-    def test_get_geometry_mask(self):
-        w = 16
-        h = 8
-        res = 1.0
-        lon_min = 0
-        lat_min = 0
-        lon_max = lon_min + w * res
-        lat_max = lat_min + h * res
-
-        triangle = shapely.geometry.Polygon(((lon_min, lat_min),
-                                             (lon_max, lat_min),
-                                             (lon_max, lat_max),
-                                             (lon_min, lat_min)))
-
-        actual_mask = get_geometry_mask(w, h, triangle, lon_min,
-                                        lat_min, res, all_touched=True)
-        expected_mask = np.array(
-            [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
-             [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
-             [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=np.byte
-        )
-        np.testing.assert_array_almost_equal(expected_mask,
-                                             actual_mask.astype('byte'))
-
-        actual_mask = get_geometry_mask(w, h, triangle, lon_min,
-                                        lat_min, res, all_touched=False)
-        expected_mask = np.array(
-            [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1],
-             [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-             [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]], dtype=np.byte
-        )
-        np.testing.assert_array_almost_equal(expected_mask,
-                                             actual_mask.astype('byte'))
-
-        smaller_triangle = triangle.buffer(-1.5 * res)
-        actual_mask = get_geometry_mask(w, h, smaller_triangle, lon_min,
-                                        lat_min, res, all_touched=True)
-        expected_mask = np.array(
-            [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.byte
-        )
-        np.testing.assert_array_almost_equal(expected_mask, actual_mask)
-
-        actual_mask = get_geometry_mask(w, h, smaller_triangle, lon_min,
-                                        lat_min, res, all_touched=False)
-        expected_mask = np.array(
-            [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=np.byte
-        )
-        np.testing.assert_array_almost_equal(expected_mask, actual_mask)
 
 
 class GetDatasetGeometryTest(unittest.TestCase):

--- a/test/core/test_subsampling.py
+++ b/test/core/test_subsampling.py
@@ -26,7 +26,6 @@ import xarray as xr
 
 from xcube.core.new import new_cube
 from xcube.core.subsampling import find_agg_method
-from xcube.core.subsampling import get_dataset_subsampling_slices
 from xcube.core.subsampling import subsample_dataset
 
 
@@ -54,20 +53,6 @@ class SubsampleDatasetTest(unittest.TestCase):
                                 variables=dict(var_1=test_data_1,
                                                var_2=test_data_2))
 
-    def test_get_dataset_subsampling_slices(self):
-        slices = get_dataset_subsampling_slices(self.dataset,
-                                                step=2)
-        self.assertEqual(
-            {
-                'var_1': (slice(None, None, None),
-                          slice(None, None, 2),
-                          slice(None, None, 2)),
-                'var_2': (slice(None, None, None),
-                          slice(None, None, 2),
-                          slice(None, None, 2))
-            },
-            slices
-        )
 
     def test_subsample_dataset_none(self):
         subsampled_dataset = subsample_dataset(self.dataset,

--- a/xcube/core/gen2/local/subsetter.py
+++ b/xcube/core/gen2/local/subsetter.py
@@ -79,7 +79,6 @@ class CubeSubsetter(CubeTransformer):
                 gm = GridMapping.from_dataset(
                     cube,
                     crs=gm.crs,
-                    xy_var_names=gm.xy_var_names,
                 )
                 # Consume spatial properties
                 cube_config = cube_config.drop_props(['bbox',

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -564,27 +564,6 @@ def _save_geometry_wkt(dataset, intersection_geometry, save_geometry):
         dataset.attrs.update({attr_name: intersection_geometry.wkt})
 
 
-@deprecated(version="0.10.2", reason="No longer in use.")
-def get_geometry_mask(width: int, height: int,
-                      geometry: GeometryLike,
-                      x_min: float,
-                      y_min: float,
-                      x_res: float,
-                      y_res: Optional[float] = None,
-                      all_touched: bool = True) -> np.ndarray:
-    if y_res is None:
-        y_res = x_res
-    geometry = normalize_geometry(geometry)
-    # noinspection PyTypeChecker
-    transform = affine.Affine(x_res, 0.0, x_min,
-                              0.0, -y_res, y_min + y_res * height)
-    return rasterio.features.geometry_mask([geometry],
-                                           out_shape=(height, width),
-                                           transform=transform,
-                                           all_touched=all_touched,
-                                           invert=True)
-
-
 def intersect_geometries(geometry1: GeometryLike, geometry2: GeometryLike) \
         -> Optional[shapely.geometry.base.BaseGeometry]:
     geometry1 = normalize_geometry(geometry1)

--- a/xcube/core/gridmapping/base.py
+++ b/xcube/core/gridmapping/base.py
@@ -643,7 +643,6 @@ class GridMapping(abc.ABC):
                      dataset: xr.Dataset,
                      *,
                      crs: Union[str, pyproj.crs.CRS] = None,
-                     xy_var_names: Tuple[str, str] = None,
                      tile_size: Union[int, Tuple[int, int]] = None,
                      prefer_is_regular: bool = True,
                      prefer_crs: Union[str, pyproj.crs.CRS] = None,
@@ -654,9 +653,6 @@ class GridMapping(abc.ABC):
 
         :param dataset: The dataset.
         :param crs: Optional spatial coordinate reference system.
-        :param xy_var_names: Optional tuple of the x- and
-            y-coordinate variables in *dataset*.
-            Deprecated since xcube 0.10.1.
         :param tile_size: Optional tile size
         :param prefer_is_regular: Whether to prefer a regular
             grid mapping if multiple found. Default is True.
@@ -673,7 +669,6 @@ class GridMapping(abc.ABC):
         return new_grid_mapping_from_dataset(
             dataset=dataset,
             crs=crs,
-            xy_var_names=xy_var_names,
             tile_size=tile_size,
             prefer_is_regular=prefer_is_regular,
             prefer_crs=prefer_crs,

--- a/xcube/core/gridmapping/dataset.py
+++ b/xcube/core/gridmapping/dataset.py
@@ -36,7 +36,6 @@ def new_grid_mapping_from_dataset(
         dataset: xr.Dataset,
         *,
         crs: Union[str, pyproj.crs.CRS] = None,
-        xy_var_names: Tuple[str, str] = None,
         tile_size: Union[int, Tuple[str, str]] = None,
         prefer_crs: Union[str, pyproj.crs.CRS] = None,
         prefer_is_regular: bool = None,
@@ -54,10 +53,6 @@ def new_grid_mapping_from_dataset(
         prefer_crs = _normalize_crs(prefer_crs)
     else:
         prefer_crs = crs
-    if xy_var_names:
-        warnings.warn('Argument "xy_var_names" is deprecated since '
-                      'xcube 0.10.1 and will be ignored.',
-                      category=DeprecationWarning)
 
     grid_mapping_proxies = get_dataset_grid_mapping_proxies(
         dataset,

--- a/xcube/core/resampling/rectify.py
+++ b/xcube/core/resampling/rectify.py
@@ -95,8 +95,7 @@ def rectify_dataset(source_ds: xr.Dataset,
         does not intersect with *dataset*.
     """
     if source_gm is None:
-        source_gm = GridMapping.from_dataset(source_ds,
-                                             xy_var_names=xy_var_names)
+        source_gm = GridMapping.from_dataset(source_ds)
 
     src_attrs = dict(source_ds.attrs)
 

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -131,8 +131,7 @@ def select_spatial_subset(dataset: xr.Dataset,
 
     grid_mapping = grid_mapping or geo_coding
     if grid_mapping is None:
-        grid_mapping = GridMapping.from_dataset(dataset,
-                                                xy_var_names=xy_names)
+        grid_mapping = GridMapping.from_dataset(dataset)
     x_name, y_name = grid_mapping.xy_var_names
     x = dataset[x_name]
     y = dataset[y_name]

--- a/xcube/core/subsampling.py
+++ b/xcube/core/subsampling.py
@@ -175,38 +175,6 @@ def find_agg_method(agg_methods: AggMethods,
 _FULL_SLICE = slice(None, None, None)
 
 
-@deprecated(version='0.10.3', reason='no longer in use')
-def get_dataset_subsampling_slices(
-        dataset: xr.Dataset,
-        step: int,
-        xy_dim_names: Optional[Tuple[str, str]] = None
-) -> Dict[Hashable, Optional[Tuple[slice, ...]]]:
-    """
-    Compute subsampling slices for variables in *dataset*.
-    Only data variables with spatial dimensions given by
-    *xy_dim_names* are considered.
-
-    :param dataset: the dataset providing the variables
-    :param step: the integer subsampling step
-    :param xy_dim_names: the spatial dimension names
-    """
-    assert_instance(dataset, xr.Dataset, name='dataset')
-    assert_instance(step, int, name='step')
-    slices_dict: Dict[Tuple[Hashable, ...], Tuple[slice, ...]] = dict()
-    vars_dict: Dict[Hashable, Optional[Tuple[slice, ...]]] = dict()
-    for var_name, var in dataset.data_vars.items():
-        var_index = slices_dict.get(var.dims)
-        if var_index is None:
-            var_index = get_variable_subsampling_slices(
-                var, step, xy_dim_names=xy_dim_names
-            )
-            if var_index is not None:
-                slices_dict[var.dims] = var_index
-        if var_index is not None:
-            vars_dict[var_name] = var_index
-    return vars_dict
-
-
 def get_variable_subsampling_slices(
         variable: xr.DataArray,
         step: int,

--- a/xcube/core/xarray.py
+++ b/xcube/core/xarray.py
@@ -1,6 +1,6 @@
 import threading
 from typing import Dict, List, Mapping, Any, Union, Sequence, Optional
-
+from deprecated import deprecated
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -293,6 +293,9 @@ class DatasetAccessor:
         """
         return select_variables_subset(self._dataset, var_names)
 
+    @deprecated(version='0.13.0',
+                reason='multi-level datasets should be represented by'
+                       ' class xcube.core.mldataset.MultiLevelDataset')
     def levels(self, **kwargs) -> List[xr.Dataset]:
         """
         Transform this dataset into the levels of a multi-level pyramid with spatial resolution


### PR DESCRIPTION
* Deprecated modules, classes, methods, and functions
  have finally been removed:
  - `xcube.core.geom.get_geometry_mask()`
  - `xcube.core.mldataset.FileStorageMultiLevelDataset`
  - `xcube.core.mldataset.open_ml_dataset()`
  - `xcube.core.mldataset.open_ml_dataset_from_local_fs()`
  - `xcube.core.mldataset.open_ml_dataset_from_object_storage()`
  - `xcube.core.subsampling.get_dataset_subsampling_slices()`
  - `xcube.core.tiledimage`
  - `xcube.core.tilegrid`
* The following classes, methods, and functions have been deprecated:
  - `xcube.core.xarray.DatasetAccessor.levels()`
  - `xcube.util.cmaps.get_cmap()`
  - `xcube.util.cmaps.get_cmaps()`

Checklist:

* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes

