### PR TITLE
Allow for absolute URL prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 ## Changes in 0.13.1 (in development)
 
+### Fixes
+
+* The xcube server configuration parameters `url_prefix` and 
+  `reverse_url_prefix` can now be absolute URLs. This fixes a problem for 
+  relative prefixes such as `"proxy/8000"` used for xcube server running 
+  inside JupyterLab. Here, the expected returned self-referencing URL was
+  `https://{host}/users/{user}/proxy/8000/{path}` but we got
+  `http://{host}/proxy/8000/{path}`. (#806)
+
 
 ## Changes in 0.13.0
 

--- a/test/server/test_config.py
+++ b/test/server/test_config.py
@@ -20,6 +20,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import unittest
+from typing import Callable
 
 from xcube.server.config import get_reverse_url_prefix
 from xcube.server.config import get_url_prefix
@@ -27,71 +28,47 @@ from xcube.server.config import get_url_prefix
 
 class ConfigTest(unittest.TestCase):
     def test_get_url_prefix(self):
-        self.assertEqual('',
-                         get_url_prefix(dict()))
-        self.assertEqual('',
-                         get_url_prefix(dict(url_prefix='')))
-        self.assertEqual('',
-                         get_url_prefix(dict(url_prefix=None)))
-        self.assertEqual('',
-                         get_url_prefix(dict(url_prefix='/')))
-        self.assertEqual('',
-                         get_url_prefix(dict(url_prefix='//')))
-
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='api/v1')))
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='/api/v1')))
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='api/v1/')))
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='/api/v1/')))
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='/api/v1//')))
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='//api/v1//')))
-        self.assertEqual('/api/v1',
-                         get_url_prefix(dict(url_prefix='///api/v1//')))
+        self.assert_url_prefix(get_url_prefix,
+                               key='url_prefix')
 
     def test_get_reverse_url_prefix(self):
-        self.assertEqual('',
-                         get_reverse_url_prefix(dict()))
-        self.assertEqual('',
-                         get_reverse_url_prefix(dict(reverse_url_prefix='')))
-        self.assertEqual('',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix=None)))
-        self.assertEqual('',
-                         get_reverse_url_prefix(dict(reverse_url_prefix='/')))
-        self.assertEqual('',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='//')))
+        self.assert_url_prefix(get_reverse_url_prefix,
+                               key='reverse_url_prefix')
 
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='proxy/9192')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='/proxy/9192')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='proxy/9192/')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='/proxy/9192/')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='/proxy/9192//')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='//proxy/9192//')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='///proxy/9192//')))
+    def assert_url_prefix(self,
+                          get_prefix: Callable,
+                          key: str):
+        self.assertEqual('',
+                         get_prefix({}))
+        self.assertEqual('',
+                         get_prefix({key: ''}))
+        self.assertEqual('',
+                         get_prefix({key: None}))
+        self.assertEqual('',
+                         get_prefix({key: '/'}))
+        self.assertEqual('',
+                         get_prefix({key: '//'}))
 
         self.assertEqual('/api/v1',
-                         get_reverse_url_prefix(dict(url_prefix='api/v1')))
-        self.assertEqual('/proxy/9192',
-                         get_reverse_url_prefix(
-                             dict(reverse_url_prefix='/proxy/9192',
-                                  url_prefix='/api/v1')))
+                         get_prefix({key: 'api/v1'}))
+        self.assertEqual('/api/v1',
+                         get_prefix({key: '/api/v1'}))
+        self.assertEqual('/api/v1',
+                         get_prefix({key: 'api/v1/'}))
+        self.assertEqual('/api/v1',
+                         get_prefix({key: '/api/v1/'}))
+        self.assertEqual('/api/v1',
+                         get_prefix({key: '/api/v1//'}))
+        self.assertEqual('/api/v1',
+                         get_prefix({key: '//api/v1//'}))
+        self.assertEqual('/api/v1',
+                         get_prefix({key: '///api/v1//'}))
+
+        self.assertEqual('https://test.com',
+                         get_prefix({key: 'https://test.com'}))
+        self.assertEqual('https://test.com',
+                         get_prefix({key: 'https://test.com/'}))
+        self.assertEqual('https://test.com/api',
+                         get_prefix({key: 'https://test.com/api'}))
+        self.assertEqual('http://test.com/api',
+                         get_prefix({key: 'http://test.com/api/'}))

--- a/xcube/server/config.py
+++ b/xcube/server/config.py
@@ -133,13 +133,18 @@ def _sanitize_url_prefix(url_prefix: Optional[str]) -> str:
     """
     if not url_prefix:
         return ''
+
     while url_prefix.startswith('//'):
         url_prefix = url_prefix[1:]
     while url_prefix.endswith('/'):
         url_prefix = url_prefix[:-1]
+
     if url_prefix == '':
         return ''
-    elif url_prefix.startswith('/'):
+
+    if url_prefix.startswith('/') \
+            or url_prefix.startswith('http://') \
+            or url_prefix.startswith('https://'):
         return url_prefix
-    else:
-        return '/' + url_prefix
+
+    return '/' + url_prefix

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -426,27 +426,27 @@ class TornadoApiRequest(ApiRequest):
                      path: str,
                      query: Optional[str] = None,
                      reverse: bool = False) -> str:
-        """Get the reverse URL for given *path* and *query*."""
-
-        # TODO (forman): in some cases, e.g.,
-        #   when running a tornado server (such as xcube server)
-        #   next to a remote Jupyter Server,
-        #   the URL reported by this implementation is wrong.
-        #   For example with reverse prefix "/proxy/8000", we expect
-        #       https://{host}/users/{user}/proxy/8000/{path}
-        #   but we get
-        #       http://{host}/proxy/8000/{path}
-        #   Also note, that protocol degraded from HTTPS to HTTP!
-        #
-        protocol = self._request.protocol
-        host = self._request.host
-        prefix = self._reverse_url_prefix if reverse else self._url_prefix
+        """Get the URL for given *path* and *query*.
+        If the *reverse* flag is set, the configuration parameter
+        ``reverse_url_prefix``, if provided, is used to construct the URL,
+        otherwise only ``url_prefix``, if provided, is used.
+        """
+        prefix = self._url_prefix
+        if reverse:
+            prefix = self._reverse_url_prefix or prefix
         uri = ""
         if path:
             uri = path if path.startswith("/") else "/" + path
         if query:
             uri += "?" + query
-        return f"{protocol}://{host}{prefix}{uri}"
+        if "://" in prefix:
+            # Absolute prefix
+            return f"{prefix}{uri}"
+        else:
+            # Relative prefix
+            protocol = self._request.protocol
+            host = self._request.host
+            return f"{protocol}://{host}{prefix}{uri}"
 
     @property
     def url(self) -> str:


### PR DESCRIPTION
We don't have a clear solution for #806 because we cannot know whether the actual protocol as seen by users is HTTP or HTTPS. We also cannot detect, whether the service URL is already a route configured by some proxy and hence the server's base URL would already contain a path component.

Therefore, the current solution in this PR is to allow for absolute URL prefixes. If a URL prefix is absolute, we ignore the protocol and host reported by the (Tornado) request and use it directly as base URL for constructing self-referencing URLs. 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
