### PR TITLE
Replaced `numpy.bool` by Python `bool`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Changes in 0.13.0.dev10 (in development)
 
+### Fixes
+
+* Replaced usages of deprecated numpy dtype `numpy.bool` 
+  by Python type `bool`. 
+
 ## Changes in 0.13.0.dev9
 
 ### Enhancements

--- a/test/core/test_geom.py
+++ b/test/core/test_geom.py
@@ -376,7 +376,7 @@ class DatasetGeometryTest(unittest.TestCase):
                 [0, 0, 0, 1, 1, 0, 0],
                 [0, 0, 0, 0, 0, 0, 0],
             ],
-            dtype=np.bool
+            dtype=bool
         )
         np.testing.assert_array_almost_equal(
             actual_mask_values,

--- a/test/util/test_jsonencoder.py
+++ b/test/util/test_jsonencoder.py
@@ -39,7 +39,7 @@ PY_INPUT = {
 }
 
 NP_INPUT = {
-    'np_bool': np.bool(True),
+    'np_bool': True,
     'np_int8': np.int8(1),
     'np_uint8': np.uint8(2),
     'np_int16': np.int16(3),
@@ -62,7 +62,7 @@ INPUT = {
 EXPECTED_PY_OUTPUT = {**PY_INPUT}
 
 EXPECTED_NP_OUTPUT = {
-    'np_bool': bool(np.bool(True)),
+    'np_bool': True,
     'np_int8': int(np.int8(1)),
     'np_uint8': int(np.uint8(2)),
     'np_int16': int(np.int16(3)),

--- a/xcube/core/geom.py
+++ b/xcube/core/geom.py
@@ -384,8 +384,8 @@ def mask_dataset_by_geometry(
     mask_data = da.map_blocks(
         _mask_block,
         chunks=chunks,
-        dtype=np.bool,
-        meta=np.array((), dtype=np.bool),
+        dtype=bool,
+        meta=np.array((), dtype=bool),
         geometry=intersection_geometry,
         x_offset=x_min,
         y_offset=y_max,

--- a/xcube/util/jsonencoder.py
+++ b/xcube/util/jsonencoder.py
@@ -107,7 +107,7 @@ def _key(key: Any) -> str:
 def _convert_default(obj: Any) -> Any:
     if hasattr(obj, 'dtype') and hasattr(obj, 'ndim'):
         if obj.ndim == 0:
-            if np.issubdtype(obj.dtype, np.bool):
+            if np.issubdtype(obj.dtype, bool):
                 return bool(obj)
             elif np.issubdtype(obj.dtype, np.integer):
                 return int(obj)


### PR DESCRIPTION
Replaced usages of deprecated numpy dtype `numpy.bool` by Python type `bool`.


Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
