### PR TITLE
Fix affine_transform_dataset()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,15 +13,19 @@
   2. `includes`: if not given or if any pattern matches the identifier, 
      the identifier is reported.
 
+### Fixes
+
 * xcube CLI tools no longer emit warnings when trying to import
   installed packages named `xcube_*` as xcube plugins.
   
-* The `xcube.util.timeindex` module can now handle 0-dimensional `ndarray`s as indexers.
-  This effectively avoids the warning `Can't determine indexer timezone; leaving it unmodified.`
+* The `xcube.util.timeindex` module can now handle 0-dimensional 
+  `ndarray`s as indexers. This effectively avoids the warning 
+  `Can't determine indexer timezone; leaving it unmodified.`
   which was emitted in such cases.
 
-### Fixes
-
+* Function `xcube.core.resampling.affine.affine_transform_dataset()`
+  now assumes that geographic coordinate systems are equal by default and
+  hence a resampling based on an affine transformation can be performed.
 
 ## Changes in 0.13.0.dev8
 

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -58,7 +58,10 @@ def affine_transform_dataset(
         new ones.
     :return: The resampled target dataset.
     """
-    if source_gm.crs != target_gm.crs:
+    # Are source and target both geographic grid mappings?
+    both_geographic = source_gm.crs.is_geographic \
+                      and target_gm.crs.is_geographic
+    if not (both_geographic or source_gm.crs == target_gm.crs):
         raise ValueError(f'CRS of source_gm and target_gm must be equal,'
                          f' was "{source_gm.crs.name}"'
                          f' and "{target_gm.crs.name}"')

--- a/xcube/core/resampling/affine.py
+++ b/xcube/core/resampling/affine.py
@@ -46,6 +46,10 @@ def affine_transform_dataset(
     """
     Resample dataset according to an affine transformation.
 
+    The affine transformation will be applied only if the CRS of
+    *source_gm* and the CRS of *target_gm* are both geographic or equal.
+    Otherwise, a ``ValueError`` will be raised.
+
     :param dataset: The source dataset
     :param source_gm: Source grid mapping of *dataset*.
         Must be regular. Must have same CRS as *target_gm*.


### PR DESCRIPTION
Function `xcube.core.resampling.affine.affine_transform_dataset()` now assumes that geographic coordinate systems are equal by default and hence a resampling based on an affine transformation can be performed.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
