### PR TITLE
Avoid "Can't determine indexer timezone" warning when indexer is a 0-dimensional ndarray

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,9 @@
 * xcube CLI tools no longer emit warnings when trying to import
   installed packages named `xcube_*` as xcube plugins.
   
-* The `timeindex` module can now handle 0-dimensional `ndarray`s as indexers.
+* The `xcube.util.timeindex` module can now handle 0-dimensional `ndarray`s as indexers.
+  This effectively avoids the warning `Can't determine indexer timezone; leaving it unmodified.`
+  which was emitted in such cases.
 
 ### Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * xcube CLI tools no longer emit warnings when trying to import
   installed packages named `xcube_*` as xcube plugins.
   
+* The `timeindex` module can now handle 0-dimensional `ndarray`s as indexers.
 
 ### Fixes
 

--- a/test/util/test_timeindex.py
+++ b/test/util/test_timeindex.py
@@ -1,4 +1,6 @@
 from unittest import TestCase
+
+import pytest
 import xarray as xr
 import pandas as pd
 from pytz import UTC
@@ -84,11 +86,12 @@ class TimeIndexTest(TestCase):
 
     def test_ensure_time_label_compatible_no_timezone_info(self):
         old_labels = dict(time='foo')
-        new_labels = ensure_time_label_compatible(
-            xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
-                         coords=dict(time=['foo', 'bar'])),
-            old_labels
-        )
+        with pytest.warns(UserWarning):
+            new_labels = ensure_time_label_compatible(
+                xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
+                             coords=dict(time=['foo', 'bar'])),
+                old_labels
+            )
         self.assertEqual(old_labels, new_labels)
 
     def test_ensure_time_label_compatible_no_tz_convert(self):
@@ -100,11 +103,12 @@ class TimeIndexTest(TestCase):
             pd.Timestamp('2020-01-01T12:00:00'),
             pd.Timestamp('2020-01-02T12:00:00')
         ]
-        new_labels = ensure_time_label_compatible(
-            xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
-                         coords=dict(time=time_coords)),
-            old_labels
-        )
+        with pytest.warns(UserWarning):
+            new_labels = ensure_time_label_compatible(
+                xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
+                             coords=dict(time=time_coords)),
+                old_labels
+            )
         self.assertEqual(old_labels, new_labels)
 
     def test_ensure_time_label_compatible_no_tz_localize(self):
@@ -116,11 +120,12 @@ class TimeIndexTest(TestCase):
             pd.Timestamp('2020-01-01T12:00:00+00:00'),
             pd.Timestamp('2020-01-02T12:00:00+00:00')
         ]
-        new_labels = ensure_time_label_compatible(
-            xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
-                         coords=dict(time=time_coords)),
-            old_labels
-        )
+        with pytest.warns(UserWarning):
+            new_labels = ensure_time_label_compatible(
+                xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
+                             coords=dict(time=time_coords)),
+                old_labels
+            )
         self.assertEqual(old_labels, new_labels)
 
     def test_ensure_time_label_compatible_tz_localize(self):
@@ -148,8 +153,10 @@ class TimeIndexTest(TestCase):
                          coords=dict(time=time_coords)),
             old_labels
         )
-        self.assertEqual(dict(time=np.array(pd.Timestamp('2020-01-01T12:00:00+00:00'))),
-                         new_labels)
+        self.assertEqual(
+            dict(time=np.array(pd.Timestamp('2020-01-01T12:00:00+00:00'))),
+            new_labels
+        )
 
 
 def _are_times_equal(labels1, labels2):

--- a/test/util/test_timeindex.py
+++ b/test/util/test_timeindex.py
@@ -137,6 +137,20 @@ class TimeIndexTest(TestCase):
         self.assertEqual(dict(time=pd.Timestamp('2020-01-01T12:00:00+00:00')),
                          new_labels)
 
