### PR TITLE
Changed behaviour of xcube.core.mldataset.CombinedMultiLevelDataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,16 @@
     a multi-level dataset persisted to some filesystem, like 
     "file", "s3", "memory". It can also write datasets to the filesystem. 
 
+
+* Changed the behaviour of the class 
+  `xcube.core.mldataset.CombinedMultiLevelDataset` to do what we 
+  actually expect:
+  If the keyword argument `combiner_func` is not given or ``None`` is passed, 
+  a copy of the first dataset is made, which is then subsequently updated 
+  by the remaining datasets using ``xarray.Dataset.update()``.
+  The former default was using the ``xarray.merge()``, which for some reason
+  can eagerly load Dask array chunks into memory that won't be released. 
+
 ### Fixes
 
 * Tiles of datasets with forward slashes in their identifiers

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,10 +65,10 @@
 * Changed the behaviour of the class 
   `xcube.core.mldataset.CombinedMultiLevelDataset` to do what we 
   actually expect:
-  If the keyword argument `combiner_func` is not given or ``None`` is passed, 
+  If the keyword argument `combiner_func` is not given or `None` is passed, 
   a copy of the first dataset is made, which is then subsequently updated 
-  by the remaining datasets using ``xarray.Dataset.update()``.
-  The former default was using the ``xarray.merge()``, which for some reason
+  by the remaining datasets using `xarray.Dataset.update()`.
+  The former default was using the `xarray.merge()`, which for some reason
   can eagerly load Dask array chunks into memory that won't be released. 
 
 ### Fixes

--- a/test/core/mldataset/test_combined.py
+++ b/test/core/mldataset/test_combined.py
@@ -2,6 +2,7 @@ import unittest
 
 from xcube.core.mldataset import BaseMultiLevelDataset
 from xcube.core.mldataset import CombinedMultiLevelDataset
+from xcube.core.mldataset import MultiLevelDataset
 from .helpers import get_test_dataset
 
 
@@ -18,7 +19,15 @@ class CombinedMultiLevelDatasetTest(unittest.TestCase):
         )
 
         ml_ds = CombinedMultiLevelDataset([ml_ds_1, ml_ds_2, ml_ds_3])
+        self.assert_ml_dataset_structure_ok(ml_ds)
+        ml_ds.close()
 
+        ml_ds = CombinedMultiLevelDataset([ml_ds_1, ml_ds_2, ml_ds_3],
+                                          combiner_function=None)
+        self.assert_ml_dataset_structure_ok(ml_ds)
+        ml_ds.close()
+
+    def assert_ml_dataset_structure_ok(self, ml_ds: MultiLevelDataset):
         self.assertEqual(3, ml_ds.num_levels)
         self.assertEqual((180, 180), ml_ds.grid_mapping.tile_size)
 
@@ -48,5 +57,3 @@ class CombinedMultiLevelDatasetTest(unittest.TestCase):
                             for v in ds2.data_vars.values()))
 
         self.assertEqual([ds0, ds1, ds2], ml_ds.datasets)
-
-        ml_ds.close()

--- a/xcube/core/mldataset/combined.py
+++ b/xcube/core/mldataset/combined.py
@@ -39,9 +39,9 @@ class CombinedMultiLevelDataset(LazyMultiLevelDataset):
         If given, it receives a list of datasets
         (``xarray.Dataset`` instances) and *combiner_params* as keyword
         arguments.
-            If not given or ``None`` is passed, a copy of the first dataset
-            is made, which is then subsequently updated by the remaining datasets
-            using ``xarray.Dataset.update()``.
+        If not given or ``None`` is passed, a copy of the first dataset
+        is made, which is then subsequently updated by the remaining datasets
+        using ``xarray.Dataset.update()``.
     :param combiner_params: Parameters to the *combiner_function*
         passed as keyword arguments.
     """
@@ -49,7 +49,7 @@ class CombinedMultiLevelDataset(LazyMultiLevelDataset):
     def __init__(self,
                  ml_datasets: Sequence[MultiLevelDataset],
                  ds_id: Optional[str] = None,
-                 combiner_function: Optional[Callable] = xr.merge,
+                 combiner_function: Optional[Callable] = None,
                  combiner_params: Optional[Dict[str, Any]] = None):
         if not ml_datasets or len(ml_datasets) < 2:
             raise ValueError('ml_datasets must have at least two elements')

--- a/xcube/core/mldataset/combined.py
+++ b/xcube/core/mldataset/combined.py
@@ -19,7 +19,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-from typing import Sequence, Any, Dict, Callable
+from typing import Sequence, Any, Dict, Callable, Optional
 
 import xarray as xr
 
@@ -34,34 +34,44 @@ class CombinedMultiLevelDataset(LazyMultiLevelDataset):
     :param ml_datasets: The multi-level datasets to be combined.
         At least two must be provided.
     :param ds_id: Optional dataset identifier.
-    :param combiner_function: A function used to combine the datasets.
-        It receives a list of datasets (``xarray.Dataset`` instances)
-        and *combiner_params* as keyword arguments.
-        Defaults to function ``xarray.merge()`` with default parameters.
+    :param combiner_function: An optional function used to combine the
+        datasets, for example ``xarray.merge``.
+        If given, it receives a list of datasets
+        (``xarray.Dataset`` instances) and *combiner_params* as keyword
+        arguments.
+            If not given or ``None`` is passed, a copy of the first dataset
+            is made, which is then subsequently updated by the remaining datasets
+            using ``xarray.Dataset.update()``.
     :param combiner_params: Parameters to the *combiner_function*
         passed as keyword arguments.
     """
 
     def __init__(self,
                  ml_datasets: Sequence[MultiLevelDataset],
-                 ds_id: str = None,
-                 combiner_function: Callable = None,
-                 combiner_params: Dict[str, Any] = None):
+                 ds_id: Optional[str] = None,
+                 combiner_function: Optional[Callable] = xr.merge,
+                 combiner_params: Optional[Dict[str, Any]] = None):
         if not ml_datasets or len(ml_datasets) < 2:
             raise ValueError('ml_datasets must have at least two elements')
         super().__init__(ds_id=ds_id,
                          parameters=combiner_params)
         self._ml_datasets = ml_datasets
-        self._combiner_function = combiner_function or xr.merge
+        self._combiner_function = combiner_function
 
     def _get_num_levels_lazily(self) -> int:
         return self._ml_datasets[0].num_levels
 
     def _get_dataset_lazily(self, index: int,
                             combiner_params: Dict[str, Any]) -> xr.Dataset:
-        datasets = [ml_dataset.get_dataset(index) for ml_dataset in
-                    self._ml_datasets]
-        return self._combiner_function(datasets, **combiner_params)
+        datasets = [ml_dataset.get_dataset(index)
+                    for ml_dataset in self._ml_datasets]
+        if self._combiner_function is None:
+            combined_dataset = datasets[0].copy()
+            for dataset in datasets[1:]:
+                combined_dataset.update(dataset)
+            return combined_dataset
+        else:
+            return self._combiner_function(datasets, **combiner_params)
 
     def close(self):
         for ml_dataset in self._ml_datasets:


### PR DESCRIPTION
Changed the behaviour of the class `xcube.core.mldataset.CombinedMultiLevelDataset` to do what we actually expect:
If the keyword argument `combiner_func` is not given or `None` is passed, a copy of the first dataset is made, which is then subsequently updated by the remaining datasets using `xarray.Dataset.update()`. The former default was using the `xarray.merge()`, which for some reason can eagerly load Dask array chunks into memory that won't be released. 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
