### PR TITLE
Suppress xcube plugin warnings emitted by CLI tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
   2. `includes`: if not given or if any pattern matches the identifier, 
      the identifier is reported.
 
+* xcube CLI tools no longer emit warnings when trying to import
+  installed packages named `xcube_*` as xcube plugins.
+  
+
 ### Fixes
 
 


### PR DESCRIPTION
xcube CLI tools no longer emit warnings when trying to import installed packages named `xcube_*` as xcube plugins.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
