### PR TITLE
Accept datasets with coordinate names `longitude` and `latitude`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@
 
 ### Fixes
 
+* `xcube serve` will now also accept datasets with coordinate names
+  `longitude` and `latitude`, even if the attribute `long_name` isn't set.
+  (#763)
 
 ## Changes in 0.13.0.dev8
 

--- a/test/core/test_geom.py
+++ b/test/core/test_geom.py
@@ -443,6 +443,16 @@ class GetDatasetBoundsTest(unittest.TestCase):
         bounds = get_dataset_bounds(ds2)
         self.assertEqual((-25.0, -15.0, 15.0, 15.0), bounds)
 
+    def test_longitude_latitude(self):
+        ds1, ds2 = _get_nominal_datasets()
+        ds1 = ds1.rename(dict(lon='longitude', lat='latitude'))
+        ds2 = ds2.rename(dict(lon='longitude', lat='latitude'))
+
+        bounds = get_dataset_bounds(ds1)
+        self.assertEqual((-25.0, -15.0, 15.0, 15.0), bounds)
+        bounds = get_dataset_bounds(ds2)
+        self.assertEqual((-25.0, -15.0, 15.0, 15.0), bounds)
+
     def test_inv_y(self):
         ds1, ds2 = _get_inv_y_datasets()
         bounds = get_dataset_bounds(ds1)

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -713,7 +713,7 @@ def get_dataset_geometry(dataset: Union[xr.Dataset, xr.DataArray],
 
 
 def get_dataset_bounds(dataset: Union[xr.Dataset, xr.DataArray],
-                       xy_var_names: Tuple[str, str] = None) -> Bounds:
+                       xy_var_names: Optional[Tuple[str, str]] = None) -> Bounds:
     if xy_var_names is None:
         xy_var_names = get_dataset_xy_var_names(dataset, must_exist=True)
     x_name, y_name = xy_var_names

--- a/xcube/core/schema.py
+++ b/xcube/core/schema.py
@@ -263,9 +263,12 @@ def get_cube_schema(cube: xr.Dataset) -> CubeSchema:
                       chunks=first_chunks)
 
 
-def get_dataset_xy_var_names(coords: Union[xr.Dataset, xr.DataArray, Mapping[Hashable, xr.DataArray]],
+def get_dataset_xy_var_names(coords: Union[xr.Dataset,
+                                           xr.DataArray,
+                                           Mapping[Hashable, xr.DataArray]],
                              must_exist: bool = False,
-                             dataset_arg_name: str = 'dataset') -> Optional[Tuple[str, str]]:
+                             dataset_arg_name: str = 'dataset') \
+        -> Optional[Tuple[str, str]]:
     if hasattr(coords, 'coords'):
         coords = coords.coords
     x_var_name = None
@@ -294,7 +297,9 @@ def get_dataset_xy_var_names(coords: Union[xr.Dataset, xr.DataArray, Mapping[Has
         if x_var_name and y_var_name:
             return str(x_var_name), str(y_var_name)
 
-    for x_var_name, y_var_name in (('lon', 'lat'), ('x', 'y')):
+    for x_var_name, y_var_name in (('lon', 'lat'),
+                                   ('longitude', 'latitude'),
+                                   ('x', 'y')):
         if x_var_name in coords and y_var_name in coords:
             x_var = coords[x_var_name]
             y_var = coords[y_var_name]
@@ -302,7 +307,8 @@ def get_dataset_xy_var_names(coords: Union[xr.Dataset, xr.DataArray, Mapping[Has
                 return x_var_name, y_var_name
 
     if must_exist:
-        raise ValueError(f'{dataset_arg_name} has no valid spatial coordinate variables')
+        raise ValueError(f'{dataset_arg_name}'
+                         f' has no valid spatial coordinate variables')
 
 
 def get_dataset_time_var_name(dataset: Union[xr.Dataset, xr.DataArray],


### PR DESCRIPTION
`xcube serve` will now also accept datasets with coordinate names `longitude` and `latitude`, even if the attribute `long_name` isn't set.

Closes #763

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
