### PR TITLE
Avoid tiling scheme with negative min level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,6 @@
   `Can't determine indexer timezone; leaving it unmodified.`
   which was emitted in such cases.
 
-### Fixes
-
 * `xcube serve` will now also accept datasets with coordinate names
   `longitude` and `latitude`, even if the attribute `long_name` isn't set.
   (#763)
@@ -32,6 +30,11 @@
 * Function `xcube.core.resampling.affine.affine_transform_dataset()`
   now assumes that geographic coordinate systems are equal by default and
   hence a resampling based on an affine transformation can be performed.
+
+* Fixed a problem with xcube server's WMTS implementation.
+  For multi-level resolution datasets with very coarse low resolution levels, 
+  the tile matrix sets `WorldCRS84Quad` and `WorldWebMercatorQuad` have 
+  reported a negative minimum z-level.
 
 ## Changes in 0.13.0.dev8
 

--- a/test/core/test_tilingscheme.py
+++ b/test/core/test_tilingscheme.py
@@ -295,6 +295,57 @@ class TilingSchemeTest(unittest.TestCase):
                 'degrees'
             )
 
+    def test_get_limited_levels_for_resolutions_geographic(self):
+        tiling_scheme = TilingScheme.GEOGRAPHIC
+
+        self.assertEqual(
+            (0, 2),
+            tiling_scheme.get_levels_for_resolutions(
+                [0.25, 0.5, 1.0, 2.0],
+                'degrees'
+            )
+        )
+
+        self.assertEqual(
+            (0, 2),
+            tiling_scheme.get_levels_for_resolutions(
+                [0.25, 0.5, 1.0, 2.0, 4.0],
+                'degrees'
+            )
+        )
+
+        self.assertEqual(
+            (0, 3),
+            tiling_scheme.get_levels_for_resolutions(
+                [0.125, 0.25, 0.5, 1.0, 2.0],
+                'degrees'
+            )
+        )
+
+        self.assertEqual(
+            (0, 3),
+            tiling_scheme.get_levels_for_resolutions(
+                [0.125, 0.25, 0.5, 1.0, 2.0, 4.0],
+                'degrees'
+            )
+        )
+
+        self.assertEqual(
+            (0, 4),
+            tiling_scheme.get_levels_for_resolutions(
+                [0.0625, 0.125, 0.25, 0.5, 1.0, 2.0],
+                'degrees'
+            )
+        )
+
+        self.assertEqual(
+            (0, 4),
+            tiling_scheme.get_levels_for_resolutions(
+                [0.0625, 0.125, 0.25, 0.5, 1.0, 2.0, 4.0],
+                'degrees'
+            )
+        )
+
 
 class TilingSchemeHelpersTest(unittest.TestCase):
 

--- a/xcube/core/tilingscheme.py
+++ b/xcube/core/tilingscheme.py
@@ -284,10 +284,10 @@ class TilingScheme:
         map_levels = np.ceil(np.log2(
             self.level_zero_resolution / map_resolutions
         ))
-        min_level = np.min(map_levels)
-        max_level = np.max(map_levels)
+        min_level = max(int(np.min(map_levels)), 0)
+        max_level = max(int(np.max(map_levels)), min_level)
 
-        return int(min_level), int(max_level)
+        return min_level, max_level
 
     def get_resolutions_level(
             self,


### PR DESCRIPTION
Prevent `TilingScheme.get_levels_for_resolutions()` from returning a negative minimum level.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
