### PR TITLE
Add skip_branch_with_pr: true to AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,10 @@ configuration: Release
 platform:
   - x64
 
-# Do not build feature branch with open Pull Requests
+# Do not build feature branch with open Pull Requests.
+# Note that a feature branch build may still occur on the first push to
+# the branch -- see
+# https://help.appveyor.com/discussions/questions/18437-skip_branch_with_pr-setting-doesnt-work
 skip_branch_with_pr: true
 
 for:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ configuration: Release
 platform:
   - x64
 
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 for:
 -
   matrix:


### PR DESCRIPTION
This should disable branch builds for branches with a PR (since they have a PR build anyway).

Addresses #884.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
