### PR TITLE
Providing backward compatibility with Python 3.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * Module `xcube.core.mldataset` has been refactored into 
   a sub-package for clarity and maintainability.
 
+* Provided backward compatibility with Python 3.8. (#)
+
 ## Changes in 0.13.0.dev6
 
 ## Changes in 0.13.0.dev5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 * Module `xcube.core.mldataset` has been refactored into 
   a sub-package for clarity and maintainability.
 
-* Provided backward compatibility with Python 3.8. (#)
+* Provided backward compatibility with Python 3.8. (#760)
 
 ## Changes in 0.13.0.dev6
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,8 @@ channels:
   - defaults
 dependencies:
   # Python
-  - python >=3.8,<3.10
+  # - python >=3.8,<3.10
+  - python =3.8
   # Required
   - affine >=2.2
   - click >=8.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,7 @@ channels:
   - defaults
 dependencies:
   # Python
-  # - python >=3.8,<3.10
-  - python =3.8
+  - python >=3.8,<3.10
   # Required
   - affine >=2.2
   - click >=8.0

--- a/xcube/core/mldataset/mapped.py
+++ b/xcube/core/mldataset/mapped.py
@@ -31,7 +31,7 @@ class MappedMultiLevelDataset(LazyMultiLevelDataset):
     def __init__(
             self,
             ml_dataset: MultiLevelDataset,
-            mapper_function: Callable[[xr.Dataset, ...], xr.Dataset],
+            mapper_function: Callable[[xr.Dataset], xr.Dataset],
             ds_id: str = None,
             mapper_params: Dict[str, Any] = None
     ):

--- a/xcube/core/select.py
+++ b/xcube/core/select.py
@@ -19,16 +19,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import warnings
-from collections.abc import Mapping
-from typing import Collection, Optional, Tuple, Callable, Dict, Any, List
-from typing import Union
-
 import cftime
 import dask.array as da
 import numpy as np
 import pandas as pd
+import warnings
 import xarray as xr
+from typing import Collection, Optional, Tuple, Callable, Dict, Any, \
+    List, Mapping
+from typing import Union
 
 from xcube.core.gridmapping import GridMapping
 from xcube.util.assertions import assert_given

--- a/xcube/core/store/fs/impl/mldataset.py
+++ b/xcube/core/store/fs/impl/mldataset.py
@@ -308,7 +308,8 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
             with fs.open(str(link_path), 'r') as fp:
                 level_path = self._get_path(fp.read())
             if not level_path.is_absolute() \
-                    and not level_path.is_relative_to(ds_path):
+                    and not self._is_path_relative_to_path(level_path,
+                                                           ds_path):
                 level_path = resolve_path(ds_path / level_path)
         else:
             # Nominal "{index}.zarr" must exist
@@ -339,6 +340,18 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
 
         level_dataset.zarr_store.set(level_zarr_store)
         return level_dataset
+
+    @staticmethod
+    def _is_path_relative_to_path(level_path, ds_path):
+        if hasattr(level_path, 'is_relative_to'):
+            # Python >=3.9
+            return level_path.is_relative_to(ds_path)
+        try:
+            # Python <3.9
+            level_path.relative_to(ds_path)
+            return True
+        except ValueError:
+            return False
 
     @staticmethod
     def compute_size_weights(num_levels: int) -> np.ndarray:

--- a/xcube/core/zarrstore/generic.py
+++ b/xcube/core/zarrstore/generic.py
@@ -43,7 +43,7 @@ GetData = Callable[[Tuple[int]],
 OnClose = Callable[[Dict[str, Any]], None]
 
 
-class GenericArray(dict[str, any]):
+class GenericArray(Dict[str, any]):
     """
     Represent a generic array in the ``GenericZarrStore`` as
     dictionary of properties.

--- a/xcube/util/frozen.py
+++ b/xcube/util/frozen.py
@@ -21,7 +21,8 @@
 
 import collections.abc
 from abc import abstractmethod, ABC
-from typing import Generic, TypeVar, Tuple, Any, Iterable, Dict, List
+from typing import Generic, TypeVar, Tuple, Any, Iterable, Dict, List, \
+    Sequence, Mapping
 
 K = TypeVar('K')
 V = TypeVar('V')
@@ -47,11 +48,11 @@ class Frozen(ABC):
         """
 
 
-class FrozenDict(dict[K, V], Frozen, Generic[K, V]):
+class FrozenDict(Dict[K, V], Frozen, Generic[K, V]):
     """A frozen version of a standard ``dict``."""
 
     @classmethod
-    def freeze(cls, other: collections.abc.Mapping) -> "FrozenDict":
+    def freeze(cls, other: Mapping) -> "FrozenDict":
         return FrozenDict({key: freeze_value(value)
                            for key, value in other.items()})
 
@@ -87,11 +88,11 @@ class FrozenDict(dict[K, V], Frozen, Generic[K, V]):
         raise TypeError(_DICT_IS_READONLY)
 
 
-class FrozenList(list[V], Frozen, Generic[V]):
+class FrozenList(List[V], Frozen, Generic[V]):
     """A frozen version of a standard ``list``."""
 
     @classmethod
-    def freeze(cls, other: collections.abc.Sequence[V]) -> "FrozenList":
+    def freeze(cls, other: Sequence[V]) -> "FrozenList":
         return FrozenList(freeze_value(item) for item in other)
 
     def defrost(self) -> List[V]:

--- a/xcube/webapi/ows/wmts/controllers.py
+++ b/xcube/webapi/ows/wmts/controllers.py
@@ -21,8 +21,7 @@
 
 import urllib.parse
 import warnings
-from collections.abc import Mapping
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Mapping
 
 import numpy as np
 import pyproj

--- a/xcube/webapi/s3/objectstorage.py
+++ b/xcube/webapi/s3/objectstorage.py
@@ -20,7 +20,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import collections.abc
-from typing import Union, Iterator, Tuple
+from typing import Union, Iterator, Tuple, Mapping
 
 import xarray as xr
 import zarr.storage
@@ -42,7 +42,7 @@ class ObjectStorage(collections.abc.Mapping):
     """
 
     def __init__(self,
-                 datasets: collections.abc.Mapping[
+                 datasets: Mapping[
                      str,
                      Union[xr.Dataset, MultiLevelDataset]
                  ]):


### PR DESCRIPTION
This PR provides backward compatibility with Python 3.8.

Note, once CI is ok, we'll restore our `environment.yml` so that `python >=3.8,<3.10`.

Closes #760

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
