### PR TITLE
fixed github action workflow

### DIFF
--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Setup miniconda build env
-      - uses: conda-incubator/setup-miniconda@v2.2.0
+      - uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           miniconda-version: py39_22.11.1-1
           mamba-version: "*"

--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -17,9 +17,10 @@ jobs:
       NUMBA_DISABLE_JIT: 1
     steps:
       - uses: actions/checkout@v2
-      # Setup miniconda nd build env
-      - uses: conda-incubator/setup-miniconda@v2
+      # Setup miniconda build env
+      - uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          miniconda-version: py39_22.11.1-1
           mamba-version: "*"
           channels: conda-forge
           activate-environment: xcube


### PR DESCRIPTION
Fixes the github action workflow. I have to confess I don't understand why the workflow broke (all I know is that miniconda was adamant about using python 3.10). I also tried other combinations of miniconda and setup-miniconda, but this is the one that works.
I propose to go for a new configuration as soon as xcube runs on python 3.10, in the meantime, this will work.
