### PR TITLE
xcube Server to allow for custom Multi-Level Datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,9 +20,20 @@
     Function: resample_in_time:compute_dataset
     InputDatasets: ["local"]
   ```
+  
   Implementation note: this has been achieved by using 
   `xcube.core.byoa.CodeConfig` in
   `xcube.core.mldataset.ComputedMultiLevelDataset`.
+
+* Instead of the `Function` keyword it is now
+  possible to use the `Class` keyword.
+  While `Function` references a function that receives one or 
+  more datasets (type `xarray.Dataset`) and returns a new one, 
+  `Class` references a callable that receives one or 
+  more multi-level datasets and returns a new one.
+  The callable is either a class derived from  
+  or a function that returns an instance of 
+  `xcube.core.nldataset.MultiLevelDataset`. 
 
 * Module `xcube.core.mldataset` has been refactored into 
   a sub-package for clarity and maintainability.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@
   more multi-level datasets and returns a new one.
   The callable is either a class derived from  
   or a function that returns an instance of 
-  `xcube.core.nldataset.MultiLevelDataset`. 
+  `xcube.core.mldataset.MultiLevelDataset`. 
 
 * Module `xcube.core.mldataset` has been refactored into 
   a sub-package for clarity and maintainability.

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -216,7 +216,7 @@ Remotely stored xcube Datasets
 ------------------------------
 
 The following configuration snippet demonstrates how to
-publish static (persistent) xcube datasets stored
+publish static (persistent) xcube datasets stored in
 S3-compatible object storage:
 
 .. code:: yaml

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -206,14 +206,19 @@ Dataset Attribution may be added to the server via *DatasetAttribution*.
 
 Datasets [mandatory]
 --------------------
-In order to publish selected xcube datasets via xcube serve the datasets need to be specified in the configuration
-file of the server. Several xcube datasets may be served within one server, by providing a list of information
-concerning the xcube datasets.
+
+In order to publish selected xcube datasets via ``xcube serve``,
+the datasets need to be described in the server configuration.
 
 .. _remotely stored xcube datasets:
 
-Remotely Stored xcube Datasets
------------------------------
+Remotely stored xcube Datasets
+------------------------------
+
+The following configuration snippet demonstrates how to
+publish static (persistent) xcube datasets stored
+S3-compatible object storage:
+
 .. code:: yaml
 
     Datasets:
@@ -248,7 +253,7 @@ Credentials may be saved either in a file called .aws/credentials with content l
 Or they may be exported as environment variables AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID.
 
 Further down an example for a `locally stored xcube datasets`_ will be given,
-as well as an example of a `on-the-fly generation of xcube datasets`_.
+as well as an example of a `dynamic xcube datasets`_.
 
 *Identifier* [mandatory]
 is a unique ID for each xcube dataset, it is ment for machine-to-machine interaction
@@ -291,10 +296,11 @@ configuring the *RequiredScopes* entry whose value is a list of required scopes,
 
 .. _locally stored xcube datasets:
 
-Locally Stored xcube Datasets
+Locally stored xcube Datasets
 -----------------------------
 
-To serve a locally stored dataset the configuration of it would look like the example below:
+The following configuration snippet demonstrates how to
+publish static (persistent) xcube datasets stored in the local filesystem:
 
 .. code:: yaml
 
@@ -350,13 +356,14 @@ can only be used when providing `authentication`_. By passing the *IsSubstitute*
 a dataset disappears for authorized requests. This might be useful for showing a demo dataset in the viewer for
 user who are not logged in.
 
-.. _on-the-fly generation of xcube datasets:
+.. _dynamic xcube datasets:
 
-On-the-fly Generation of xcube Datasets
----------------------------------------
+Dynamic xcube Datasets
+----------------------
 
-There is the possibility of generating resampled xcube datasets on-the-fly, e.g. in order to
-obtain daily or weekly averages of a xcube dataset.
+There is the possibility to define dynamic xcube datasets
+that are computed on-the-fly. Given here is an example that
+obtains daily or weekly averages of an xcube dataset named "local".
 
 .. code:: yaml
 
@@ -378,18 +385,36 @@ obtain daily or weekly averages of a xcube dataset.
       IsSubstitute: True
 
 *FileSystem* [mandatory]
-is defined as "memory" for the on-the-fly generated dataset.
+must be "memory" for dynamically generated datasets.
 
 *Path* [mandatory]
-leads to the resample python module. There might be several functions specified in the
-python module, therefore the particular *Function* needs to be included into the configuration.
+points to a Python module. Can be a Python file, a package, or a Zip file.
+
+*Function* [mandatory, mutually exclusive with *Class*]
+references a function in the Python file given by *Path*. Must be suffixed
+by colon-separated module name, if *Path* references a package or Zip file.
+The function receives one or more datasets of type ``xarray.Dataset``
+as defined by *InputDatasets* and optional keyword-arguments as
+given by *InputParameters*, if any. It must return a new ``xarray.Dataset``
+with same spatial coordinates as the inputs.
+
+*Class* [mandatory, mutually exclusive with *Function*]
+references a callable in the Python file given by *Path*. Must be suffixed
+by colon-separated module name, if *Path* references a package or Zip file.
+The callable is either a class derived from
+``xcube.core.mldataset.MultiLevelDataset`` or a function that returns
+an instance of ``xcube.core.mldataset.MultiLevelDataset``.
+The callable receives one or more datasets of type
+``xcube.core.mldataset.MultiLevelDataset`` as defined by *InputDatasets*
+and optional keyword-arguments as given by *InputParameters*, if any.
 
 *InputDatasets* [mandatory]
-specifies the dataset to be resampled.
+specifies the input datasets passed to *Function* or *Class*.
 
-*InputParameter* [mandatory]
-defines which kind of resampling should be performed.
-In the example a weekly average is computed.
+*InputParameters* [mandatory]
+specifies optional keyword arguments passed to *Function* or *Class*.
+In the example, *InputParameters* defines which kind of resampling
+should be performed.
 
 Again, the dataset may be associated with place groups.
 

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -253,7 +253,7 @@ Credentials may be saved either in a file called .aws/credentials with content l
 Or they may be exported as environment variables AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID.
 
 Further down an example for a `locally stored xcube datasets`_ will be given,
-as well as an example of a `dynamic xcube datasets`_.
+as well as an example of `dynamic xcube datasets`_.
 
 *Identifier* [mandatory]
 is a unique ID for each xcube dataset, it is ment for machine-to-machine interaction

--- a/test/webapi/datasets/test_context.py
+++ b/test/webapi/datasets/test_context.py
@@ -227,6 +227,15 @@ class DatasetsContextTest(unittest.TestCase):
         self.assertIsNotNone(store_params)
         self.assertEqual(expected_dict, store_params)
 
+    def test_computed_ml_dataset(self):
+        ctx = get_datasets_ctx(server_config='config-class.yml')
+        ds1 = ctx.get_ml_dataset("ds-1")
+        ds2 = ctx.get_ml_dataset("ds-2")
+        self.assertEqual(set(ds1.base_dataset.coords),
+                         set(ds2.base_dataset.coords))
+        self.assertEqual(set(ds1.base_dataset.data_vars),
+                         set(ds2.base_dataset.data_vars))
+
 
 class MaybeAssignStoreInstanceIdsTest(unittest.TestCase):
 

--- a/test/webapi/res/config-class.yml
+++ b/test/webapi/res/config-class.yml
@@ -1,11 +1,25 @@
 Datasets:
   - Identifier: ds-1
-    Title: Dataset A
+    Title: Dataset
     Path: ../../../examples/serve/demo/cube-1-250-250.zarr
 
   - Identifier: ds-2
-    Title: Dataset A Copy
+    Title: Dataset Copy
     FileSystem: memory
     Path: script.py
     Class: CopyMultiLevelDataset
+    InputDatasets: ["ds-1"]
+
+  - Identifier: ds-3
+    Title: Dataset Broken
+    FileSystem: memory
+    Path: script.py
+    Class: broken_ml_dataset_factory_1
+    InputDatasets: ["ds-1"]
+
+  - Identifier: ds-4
+    Title: Dataset Broken
+    FileSystem: memory
+    Path: script.py
+    Class: broken_ml_dataset_factory_2
     InputDatasets: ["ds-1"]

--- a/test/webapi/res/config-class.yml
+++ b/test/webapi/res/config-class.yml
@@ -1,0 +1,11 @@
+Datasets:
+  - Identifier: ds-1
+    Title: Dataset A
+    Path: ../../../examples/serve/demo/cube-1-250-250.zarr
+
+  - Identifier: ds-2
+    Title: Dataset A Copy
+    FileSystem: memory
+    Path: script.py
+    Class: CopyMultiLevelDataset
+    InputDatasets: ["ds-1"]

--- a/test/webapi/res/script.py
+++ b/test/webapi/res/script.py
@@ -2,6 +2,7 @@ import numpy as np
 import xarray as xr
 
 from xcube.core.mldataset import IdentityMultiLevelDataset
+from xcube.core.mldataset import MultiLevelDataset
 
 
 def compute_dataset(ds, period='1W', incl_stdev=False):
@@ -47,3 +48,13 @@ def _categorize_chl(chl):
 
 class CopyMultiLevelDataset(IdentityMultiLevelDataset):
     """Example for a custom MultiLevelDataset class."""
+
+
+def broken_ml_dataset_factory_1():
+    """Example for a custom, broken MultiLevelDataset class."""
+    return None
+
+
+def broken_ml_dataset_factory_2(ml_dataset: MultiLevelDataset):
+    """Example for a custom, broken MultiLevelDataset class."""
+    return xr.Dataset()

--- a/test/webapi/res/script.py
+++ b/test/webapi/res/script.py
@@ -1,12 +1,15 @@
 import numpy as np
 import xarray as xr
 
+from xcube.core.mldataset import IdentityMultiLevelDataset
+
 
 def compute_dataset(ds, period='1W', incl_stdev=False):
     if incl_stdev:
         resample_obj = ds.resample(time=period)
         ds_mean = resample_obj.mean(dim='time')
-        ds_std = resample_obj.std(dim='time').rename(name_dict={name: f"{name}_stdev" for name in ds.data_vars})
+        ds_std = resample_obj.std(dim='time').rename(
+            name_dict={name: f"{name}_stdev" for name in ds.data_vars})
         ds_merged = xr.merge([ds_mean, ds_std])
         ds_merged.attrs.update(ds.attrs)
         return ds_merged
@@ -16,17 +19,23 @@ def compute_dataset(ds, period='1W', incl_stdev=False):
 
 def compute_variables(ds, factor_chl, factor_tsm):
     chl_tsm_sum = factor_chl * ds.conc_chl + factor_tsm * ds.conc_tsm
-    chl_tsm_sum.attrs.update(dict(units='-',
-                                  long_name='Weighted sum of CHL nd TSM concentrations',
-                                  description='Nonsense variable, for demo purpose only'))
+    chl_tsm_sum.attrs.update(
+        dict(units='-',
+             long_name='Weighted sum of CHL nd TSM concentrations',
+             description='Nonsense variable, for demo purpose only')
+    )
 
     chl_category = _categorize_chl(ds.conc_chl)
-    chl_category.attrs.update(dict(units='-',
-                                   long_name='Categorized CHL',
-                                   description='0: 0<=CHL<3, 1: 3<=CHL<4, 2: CHL>4 mg/m^3'))
+    chl_category.attrs.update(
+        dict(units='-',
+             long_name='Categorized CHL',
+             description='0: 0<=CHL<3, 1: 3<=CHL<4, 2: CHL>4 mg/m^3')
+    )
 
-    return xr.Dataset(dict(chl_tsm_sum=chl_tsm_sum,
-                           chl_category=chl_category))
+    return xr.Dataset(
+        dict(chl_tsm_sum=chl_tsm_sum,
+             chl_category=chl_category)
+    )
 
 
 def _categorize_chl(chl):
@@ -34,3 +43,7 @@ def _categorize_chl(chl):
                     xr.where(chl >= 3.0, 1,
                              xr.where(chl >= 0.0, 0,
                                       np.nan)))
+
+
+class CopyMultiLevelDataset(IdentityMultiLevelDataset):
+    """Example for a custom MultiLevelDataset class."""

--- a/xcube/core/mldataset/computed.py
+++ b/xcube/core/mldataset/computed.py
@@ -21,7 +21,7 @@
 
 import os.path
 import uuid
-from typing import Sequence, Any, Dict, Callable, Mapping, Optional
+from typing import Sequence, Any, Dict, Callable, Mapping, Optional, Tuple
 
 import xarray as xr
 
@@ -33,7 +33,6 @@ from xcube.util.assertions import assert_true
 from xcube.util.perf import measure_time
 from .abc import MultiLevelDataset
 from .lazy import LazyMultiLevelDataset
-
 
 MultiLevelDatasetGetter = Callable[[str], MultiLevelDataset]
 MultiLevelDatasetSetter = Callable[[MultiLevelDataset], None]
@@ -56,6 +55,35 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
                  ds_id: str = '',
                  exception_type: type = ValueError):
 
+        callable_ref, callable_obj = self.get_callable(
+            script_path,
+            callable_name,
+            input_ml_dataset_ids,
+            input_ml_dataset_getter,
+            input_parameters=input_parameters,
+            ds_id=ds_id,
+            exception_type=exception_type
+        )
+
+        super().__init__(ds_id=ds_id, parameters=input_parameters)
+        self._callable_ref = callable_ref
+        self._callable_obj = callable_obj
+        self._input_ml_dataset_ids = input_ml_dataset_ids
+        self._input_ml_dataset_getter = input_ml_dataset_getter
+        self._exception_type = exception_type
+
+    @classmethod
+    def get_callable(
+            cls,
+            script_path: str,
+            callable_name: str,
+            input_ml_dataset_ids: Sequence[str],
+            input_ml_dataset_getter: MultiLevelDatasetGetter,
+            input_parameters: Optional[Mapping[str, Any]] = None,
+            ds_id: str = '',
+            exception_type: type = ValueError
+    ) -> Tuple[str, Callable]:
+
         assert_instance(script_path, str, name='script_path')
         assert_given(script_path, name='script_path')
         assert_true(callable(input_ml_dataset_getter),
@@ -77,7 +105,7 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
             if not module_name:
                 raise exception_type(
                     f"Invalid in-memory dataset descriptor {ds_id!r}:"
-                    f' Missing module name in {callable_name}'
+                    f' Missing module name in {callable_name!r}'
                 )
             callable_ref = f'{module_name}:{callable_name}'
 
@@ -107,12 +135,7 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
                 f"Invalid dataset descriptor {ds_id!r}: {e}"
             ) from e
 
-        super().__init__(ds_id=ds_id, parameters=input_parameters)
-        self._callable_ref = callable_ref
-        self._callable_obj = callable_obj
-        self._input_ml_dataset_ids = input_ml_dataset_ids
-        self._input_ml_dataset_getter = input_ml_dataset_getter
-        self._exception_type = exception_type
+        return callable_ref, callable_obj
 
     def _get_num_levels_lazily(self) -> int:
         ds_0 = self._input_ml_dataset_getter(self._input_ml_dataset_ids[0])
@@ -144,25 +167,6 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
         return computed_value
 
 
-def open_ml_dataset_from_python_code(
-        script_path: str,
-        callable_name: str,
-        input_ml_dataset_ids: Sequence[str],
-        input_ml_dataset_getter: MultiLevelDatasetGetter,
-        input_parameters: Optional[Mapping[str, Any]] = None,
-        ds_id: str = '',
-        exception_type: type = ValueError
-) -> MultiLevelDataset:
-    with measure_time(tag=f"Opened memory dataset {script_path}"):
-        return ComputedMultiLevelDataset(script_path,
-                                         callable_name,
-                                         input_ml_dataset_ids,
-                                         input_ml_dataset_getter,
-                                         input_parameters=input_parameters,
-                                         ds_id=ds_id,
-                                         exception_type=exception_type)
-
-
 def augment_ml_dataset(
         ml_dataset: MultiLevelDataset,
         script_path: str,
@@ -170,6 +174,7 @@ def augment_ml_dataset(
         input_ml_dataset_getter: MultiLevelDatasetGetter,
         input_ml_dataset_setter: MultiLevelDatasetSetter,
         input_parameters: Optional[Mapping[str, Any]] = None,
+        is_factory: bool = False,
         exception_type: type = ValueError
 ):
     from .identity import IdentityMultiLevelDataset
@@ -180,11 +185,83 @@ def augment_ml_dataset(
         aug_inp_id = f'aug-input-{aug_id}'
         aug_inp_ds = IdentityMultiLevelDataset(ml_dataset, ds_id=aug_inp_id)
         input_ml_dataset_setter(aug_inp_ds)
-        aug_ds = ComputedMultiLevelDataset(script_path,
-                                           callable_name,
-                                           [aug_inp_id],
-                                           input_ml_dataset_getter,
-                                           input_parameters=input_parameters,
-                                           ds_id=f'aug-{aug_id}',
-                                           exception_type=exception_type)
+        aug_ds = _open_ml_dataset_from_python_code(
+            script_path,
+            callable_name,
+            [aug_inp_id],
+            input_ml_dataset_getter,
+            input_parameters=input_parameters,
+            is_factory=is_factory,
+            ds_id=f'aug-{aug_id}',
+            exception_type=exception_type
+        )
         return CombinedMultiLevelDataset([ml_dataset, aug_ds], ds_id=orig_id)
+
+
+def open_ml_dataset_from_python_code(
+        script_path: str,
+        callable_name: str,
+        input_ml_dataset_ids: Sequence[str],
+        input_ml_dataset_getter: MultiLevelDatasetGetter,
+        input_parameters: Optional[Mapping[str, Any]] = None,
+        is_factory: bool = False,
+        ds_id: str = '',
+        exception_type: type = ValueError
+) -> MultiLevelDataset:
+    with measure_time(tag=f"Opened memory dataset {script_path}"):
+        return _open_ml_dataset_from_python_code(
+            script_path,
+            callable_name,
+            input_ml_dataset_ids,
+            input_ml_dataset_getter,
+            input_parameters=input_parameters,
+            is_factory=is_factory,
+            ds_id=ds_id,
+            exception_type=exception_type
+        )
+
+
+def _open_ml_dataset_from_python_code(
+        script_path: str,
+        callable_name: str,
+        input_ml_dataset_ids: Sequence[str],
+        input_ml_dataset_getter: MultiLevelDatasetGetter,
+        input_parameters: Optional[Mapping[str, Any]] = None,
+        is_factory: bool = False,
+        ds_id: str = '',
+        exception_type: type = ValueError
+) -> MultiLevelDataset:
+    if is_factory:
+        callable_ref, callable_obj = ComputedMultiLevelDataset.get_callable(
+            script_path,
+            callable_name,
+            input_ml_dataset_ids,
+            input_ml_dataset_getter,
+            input_parameters=input_parameters,
+            ds_id=ds_id,
+            exception_type=exception_type
+        )
+        ml_dataset = callable_obj(
+            *[input_ml_dataset_getter(ds_id)
+              for ds_id in input_ml_dataset_ids],
+            **(input_parameters or {})
+        )
+        if isinstance(ml_dataset, MultiLevelDataset):
+            ml_dataset.ds_id = ds_id
+            return ml_dataset
+        raise exception_type(
+            f"Invalid in-memory dataset descriptor {ds_id!r}:"
+            f" {callable_ref!r} must return instance of"
+            f" xcube.core.mldataset.MultiLevelDataset,"
+            f" was {type(ml_dataset)}"
+        )
+    else:
+        return ComputedMultiLevelDataset(
+            script_path,
+            callable_name,
+            input_ml_dataset_ids,
+            input_ml_dataset_getter,
+            input_parameters=input_parameters,
+            ds_id=ds_id,
+            exception_type=exception_type
+        )

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -49,6 +49,7 @@ AUGMENTATION_SCHEMA = JsonObjectSchema(
     properties=dict(
         Path=PATH_SCHEMA,
         Function=IDENTIFIER_SCHEMA,
+        Class=IDENTIFIER_SCHEMA,
         InputParameters=JsonObjectSchema(
             additional_properties=True,
         ),
@@ -91,6 +92,7 @@ DATASET_CONFIG_SCHEMA = JsonObjectSchema(
         Endpoint=URI_SCHEMA,
         Region=IDENTIFIER_SCHEMA,
         Function=IDENTIFIER_SCHEMA,
+        Class=IDENTIFIER_SCHEMA,
         InputDatasets=JsonArraySchema(items=IDENTIFIER_SCHEMA),
         InputParameters=JsonObjectSchema(additional_properties=True),
         **COMMON_DATASET_PROPERTIES,


### PR DESCRIPTION
In this PR:

Instead of the `Function` keyword it is now possible to use the `Class` keyword.
While `Function` references a function that receives one or more datasets (type `xarray.Dataset`) and returns a new one, `Class` references a callable that receives one or more multi-level datasets and returns a new one.
The callable is either a class derived from or a function that returns an instance of  `xcube.core.nldataset.MultiLevelDataset`. 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`~
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
