### PR TITLE
restrict gdal

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - fiona >=1.8
   - fontconfig
   - fsspec >=2021.6
-  - gdal >=3.0
+  - gdal >=3.0,<3.6.3
   - geopandas >=0.8
   - jdcal >=1.4
   - jsonschema >=3.2


### PR DESCRIPTION
Solves #853 . Different from what had been stated in the issue, I have not restricted pyproj but gdal, as we had already experienced that there were environments in which xcube worked with the latest pyproj version.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [ ] Changes documented in `CHANGES.md`
* [ ] AppVeyor CI passes
* ~[ ] Test coverage remains or increases (target 100%)~
