### PR TITLE
xcube's `Dockerfile` no longer creates a conda environment `xcube`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,12 @@
         bands_config: ${resolve_config_path("../common/bands.yaml")}
     ```
 
+* xcube's `Dockerfile` no longer creates a conda environment `xcube`.
+  All dependencies are now installed into the `base` environment making it 
+  easier to use the container as a executable for xcube applications.
+  We are now also using a `micromamba` base images instead of `miniconda`.
+  The result is a much faster build and smaller image size.
+
 * Added a `new_cluster` function to `xcube.util.dask`, which can create
   Dask clusters with various configuration options.
 
@@ -59,12 +65,6 @@
   inside JupyterLab. Here, the expected returned self-referencing URL was
   `https://{host}/users/{user}/proxy/8000/{path}` but we got
   `http://{host}/proxy/8000/{path}`. (#806)
-
-### Other changes
-
-* xcube's `Dockerfile` no longer creates a conda environment `xcube`.
-  All dependencies are now installed into the `base` environment making it 
-  easier to use the container as a executable for xcube applications.
 
 ## Changes in 0.13.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,8 +46,8 @@
 
 * xcube's `Dockerfile` no longer creates a conda environment `xcube`.
   All dependencies are now installed into the `base` environment making it 
-  easier to use the container as a executable for xcube applications.
-  We are now also using a `micromamba` base images instead of `miniconda`.
+  easier to use the container as an executable for xcube applications.
+  We are now also using a `micromamba` base image instead of `miniconda`.
   The result is a much faster build and smaller image size.
 
 * Added a `new_cluster` function to `xcube.util.dask`, which can create

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,11 @@
   `https://{host}/users/{user}/proxy/8000/{path}` but we got
   `http://{host}/proxy/8000/{path}`. (#806)
 
+### Other changes
+
+* xcube's `Dockerfile` no longer creates a conda environment `xcube`.
+  All dependencies are now installed into the `base` environment making it 
+  easier to use the container as a executable for xcube applications.
 
 ## Changes in 0.13.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ENV XCUBE_CMEMS_VERSION=latest
 # Metadata
 LABEL maintainer="xcube-team@brockmann-consult.de"
 LABEL name=xcube
-LABEL conda_env=xcube
 
 # Ensure usage of bash (ensures conda calls succeed)
 SHELL ["/bin/bash", "-c"]
@@ -29,8 +28,8 @@ RUN chown -R ${XCUBE_USER_NAME}:${XCUBE_USER_NAME} /opt/conda
 
 USER ${XCUBE_USER_NAME}
 
-RUN source activate base && conda update -n base conda && conda init
-RUN source activate base && conda install -n base -c conda-forge mamba==0.24.0 pip=21.3.1
+RUN conda update -n base conda && conda init
+RUN conda install -n base -c conda-forge mamba==0.24.0 pip=21.3.1
 
 # Setup conda environment
 # Copy yml config into image
@@ -38,7 +37,7 @@ COPY environment.yml /tmp/environment.yml
 
 # Use mamba to create an environment based on the specifications in
 # environment.yml. 
-RUN mamba env create --file /tmp/environment.yml
+RUN mamba env update -n base -f /tmp/environment.yml
 
 # Set work directory for xcube installation
 WORKDIR /home/xcube
@@ -47,7 +46,7 @@ WORKDIR /home/xcube
 COPY . ./
 
 # Setup xcube package.
-RUN source activate xcube && python setup.py install
+RUN python setup.py install
 
 WORKDIR /tmp
 ADD scripts/install_xcube.sh ./
@@ -61,7 +60,7 @@ RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install_xcube.sh xcube-cmems $
 EXPOSE 8080
 
 # Run bash in xcube environment, so we can invoke xcube CLI.
-ENTRYPOINT ["conda", "run", "-v", "-n", "xcube", "/bin/bash", "-c"]
+ENTRYPOINT ["conda", "run", "-v", "-n", "base", "/bin/bash", "-c"]
 
 # By default show xcube help 
 CMD ["xcube --help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,44 @@
-FROM mambaorg/micromamba:1.3.1
+# For micromamba image documentation,
+# goto https://hub.docker.com/r/mambaorg/micromamba
+ARG MICROMAMBA_VERSION=1.3.1
+FROM mambaorg/micromamba:${MICROMAMBA_VERSION}
+
+ARG NEW_MAMBA_USER=xcube
+ARG NEW_MAMBA_USER_ID=1000
+ARG NEW_MAMBA_USER_GID=1000
+
+ARG INSTALL_PLUGINS=1
+
+ENV XCUBE_SH_VERSION=latest
+ENV XCUBE_CCI_VERSION=latest
+ENV XCUBE_CDS_VERSION=latest
+ENV XCUBE_CMEMS_VERSION=latest
+
+LABEL maintainer="xcube-team@brockmann-consult.de"
+LABEL name=xcube
+
+# <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+USER root
+
+# Update system and ensure that basic commands are available.
+RUN apt-get -y update && \
+    apt-get -y upgrade vim jq curl wget
+
+# Magic taken from https://hub.docker.com/r/mambaorg/micromamba,
+# section "Changing the user id or name"
+RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${NEW_MAMBA_USER}" \
+        --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
+    groupmod "--new-name=${NEW_MAMBA_USER}" \
+             "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
+    # Update the expected value of MAMBA_USER for the
+    # _entrypoint.sh consistency check.
+    echo "${NEW_MAMBA_USER}" > "/etc/arg_mamba_user" && \
+    :
+
+ENV MAMBA_USER=$NEW_MAMBA_USER
+# >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+USER $MAMBA_USER
 
 # Install xcube dependencies
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
@@ -9,18 +49,27 @@ RUN micromamba install -y -n base -f /tmp/environment.yml \
 COPY --chown=$MAMBA_USER:$MAMBA_USER ./xcube /tmp/xcube
 COPY --chown=$MAMBA_USER:$MAMBA_USER ./setup.py /tmp/setup.py
 
-# Switch into /tmp to install xcube
+# Switch into /tmp to install xcube.
 WORKDIR /tmp
 
-# Required to activate env
+# Required to activate env during image build.
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
-# Install xcube from source
+# Install xcube from source.
 RUN python setup.py install
 
-# TODO: install our xcube plugins here
+# Install our known xcube plugins.
+COPY --chown=$MAMBA_USER:$MAMBA_USER docker/install-xcube-plugin.sh ./
+RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-sh ${XCUBE_SH_VERSION} release; fi;
+RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cci ${XCUBE_CCI_VERSION} release; fi;
+RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cds ${XCUBE_CDS_VERSION} release; fi;
+RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cmems ${XCUBE_CMEMS_VERSION} release; fi;
 
-# micromamba entrypoint. Allows us to run container as executable
+WORKDIR /home/$MAMBA_USER
+
+# The micromamba entrypoint.
+# Allows us to run container as an executable with
+# base environment activated.
 ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]
 
 # Default command (shell form)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN conda update -n base conda && conda init
 RUN conda install -n base -c conda-forge mamba==0.24.0 pip=21.3.1
 
 # Setup conda environment
-# Copy yml config into image
+# Copy environment.yml into image
 COPY environment.yml /tmp/environment.yml
 
 # Use mamba to create an environment based on the specifications in
@@ -55,9 +55,6 @@ RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install_xcube.sh xcube-sh ${XC
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install_xcube.sh xcube-cci ${XCUBE_CCI_VERSION} release; fi;
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install_xcube.sh xcube-cds ${XCUBE_CDS_VERSION} release; fi;
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install_xcube.sh xcube-cmems ${XCUBE_CMEMS_VERSION} release; fi;
-
-# Export web server port
-EXPOSE 8080
 
 # Run bash in xcube environment, so we can invoke xcube CLI.
 ENTRYPOINT ["conda", "run", "-v", "-n", "base", "/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cci ${XCUBE_CCI_VERSION} release; fi;
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cds ${XCUBE_CDS_VERSION} release; fi;
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cmems ${XCUBE_CMEMS_VERSION} release; fi;
-
+RUN micromamba clean --all --force-pkgs-dirs --yes
 WORKDIR /home/$MAMBA_USER
 
 # The micromamba entrypoint.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ USER root
 
 # Update system and ensure that basic commands are available.
 RUN apt-get -y update && \
-    apt-get -y upgrade vim jq curl wget
+    apt-get -y upgrade vim jq curl wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Magic taken from https://hub.docker.com/r/mambaorg/micromamba,
 # section "Changing the user id or name"

--- a/docker/install-xcube-plugin.sh
+++ b/docker/install-xcube-plugin.sh
@@ -14,7 +14,7 @@ if [[ $INSTALL_MODE == "branch" ]]; then
   git checkout "${PACKAGE_VERSION}"
   sed -i "s/- xcube/#- xcube/g" environment.yml || exit
 
-  mamba env update -n base
+  micromamba env update -n base
   pip install .
   cd .. && rm -rf "${PACKAGE}"
 elif [[ $INSTALL_MODE == "release" ]]; then
@@ -35,11 +35,11 @@ elif [[ $INSTALL_MODE == "release" ]]; then
   sed -i "s/- xcube/#- xcube/g" environment.yml || exit
 
   cat environment.yml
-  mamba env update -n base
+  micromamba env update -n base
   pip install .
   cd .. && rm v"${PACKAGE_VERSION}".tar.gz
 else
-  mamba install -y -n base -c conda-forge "${PACKAGE}"="${PACKAGE_VERSION}"
+  micromamba install -y -n base -c conda-forge "${PACKAGE}"="${PACKAGE_VERSION}"
 fi
 
 

--- a/docker/install-xcube-plugin.sh
+++ b/docker/install-xcube-plugin.sh
@@ -14,7 +14,7 @@ if [[ $INSTALL_MODE == "branch" ]]; then
   git checkout "${PACKAGE_VERSION}"
   sed -i "s/- xcube/#- xcube/g" environment.yml || exit
 
-  micromamba env update -n base
+  micromamba install --yes --quiet --name base --file environment.yml
   pip install .
   cd .. && rm -rf "${PACKAGE}"
 elif [[ $INSTALL_MODE == "release" ]]; then

--- a/docker/install-xcube-plugin.sh
+++ b/docker/install-xcube-plugin.sh
@@ -35,7 +35,7 @@ elif [[ $INSTALL_MODE == "release" ]]; then
   sed -i "s/- xcube/#- xcube/g" environment.yml || exit
 
   cat environment.yml
-  micromamba env update -n base
+micromamba install --yes --quiet --name base --file environment.yml
   pip install .
   cd .. && rm v"${PACKAGE_VERSION}".tar.gz
 else

--- a/scripts/install_xcube.sh
+++ b/scripts/install_xcube.sh
@@ -14,8 +14,8 @@ if [[ $INSTALL_MODE == "branch" ]]; then
   git checkout "${PACKAGE_VERSION}"
   sed -i "s/- xcube/#- xcube/g" environment.yml || exit
 
-  source activate xcube && mamba env update -n xcube
-  source activate xcube && pip install .
+  mamba env update -n base
+  pip install .
   cd .. && rm -rf "${PACKAGE}"
 elif [[ $INSTALL_MODE == "release" ]]; then
   # Receive version number if PACKAGE_VERSION is latest
@@ -29,17 +29,17 @@ elif [[ $INSTALL_MODE == "release" ]]; then
 
   cd "${PACKAGE}"-"${PACKAGE_VERSION}" || exit
 
-# xcubes python version should not be changed by the plugins
+  # xcube's python version should not be changed by the plugins
   sed -i "s/- python/#- python/g" environment.yml || exit
-# xcubes version should not be changed by the plugins
+  # xcube version should not be changed by the plugins
   sed -i "s/- xcube/#- xcube/g" environment.yml || exit
 
   cat environment.yml
-  source activate xcube && mamba env update -n xcube
-  source activate xcube && pip install .
+  mamba env update -n base
+  pip install .
   cd .. && rm v"${PACKAGE_VERSION}".tar.gz
 else
-  mamba install -y -n xcube -c conda-forge "${PACKAGE}"="${PACKAGE_VERSION}"
+  mamba install -y -n base -c conda-forge "${PACKAGE}"="${PACKAGE_VERSION}"
 fi
 
 


### PR DESCRIPTION
xcube's `Dockerfile` no longer creates a conda environment `xcube`. All dependencies are now installed into the `base` environment making it easier to use the container as a executable for xcube applications. We are now also using a `micromamba` base images instead of `miniconda`. The result is a much faster build and smaller image size.

`docker build`:
![image](https://user-images.githubusercontent.com/206773/221137296-75140ebd-c527-4384-95ba-39b3a677f964.png)

`docker run`:
![image](https://user-images.githubusercontent.com/206773/221137620-80fe8499-bb5a-44ee-bf59-ecbe939650e8.png)