+    def test_with_ndarray_time_label(self):
+        old_labels = dict(time=np.array(pd.Timestamp('2020-01-01T12:00:00')))
+        time_coords = [
+            pd.Timestamp('2020-01-01T12:00:00+00:00'),
+            pd.Timestamp('2020-01-02T12:00:00+00:00')
+        ]
+        new_labels = ensure_time_label_compatible(
+            xr.DataArray([[1, 2], [3, 4]], dims=('x', 'time'),
+                         coords=dict(time=time_coords)),
+            old_labels
+        )
+        self.assertEqual(dict(time=np.array(pd.Timestamp('2020-01-01T12:00:00+00:00'))),
+                         new_labels)
+
 
 def _are_times_equal(labels1, labels2):
     return pd.Timestamp(labels1['time']) == pd.Timestamp(labels2['time'])

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -112,10 +112,19 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
         return None
 
     if isinstance(time_value, np.ndarray):
-        def check_time_value(t):
-            return _ensure_timestamp_compatible(var, t, time_name)
-        new_value = np.vectorize(check_time_value)(time_value)
-        return time_value if time_value == new_value else new_value
+        if time_value.shape == ():
+            contents = time_value[()]
+            new_contents = _ensure_timestamp_compatible(
+                var, contents, time_name
+            )
+            return (
+                time_value if contents == new_contents
+                else np.array(new_contents)
+            )
+        else:
+            logger.warning('Indexer is a multi-element ndarray; '
+                           'leaving it unmodified')
+            return time_value
 
     if hasattr(time_value, 'tzinfo'):
         timestamp = time_value

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -147,8 +147,15 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
             timestamp = pd.Timestamp(time_value)
             time_value_tzinfo = timestamp.tzinfo
         except (TypeError, ValueError):
-            warnings.warn('Can\'t determine indexer timezone; leaving it '
-                          'unmodified.')
+            warnings.warn(
+                "We can't determine whether the time indexer has a time "
+                "zone. We will therefore omit the check on whether the time "
+                "indexer and the variable are incompatible in terms of "
+                "timezone awareness. This may result in an error when an "
+                "indexing operation is carried out. If such an error occurs "
+                "after this warning, make sure that the time indexer has "
+                "timezone information."
+            )
             return time_value
 
     if _has_datetime64_time(var, time_name):
@@ -171,7 +178,13 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
             array_timezone = first_time_value.tzinfo
         else:
             warnings.warn(
-                'Can\'t determine array timezone; leaving indexer unmodified.'
+                "We can't determine whether the time co-ordinate of the "
+                "variable has a time zone. We will therefore omit the check on "
+                "whether the time indexer and the variable are incompatible in "
+                "terms of timezone awareness. This may result in an error when "
+                "an indexing operation is carried out. If such an error occurs "
+                "after this warning, make sure that the data in the time "
+                "co-ordinate have timezone information."
             )
             return time_value
 
@@ -179,13 +192,29 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
         if hasattr(timestamp, 'tz_convert'):
             return timestamp.tz_convert(None)
         else:
-            warnings.warn('Indexer lacks tz_convert; leaving it unmodified.')
+            warnings.warn(
+                "The time indexer has no tz_convert method, so we can't "
+                "convert it to a timezone-naive value in order to make it "
+                "compatible with the time co-ordinate of the variable. This "
+                "may result in an indexing error. If such an error occurs "
+                "after this warning, make sure that the time indexer and "
+                "time co-ordinate are compatible (both timezone-naive or both "
+                "timezone-aware) or that the indexer has a tz_convert method."
+            )
             return time_value
     elif array_timezone is not None and time_value_tzinfo is None:
         if hasattr(timestamp, 'tz_localize'):
             return timestamp.tz_localize(array_timezone)
         else:
-            warnings.warn('Indexer lacks tz_localize; leaving it unmodified.')
+            warnings.warn(
+                "The time indexer has no tz_localize method, so we can't "
+                "convert it to a timezone-aware value in order to make it "
+                "compatible with the time co-ordinate of the variable. This "
+                "may result in an indexing error. If such an error occurs "
+                "after this warning, make sure that the time indexer and "
+                "time co-ordinate are compatible (both timezone-naive or both "
+                "timezone-aware) or that the indexer has a tz_localize method."
+            )
             return time_value
     else:
         return time_value

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -23,6 +23,11 @@
 
 The utilities in this module check and, where necessary, modify time indexers
 to ensure that they are compatible with the variables they are indexing.
