### PR TITLE
Fix `get_dataset_bounds()` for different resolutions in x, y

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 ### Intermediate changes
 
 * Removed outdated example resources from `examples/serve/demo`.
+* Account for different spatial resolutions in x and y in 
+  `xcube.core.geom.get_dataset_bounds()`.
+* Make code robust against 0-size coordinates in 
+  `xcube.core.update._update_dataset_attrs()`.
+
 
 ## Changes in 0.13.0.dev2
 

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -522,13 +522,14 @@ def _clip_dataset_by_geometry(
 
     width = x_var.size
     height = y_var.size
-    res = (ds_y_max - ds_y_min) / height
+    res_x = (ds_x_max - ds_x_min) / width
+    res_y = (ds_y_max - ds_y_min) / height
 
     g_x_min, g_y_min, g_x_max, g_y_max = intersection_geometry.bounds
-    x1 = _clamp(int(math.floor((g_x_min - ds_x_min) / res)), 0, width - 1)
-    x2 = _clamp(int(math.ceil((g_x_max - ds_x_min) / res)), 0, width - 1)
-    y1 = _clamp(int(math.floor((g_y_min - ds_y_min) / res)), 0, height - 1)
-    y2 = _clamp(int(math.ceil((g_y_max - ds_y_min) / res)), 0, height - 1)
+    x1 = _clamp(int(math.floor((g_x_min - ds_x_min) / res_x)), 0, width - 1)
+    x2 = _clamp(int(math.ceil((g_x_max - ds_x_min) / res_x)), 0, width - 1)
+    y1 = _clamp(int(math.floor((g_y_min - ds_y_min) / res_y)), 0, height - 1)
+    y2 = _clamp(int(math.ceil((g_y_max - ds_y_min) / res_y)), 0, height - 1)
     if y_var[0] > y_var[-1]:  # inverse ?
         _y1, _y2 = y1, y2
         y1 = height - _y2 - 1

--- a/xcube/core/update.py
+++ b/xcube/core/update.py
@@ -113,7 +113,10 @@ def _update_dataset_attrs(dataset: xr.Dataset,
                 coord_bnds_name = coord.attrs.get('bounds', coord_bnds_name)
             if coord_bnds_name in dataset:
                 coord_bnds = dataset[coord_bnds_name]
-            if coord_bnds is not None and coord_bnds.ndim == 2 and coord_bnds.shape[1] == 2:
+            if coord_bnds is not None \
+                    and coord_bnds.ndim == 2 \
+                    and coord_bnds.shape[0] > 0 \
+                    and coord_bnds.shape[1] == 2:
                 coord_v1 = coord_bnds[0][0]
                 coord_v2 = coord_bnds[-1][1]
                 coord_res = (coord_v2 - coord_v1) / coord_bnds.shape[0]
@@ -121,7 +124,9 @@ def _update_dataset_attrs(dataset: xr.Dataset,
                 coord_min, coord_max = (coord_v1, coord_v2) if coord_res > 0 else (coord_v2, coord_v1)
                 dataset.attrs[coord_min_attr_name] = cast(coord_min.values)
                 dataset.attrs[coord_max_attr_name] = cast(coord_max.values)
-            elif coord is not None and coord.ndim == 1:
+            elif coord is not None \
+                    and coord.ndim == 1 \
+                    and coord.shape[0] > 0:
                 coord_v1 = coord[0]
                 coord_v2 = coord[-1]
                 if coord.shape[0] > 1:


### PR DESCRIPTION
This fix is mandatory to allow for creating time-series from datasets that have different spatial resolutions in x, y. Otherwise dataset subsets with 0-size coordinates are generated. Different spatial resolutions in x, y is common for gridded data using CRS WGS-84 or EPSG:4326. An example is CMEMS `"dataset-bal-analysis-forecast-wav-hourly"`.

* Account for different spatial resolutions in x and y in `xcube.core.geom.get_dataset_bounds()`.
* Make code robust against 0-size coordinates in `xcube.core.update._update_dataset_attrs()`.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
