### PR TITLE
xcube Server to allow for custom Multi-Level Datasets, Part 2

### DIFF
--- a/test/core/mldataset/test_computed.py
+++ b/test/core/mldataset/test_computed.py
@@ -115,8 +115,12 @@ class ComputedMultiLevelDatasetTest(unittest.TestCase):
             self,
             computed_ml_ds: ComputedMultiLevelDataset
     ):
-        # assert output is same as input
         self.assertEqual(3, computed_ml_ds.num_levels)
+        self.assertEqual(1, computed_ml_ds.num_inputs)
+        self.assertEqual(computed_ml_ds.grid_mapping,
+                         computed_ml_ds.get_input_dataset(0).grid_mapping)
+
+        # assert output is same as input
         base_dataset = computed_ml_ds.get_dataset(0)
         self.assertEqual({'lon', 'lat',
                           'lat_bnds', 'lon_bnds',

--- a/xcube/core/mldataset/computed.py
+++ b/xcube/core/mldataset/computed.py
@@ -27,6 +27,7 @@ import xarray as xr
 
 from xcube.core.byoa import CodeConfig
 from xcube.core.byoa import FileSet
+from xcube.core.gridmapping import GridMapping
 from xcube.util.assertions import assert_given
 from xcube.util.assertions import assert_instance
 from xcube.util.assertions import assert_true
@@ -137,11 +138,23 @@ class ComputedMultiLevelDataset(LazyMultiLevelDataset):
 
         return callable_ref, callable_obj
 
-    def _get_num_levels_lazily(self) -> int:
-        ds_0 = self._input_ml_dataset_getter(self._input_ml_dataset_ids[0])
-        return ds_0.num_levels
+    @property
+    def num_inputs(self) -> int:
+        return len(self._input_ml_dataset_ids)
 
-    def _get_dataset_lazily(self, index: int,
+    def get_input_dataset(self, index: int) -> MultiLevelDataset:
+        return self._input_ml_dataset_getter(
+            self._input_ml_dataset_ids[index]
+        )
+
+    def _get_num_levels_lazily(self) -> int:
+        return self.get_input_dataset(0).num_levels
+
+    def _get_grid_mapping_lazily(self) -> GridMapping:
+        return self.get_input_dataset(0).grid_mapping
+
+    def _get_dataset_lazily(self,
+                            index: int,
                             parameters: Dict[str, Any]) -> xr.Dataset:
         input_datasets = [
             self._input_ml_dataset_getter(ds_id).get_dataset(index)


### PR DESCRIPTION
Fixes computation of `grid_mapping` property of `ComputedMultiLevelDataset`.

This is a follow-up of #772.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] ~Changes documented in `CHANGES.md`~
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
