### PR TITLE
xcube-758: xcube server fails to resolve datasets for relative parent paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changes in 0.13.0.dev4
 
+### Fixes
+
+* xcube serve correctly resolves relative paths to datasets (#758)
+
 ## Changes in 0.13.0.dev3
 
 ### Other

--- a/test/webapi/datasets/test_context.py
+++ b/test/webapi/datasets/test_context.py
@@ -530,3 +530,48 @@ class MaybeAssignStoreInstanceIdsTest(unittest.TestCase):
 
         self.assertEqual(dataset_configs[0]['StoreInstanceId'],
                          dataset_configs[1]['StoreInstanceId'])
+
+    def test_mix_of_absolute_and_relative_paths(self):
+        configs = [
+            {
+                'Identifier': 'z_0',
+                'FileSystem': 'file',
+                'Path': '/path/abc.zarr'
+            },
+            {
+                'Identifier': 'z_1',
+                'FileSystem': 'file',
+                'Path': 'def.zarr'
+            },
+            {
+                'Identifier': 'z_2',
+                'FileSystem': 'file',
+                'Path': 'relative/ghi.zarr'
+            }
+        ]
+
+        ctx = self.get_datasets_ctx(Datasets=configs)
+        dataset_configs = ctx.get_dataset_configs()
+
+        expected_dataset_configs = [
+            {
+                'Identifier': 'z_0',
+                'FileSystem': 'file',
+                'Path': 'abc.zarr',
+                'StoreInstanceId': 'file_1'
+            },
+            {
+                'Identifier': 'z_1',
+                'FileSystem': 'file',
+                'Path': 'def.zarr',
+                'StoreInstanceId': 'file_3'
+            },
+            {
+                'Identifier': 'z_2',
+                'FileSystem': 'file',
+                'Path': 'ghi.zarr',
+                'StoreInstanceId': 'file_2'
+            }
+        ]
+
+        self.assertEqual(expected_dataset_configs, dataset_configs)

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -859,7 +859,7 @@ def _get_common_prefixes(p):
 
 def _lastindex(prefix, symbol):
     try:
-        return len(prefix) - prefix[::-1].index(symbol) - 1
+        return prefix.rindex(symbol)
     except ValueError:
         return -1
 

--- a/xcube/webapi/datasets/context.py
+++ b/xcube/webapi/datasets/context.py
@@ -265,34 +265,9 @@ class DatasetsContext(ResourcesContext):
         for file_system, store_params, config_list in config_lists:
             # Retrieve paths per configuration
             paths = [dc['Path'] for dc in config_list]
-            list.sort(paths)
             # Determine common prefixes of paths (and call them roots)
-            prefixes = _get_common_prefixes(paths)
-            if len(prefixes) < 1:
-                roots = ['']
-            else:
-                # perform further step to merge prefixes with same start
-                prefixes = list(set(prefixes))
-                prefixes.sort()
-                roots = []
-                root_candidate = prefixes[0]
-                for root in prefixes[1:]:
-                    common_root = os.path.commonprefix([root_candidate, root])
-                    if _is_not_empty(common_root):
-                        root_candidate = common_root
-                    else:
-                        roots.append(root_candidate)
-                        root_candidate = root
-                roots.append(root_candidate)
+            roots = _get_roots(paths)
             for root in roots:
-                # ensure root does not end with full or partial directory
-                # or file name
-                while not root.endswith("/") \
-                        and not root.endswith("\\") \
-                        and len(root) > 0:
-                    root = root[:-1]
-                if root.endswith("/") or root.endswith("\\"):
-                    root = root[:-1]
                 abs_root = root
                 # For local file systems:
                 # Determine absolute root from base dir
@@ -320,7 +295,8 @@ class DatasetsContext(ResourcesContext):
                     data_store_pool.add_store_config(store_instance_id,
                                                      data_store_config)
                 for config in config_list:
-                    if config['Path'].startswith(root):
+                    if config['Path'].startswith(root) and \
+                            config.get('StoreInstanceId') is None:
                         config['StoreInstanceId'] = store_instance_id
                         new_path = config['Path'][len(root):]
                         while new_path.startswith("/") or \
@@ -842,16 +818,50 @@ def _is_not_empty(prefix):
     return prefix != '' and prefix != '/' and prefix != '\\'
 
 
+def _get_roots(paths):
+    list.sort(paths)
+    prefixes = _get_common_prefixes(paths)
+    if len(prefixes) < 1:
+        roots = ['']
+    else:
+        # perform further step to merge prefixes with same start
+        prefixes = list(set(prefixes))
+        prefixes.sort()
+        roots = []
+        root_candidate = prefixes[0]
+        for root in prefixes[1:]:
+            common_root = os.path.commonprefix([root_candidate, root])
+            if _is_not_empty(common_root):
+                root_candidate = common_root
+            else:
+                roots.append(root_candidate)
+                root_candidate = root
+        roots.append(root_candidate)
+    if roots[0] == '':
+        roots.append(roots.pop(0))
+    return roots
+
+
 def _get_common_prefixes(p):
     # Recursively examine a list of paths for common prefixes:
     # If no common prefix is found, split the list in half and
     # examine each half separately
     prefix = os.path.commonprefix(p)
+    # ensure prefix does not end with full or partial directory
+    # or file name
+    prefix = prefix[:max(_lastindex(prefix, '/'), _lastindex(prefix, '\\'), 0)]
     if _is_not_empty(prefix) or len(p) == 1:
         return [prefix]
     else:
         return _get_common_prefixes(p[:int(len(p) / 2)]) + \
                _get_common_prefixes(p[int(len(p) / 2):])
+
+
+def _lastindex(prefix, symbol):
+    try:
+        return len(prefix) - prefix[::-1].index(symbol) - 1
+    except ValueError:
+        return -1
 
 
 _MULTI_LEVEL_DATASET_OPENERS = {


### PR DESCRIPTION
Solves #758 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
