### PR TITLE
Order variables reported by xcube server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,9 @@
 
 * It is now possible to enforce the order of variables reported by 
   xcube server. The new server configuration key `Variables` can be added 
-  to dataset configurations. Is a list of wildcard patterns that 
-  determine the variables' order. (#835) 
+  to `Datasets` configurations. Is a list of wildcard patterns that 
+  determines the order of variables and the subset of variables to be 
+  reported. (#835) 
 
 ## Changes in 1.0.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 * Setting a dataset's `BoundingBox` in the server configuration 
   is now recognised when requesting the dataset details. (#845)
 
+* It is now possible to enforce the order of variables reported by 
+  xcube server. The new server configuration key `Variables` can be added 
+  to dataset configurations. Is a list of wildcard patterns that 
+  determine the variables' order. (#835) 
+
 ## Changes in 1.0.3
 
 Same as 1.0.2, just fixed unit tests due to minor Python environment change.

--- a/docs/source/cli/xcube_serve.rst
+++ b/docs/source/cli/xcube_serve.rst
@@ -202,7 +202,7 @@ Dataset Attribution may be added to the server via *DatasetAttribution*.
 .. _base directory:
 
 Base Directory [optional]
-------------------------------
+-------------------------
 
 A typical xcube server configuration comprises many paths, and
 relative paths of known configuration parameters are resolved against
@@ -349,6 +349,32 @@ the *PlaceGroupRef*. The configuration of *PlaceGroups* is described in section 
 *AccessControl* [optional]
 can only be used when providing `authentication`_. Datasets may be protected by
 configuring the *RequiredScopes* entry whose value is a list of required scopes, e.g. "read:datasets".
+
+*Variables* [optional]
+enforces the order of variables reported by xcube server.
+Is a list of wildcard patterns that
+determines the order of variables and the subset of variables to be
+reported.
+
+The following example reports only variables whose name starts with "conc\_":
+
+.. code:: yaml
+  Datasets:
+    - Path: demo.zarr
+      Variables:
+        - "conc_*"
+
+The next example reports all variables but ensures that ``conc_chl``
+and ``conc_tsm`` are the first ones:
+
+.. code:: yaml
+  Datasets:
+    - Path: demo.zarr
+      Variables:
+        - conc_chl
+        - conc_tsm
+        - "*"
+
 
 .. _locally stored xcube datasets:
 

--- a/examples/serve/demo/config.yml
+++ b/examples/serve/demo/config.yml
@@ -16,7 +16,7 @@ DatasetAttribution:
   - "© by Brockmann Consult GmbH 2020, contains modified Copernicus Data 2019, processed by ESA"
   - "© by EU H2020 CyanoAlert project"
 
-DatasetChunkCacheSize: 100M
+#DatasetChunkCacheSize: 100M
 
 ## You may want to specify a location of your server resources.
 #base_dir: s3://<bucket>/<path-to-your>/<resources>/
@@ -40,6 +40,13 @@ Datasets:
     Path: cube-1-250-250.levels
     Style: default
     TimeSeriesDataset: local_ts
+    Variables:
+      - "conc_chl"
+      - "chl_category"
+      - "conc_tsm"
+      - "chl_tsm_sum"
+      - "kd489"
+      - "*"
     Augmentation:
       Path: compute_extra_vars.py
       Function: compute_variables

--- a/test/webapi/res/config.yml
+++ b/test/webapi/res/config.yml
@@ -5,6 +5,13 @@ Datasets:
   - Identifier: demo
     Title: xcube-server Demonstration L2C Cube
     Path: ../../../examples/serve/demo/cube-1-250-250.zarr
+    Variables:
+      - "conc_chl"
+      - "chl_category"
+      - "conc_tsm"
+      - "chl_tsm_sum"
+      - "kd489"
+      - "*"
     Style: default
     Attribution: © by EU H2020 CyanoAlert project
 
@@ -12,6 +19,13 @@ Datasets:
     Title: xcube-server Demonstration L3 Cube
     FileSystem: memory
     Path: script.py
+    Variables:
+      - "conc_chl"
+      - "chl_category"
+      - "conc_tsm"
+      - "chl_tsm_sum"
+      - "kd489"
+      - "*"
     Function: compute_dataset
     InputDatasets: ["demo"]
     InputParameters:

--- a/xcube/webapi/datasets/config.py
+++ b/xcube/webapi/datasets/config.py
@@ -40,6 +40,14 @@ ATTRIBUTION_SCHEMA = JsonComplexSchema(
     ]
 )
 
+VARIABLES_SCHEMA = JsonArraySchema(
+    items=IDENTIFIER_SCHEMA,
+    min_items=1,
+    description="Names of variables to be published."
+                " Names may use wildcard characters '*' and '?'."
+                " Also determines the order of variables."
+)
+
 VALUE_RANGE_SCHEMA = JsonArraySchema(items=[
     JsonNumberSchema(),
     JsonNumberSchema()
@@ -71,6 +79,7 @@ ACCESS_CONTROL_SCHEMA = JsonObjectSchema(
 
 COMMON_DATASET_PROPERTIES = dict(
     Title=STRING_SCHEMA,
+    Variables=VARIABLES_SCHEMA,
     TimeSeriesDataset=IDENTIFIER_SCHEMA,
     BoundingBox=GEO_BOUNDING_BOX_SCHEMA,
     ChunkCacheSize=CHUNK_SIZE_SCHEMA,


### PR DESCRIPTION
It is now possible to enforce the order of variables reported by xcube server. The new server configuration key `Variables` can be added to dataset configurations. Is a list of wildcard patterns that determine the variables' order.

Closes #835

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