+"Compatibility" in this case refers to timezone-awareness: a timezone-aware
+indexer cannot index a timezone-naive variable, and vice versa. Since xcube
+processes data from external sources, we need a generalized way to ensure
+this compatibility before attempting an indexing operation. See
+https://github.com/dcs4cop/xcube/issues/605 for more background information.    
 """
 
 from typing import Dict, Any, Union, Hashable
@@ -112,6 +117,9 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
         return None
 
     if isinstance(time_value, np.ndarray):
+        # Sometimes a provided indexer is not a scalar, but a 0-dimensional
+        # singleton ndarray containing the scalar indexing value itself.
+        # In this case we unwrap the value and call the function recursively.
         if time_value.shape == ():
             contents = time_value[()]
             new_contents = _ensure_timestamp_compatible(

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -111,6 +111,12 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
     if time_value is None:
         return None
 
+    if isinstance(time_value, np.ndarray):
+        def check_time_value(t):
+            return _ensure_timestamp_compatible(var, t, time_name)
+        new_value = np.vectorize(check_time_value)(time_value)
+        return time_value if time_value == new_value else new_value
+
     if hasattr(time_value, 'tzinfo'):
         timestamp = time_value
         time_value_tzinfo = time_value.tzinfo

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -122,6 +122,10 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
         # singleton ndarray containing the scalar indexing value itself.
         # In this case we unwrap the value and call the function recursively.
         if time_value.shape == ():
+            # We use [()] rather than .item() here, since the contents may
+            # well be a datetime64. In that case we want to preserve the
+            # numpy array scalar type rather than converting to a native
+            # Python integer.
             contents = time_value[()]
             new_contents = _ensure_timestamp_compatible(
                 var, contents, time_name

--- a/xcube/util/timeindex.py
+++ b/xcube/util/timeindex.py
@@ -27,7 +27,7 @@ to ensure that they are compatible with the variables they are indexing.
 indexer cannot index a timezone-naive variable, and vice versa. Since xcube
 processes data from external sources, we need a generalized way to ensure
 this compatibility before attempting an indexing operation. See
-https://github.com/dcs4cop/xcube/issues/605 for more background information.    
+https://github.com/dcs4cop/xcube/issues/605 for more background information.
 """
 
 from typing import Dict, Any, Union, Hashable
@@ -36,6 +36,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 import logging
+import warnings
 
 logger = logging.getLogger('xcube')
 
@@ -130,8 +131,8 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
                 else np.array(new_contents)
             )
         else:
-            logger.warning('Indexer is a multi-element ndarray; '
-                           'leaving it unmodified')
+            warnings.warn('Indexer is a multi-element ndarray; '
+                          'leaving it unmodified')
             return time_value
 
     if hasattr(time_value, 'tzinfo'):
@@ -142,8 +143,8 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
             timestamp = pd.Timestamp(time_value)
             time_value_tzinfo = timestamp.tzinfo
         except (TypeError, ValueError):
-            logger.warning('Can\'t determine indexer timezone; leaving it '
-                           'unmodified.')
+            warnings.warn('Can\'t determine indexer timezone; leaving it '
+                          'unmodified.')
             return time_value
 
     if _has_datetime64_time(var, time_name):
@@ -165,7 +166,7 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
         if hasattr(first_time_value, 'tzinfo'):
             array_timezone = first_time_value.tzinfo
         else:
-            logger.warning(
+            warnings.warn(
                 'Can\'t determine array timezone; leaving indexer unmodified.'
             )
             return time_value
@@ -174,13 +175,13 @@ def _ensure_timestamp_compatible(var: xr.DataArray, time_value: Any,
         if hasattr(timestamp, 'tz_convert'):
             return timestamp.tz_convert(None)
         else:
-            logger.warning('Indexer lacks tz_convert; leaving it unmodified.')
+            warnings.warn('Indexer lacks tz_convert; leaving it unmodified.')
             return time_value
     elif array_timezone is not None and time_value_tzinfo is None:
         if hasattr(timestamp, 'tz_localize'):
             return timestamp.tz_localize(array_timezone)
         else:
-            logger.warning('Indexer lacks tz_localize; leaving it unmodified.')
+            warnings.warn('Indexer lacks tz_localize; leaving it unmodified.')
             return time_value
     else:
         return time_value


### PR DESCRIPTION
Fixes #781 .

This PR extends the `timeindex` module to handle 0-dimensional `ndarray`s as indexers. Previously, these were left untouched with a warning, since `pandas.Timestamp` couldn't interpret them.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* [ ] ~New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
