### PR TITLE
`create_cluster` generates tag `user` for the current user's name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -294,6 +294,10 @@
 
 * Removed deprecated example `examples/tile`.
 
+### Other Changes
+
+* The utility function `xcube.util.dask.create_cluster()` now also
+  generates the tag `user` for the current user's name.
 
 ## Changes in 0.12.1 
 

--- a/test/util/test_dask.py
+++ b/test/util/test_dask.py
@@ -135,6 +135,8 @@ class NewClusterTest(unittest.TestCase):
                       'creator': 'auto',
                       'environment': 'dev',
                       'purpose': 'xcube dask cluster',
+                      'user': os.environ.get('USER',
+                                             os.environ.get('USERNAME')),
                       'tag1': 'value1',
                       'tag2': 'value2a',
                       'tag3': 'value3'},


### PR DESCRIPTION
The utility function `xcube.util.dask.create_cluster()` now also generates the tag `user` for the current user's name.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
