### PR TITLE
adapted new_cluster to create workers in specified region and shutdown_on_close to coiled_params

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   ...
   ```
 
-### Fixes
+### Other changes
 
 * Added `shutdown_on_close=True` parameter to coiled params to ensure that the 
   clusters are shut down on close. (#881)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,15 @@
   ...
   ```
 
+### Fixes
+
+* Added `shutdown_on_close=True` parameter to coiled params to ensure that the 
+  clusters are shut down on close. (#881)
+* Introduced new parameter `region` for utility function `new_cluster` in 
+  `xcube.util.dask` which will ensure coiled creates the dask cluster in the 
+  specified region. (#882)
+  
+
 ## Changes in 1.1.3 (in development)
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
   clusters are shut down on close. (#881)
 * Introduced new parameter `region` for utility function `new_cluster` in 
   `xcube.util.dask` which will ensure coiled creates the dask cluster in the 
-  specified region. (#882)
+  prefered default region: eu-central-1. (#882)
   
 
 ## Changes in 1.1.3 (in development)

--- a/test/util/test_dask.py
+++ b/test/util/test_dask.py
@@ -130,6 +130,8 @@ class NewClusterTest(unittest.TestCase):
              'environ': None,
              'n_workers': 4,
              'name': None,
+             'region': 'eu-central-1',
+             'shutdown_on_close': True,
              'software': 'my_image-1-2-3',
              'tags': {'cost-center': 'unknown',
                       'creator': 'auto',

--- a/xcube/util/dask.py
+++ b/xcube/util/dask.py
@@ -150,6 +150,7 @@ def new_cluster(
     n_workers: int = 4,
     resource_tags: Optional[Dict[str, str]] = None,
     account: str = None,
+    region: str = 'eu-central-1',
     **kwargs,
 ) -> distributed.deploy.Cluster:
     """Create a new Dask cluster.
@@ -175,6 +176,7 @@ def new_cluster(
     :param account: cluster provider account name
     :param **kwargs: further named arguments will be passed on to the
         cluster creation function
+    :param region: region where workers of the cluster will be deployed
     """
 
     if resource_tags is None:
@@ -229,7 +231,9 @@ def new_cluster(
             name=name,
             software=software,
             use_best_zone=True,
-            compute_purchase_option='spot_with_fallback'
+            compute_purchase_option='spot_with_fallback',
+            shutdown_on_close=True,
+            region=region,
         )
         coiled_params.update(kwargs)
 

--- a/xcube/util/dask.py
+++ b/xcube/util/dask.py
@@ -176,7 +176,7 @@ def new_cluster(
     :param account: cluster provider account name
     :param **kwargs: further named arguments will be passed on to the
         cluster creation function
-    :param region: region where workers of the cluster will be deployed
+    :param region: default region where workers of the cluster will be deployed set to eu-central-1
     """
 
     if resource_tags is None:


### PR DESCRIPTION
[Description of PR]

This PR modifies `new_cluster` to create workers in specified region, by default 'eu-central-1' and adds parameter `shutdown_on_close` to coiled_params

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
