### PR TITLE
More tolerant xcube Server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
   2. `includes`: if not given or if any pattern matches the identifier, 
      the identifier is reported.
 
+* `xcube serve` is now more tolerant with respect to datasets it can not 
+  open without errors. Implementation detail: It no longer fails if 
+  opening datasets raises any exception other than `DatasetIsNotACubeError`.
+  (#789)
+
 ### Fixes
 
 * xcube CLI tools no longer emit warnings when trying to import

--- a/xcube/webapi/datasets/controllers.py
+++ b/xcube/webapi/datasets/controllers.py
@@ -51,10 +51,6 @@ from ..places.controllers import find_places
 _CRS84 = pyproj.CRS.from_string('CRS84')
 
 
-# TODO (forman): Is this really still in use?
-class CubeIsNotDisplayable(ValueError):
-    pass
-
 
 def find_dataset_places(ctx: DatasetsContext,
                         place_group_id: str,
@@ -147,8 +143,8 @@ def get_datasets(ctx: DatasetsContext,
                                     granted_scopes=granted_scopes)
                     )
                 filtered_dataset_dicts.append(dataset_dict)
-            except (DatasetIsNotACubeError, CubeIsNotDisplayable) as e:
-                LOG.warning(f'Skipping dataset {ds_id}: {e}')
+            except Exception as e:
+                LOG.warning(f'Skipping dataset {ds_id}: {e}', exc_info=True)
         dataset_dicts = filtered_dataset_dicts
 
     if point:


### PR DESCRIPTION
`/datasets?details=1` no longer fails if opening datasets raises any exception other than `DatasetIsNotACubeError`.

Closes #789

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
