### PR TITLE
Allow scripts to import modules from script directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* xcube server Python scripts can now import modules from
+  the script's directory.
 * xcube serve correctly resolves relative paths to datasets (#758)
 
 ## Changes in 0.13.0.dev3

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -461,7 +461,11 @@ class BaseMultiLevelDataset(LazyMultiLevelDataset):
 
 class ComputedMultiLevelDataset(LazyMultiLevelDataset):
     """
-    A multi-level dataset whose level datasets are a computed from a Python script.
+    A multi-level dataset whose level datasets are a computed from a Python
+    script.
+
+    The script can import other Python modules located in the same
+    directory as *script_path*.
     """
 
     def __init__(self,

--- a/xcube/core/mldataset.py
+++ b/xcube/core/mldataset.py
@@ -20,7 +20,9 @@
 # SOFTWARE.
 
 import math
+import os.path
 import threading
+import sys
 import uuid
 from abc import abstractmethod, ABCMeta
 from functools import cached_property
@@ -480,6 +482,12 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
         except OSError as e:
             raise exception_type(
                 f"Failed to read Python code for in-memory dataset {ds_id!r} from {script_path!r}: {e}") from e
+
+        # Allow scripts to import modules from
+        # within directory
+        script_parent = os.path.dirname(script_path)
+        if script_parent not in sys.path:
+            sys.path = [script_parent] + sys.path
 
         global_env = dict()
         try:


### PR DESCRIPTION
Allow scripts to import modules from script directory.
To be tested with current decision tree processor from OpenSR.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
