### PR TITLE
Various improvements to STAC and OGC APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,14 +3,16 @@
 ### Enhancements
 
 * Added a basic implementation of the draft version of OGC API - Coverages.
+  (#879, #889, #900)
 * Adapted the STAC implementation to additionally offer datasets as
   individual collections for better integration with OGC API - Coverages.
-* Various minor improvements to STAC implementation.
+  (#889)
+* Various minor improvements to STAC implementation. (#900)
 
 ### Fixes
 
 * Resolved the issue for CRS84 error due to latest version of gdal (#869)
-* Fixed incorrect additional variable data in STAC datacube properties.
+* Fixed incorrect additional variable data in STAC datacube properties. (#889)
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,15 @@
 * Added a basic implementation of the draft version of OGC API - Coverages.
 * Adapted the STAC implementation to additionally offer datasets as
   individual collections for better integration with OGC API - Coverages.
+* Various minor improvements to STAC implementation.
 
 ### Fixes
-* Resolved the issue for CRS84 error due to latest version of gdal (#869)
 
+* Resolved the issue for CRS84 error due to latest version of gdal (#869)
 * Fixed incorrect additional variable data in STAC datacube properties.
 
 ### Other changes
+
 * `update_dataset_attrs` can now also handle datasets with CRS other than 
   WGS84 and update the metadata according to the 
   [ESIP Attribute Convention for Data Discovery](https://wiki.esipfed.org/Attribute_Convention_for_Data_Discovery_1-3#Recommended). 

--- a/test/webapi/ows/coverages/expected.json
+++ b/test/webapi/ows/coverages/expected.json
@@ -38,8 +38,8 @@
       {
         "type": "RegularAxis",
         "axisLabel": "time",
-        "lowerBound": 1484561361834255872,
-        "upperBound": 1485773193836892416,
+        "lowerBound": "2017-01-16T10:09:21.834255872",
+        "upperBound": "2017-01-30T10:46:33.836892416",
         "resolution": 242366400527308.8,
         "uomLabel": "ns"
       }
@@ -84,8 +84,8 @@
         {
           "type": "RegularAxis",
           "axisLabel": "time",
-          "lowerBound": 1484561361834255872,
-          "upperBound": 1485773193836892416,
+          "lowerBound": "2017-01-16T10:09:21.834255872",
+          "upperBound": "2017-01-30T10:46:33.836892416",
           "resolution": 242366400527308.8,
           "uomLabel": "ns"
         }

--- a/test/webapi/ows/coverages/expected.json
+++ b/test/webapi/ows/coverages/expected.json
@@ -25,7 +25,7 @@
         "lowerBound": 0,
         "upperBound": 1,
         "resolution": 0.5,
-        "uomLabel": "degree"
+        "uomLabel": "unknown"
       },
       {
         "type": "RegularAxis",
@@ -71,7 +71,7 @@
           "lowerBound": 0,
           "upperBound": 1,
           "resolution": 0.5,
-          "uomLabel": "degree"
+          "uomLabel": "unknown"
         },
         {
           "type": "RegularAxis",

--- a/test/webapi/ows/coverages/expected.json
+++ b/test/webapi/ows/coverages/expected.json
@@ -25,7 +25,7 @@
         "lowerBound": 0,
         "upperBound": 1,
         "resolution": 0.5,
-        "uomLabel": "degrees"
+        "uomLabel": "degree"
       },
       {
         "type": "RegularAxis",
@@ -41,7 +41,7 @@
         "lowerBound": 1484561361834255872,
         "upperBound": 1485773193836892416,
         "resolution": 242366400527308.8,
-        "uomLabel": "degrees"
+        "uomLabel": "ns"
       }
     ]
   },
@@ -71,7 +71,7 @@
           "lowerBound": 0,
           "upperBound": 1,
           "resolution": 0.5,
-          "uomLabel": "degrees"
+          "uomLabel": "degree"
         },
         {
           "type": "RegularAxis",
@@ -87,7 +87,7 @@
           "lowerBound": 1484561361834255872,
           "upperBound": 1485773193836892416,
           "resolution": 242366400527308.8,
-          "uomLabel": "degrees"
+          "uomLabel": "ns"
         }
       ],
       "gridLimits": {

--- a/test/webapi/ows/coverages/test_controllers.py
+++ b/test/webapi/ows/coverages/test_controllers.py
@@ -35,8 +35,8 @@ from xcube.webapi.ows.coverages.controllers import (
     get_coverage_data,
     get_crs_from_dataset,
     dtype_to_opengis_datatype,
-    get_dataarray_description, 
-    _get_units,
+    get_dataarray_description,
+    get_units,
 )
 
 
@@ -153,6 +153,6 @@ class CoveragesControllersTest(unittest.TestCase):
 
     def test_get_units(self):
         self.assertEqual(
-            's',
-            _get_units(xr.Dataset({'time': [1, 2, 3]}), 'time')
+            'unknown',
+            get_units(xr.Dataset({'time': [1, 2, 3]}), 'time')
         )

--- a/test/webapi/ows/coverages/test_controllers.py
+++ b/test/webapi/ows/coverages/test_controllers.py
@@ -35,7 +35,8 @@ from xcube.webapi.ows.coverages.controllers import (
     get_coverage_data,
     get_crs_from_dataset,
     dtype_to_opengis_datatype,
-    get_dataarray_description, _get_units,
+    get_dataarray_description, 
+    _get_units,
 )
 
 

--- a/test/webapi/ows/coverages/test_controllers.py
+++ b/test/webapi/ows/coverages/test_controllers.py
@@ -29,12 +29,13 @@ import xarray as xr
 import rioxarray
 
 from test.webapi.ows.coverages.test_context import get_coverages_ctx
+from xcube.server.api import ApiError
 from xcube.webapi.ows.coverages.controllers import (
     get_coverage_as_json,
     get_coverage_data,
     get_crs_from_dataset,
     dtype_to_opengis_datatype,
-    get_dataarray_description,
+    get_dataarray_description, _get_units,
 )
 
 
@@ -68,8 +69,9 @@ class CoveragesControllersTest(unittest.TestCase):
     def test_get_coverage_data_netcdf(self):
         query = dict(
             bbox=['52,1,51,2'],
-            datetime=['2017-01-25'],
+            datetime=['2017-01-24/2017-01-27'],
             properties=['conc_chl,kd489'],
+            crs=['EPSG:4326'],
         )
         result = get_coverage_data(
             get_coverages_ctx().datasets_ctx,
@@ -87,7 +89,9 @@ class CoveragesControllersTest(unittest.TestCase):
             with open(path, 'wb') as fh:
                 fh.write(result)
             ds = xr.open_dataset(path)
-            self.assertEqual({'lat': 400, 'lon': 400, 'bnds': 2}, ds.dims)
+            self.assertEqual(
+                {'lat': 400, 'lon': 400, 'time': 2, 'bnds': 2}, ds.dims
+            )
             self.assertEqual(['conc_chl', 'kd489'], list(ds.data_vars))
             self.assertEqual(
                 [
@@ -103,6 +107,26 @@ class CoveragesControllersTest(unittest.TestCase):
                 list(ds.variables),
             )
             ds.close()
+
+    def test_get_coverage_data_png(self):
+        query = dict(
+            subset=['lat(51:52),lon(1:2),time(2017-01-25)'],
+            properties=['conc_chl'],
+        )
+        result = get_coverage_data(
+            get_coverages_ctx().datasets_ctx, 'demo', query, 'png'
+        )
+        with BytesIO(result) as fh:
+            da = rioxarray.open_rasterio(fh, driver='PNG')
+            self.assertIsInstance(da, xr.DataArray)
+            self.assertEqual(('band', 'y', 'x'), da.dims)
+            self.assertEqual((1, 400, 400), da.shape)
+
+    def test_get_coverage_unsupported_type(self):
+        with self.assertRaises(ApiError.UnsupportedMediaType):
+            get_coverage_data(
+                get_coverages_ctx().datasets_ctx, 'demo', {}, 'nonexistent'
+            )
 
     def test_get_crs_from_dataset(self):
         ds = xr.Dataset({'crs': ([], None, {'spatial_ref': '3035'})})
@@ -125,3 +149,9 @@ class CoveragesControllersTest(unittest.TestCase):
         name = 'foo'
         da = xr.DataArray(data=[], coords=[('x', [])], dims=['x'], name=name)
         self.assertEqual(name, get_dataarray_description(da))
+
+    def test_get_units(self):
+        self.assertEqual(
+            's',
+            _get_units(xr.Dataset({'time': [1, 2, 3]}), 'time')
+        )

--- a/test/webapi/ows/coverages/test_routes.py
+++ b/test/webapi/ows/coverages/test_routes.py
@@ -70,4 +70,4 @@ class CoveragesRoutesTest(RoutesTestCase):
         response = self.fetch(
             PATH_PREFIX + '/collections/demo/coverage/rangeset'
         )
-        self.assertEqual(response.status, 501)
+        self.assertEqual(response.status, 405)

--- a/test/webapi/ows/stac/demo-collection.json
+++ b/test/webapi/ows/stac/demo-collection.json
@@ -161,7 +161,7 @@
       "title": "Feature for the dataset \"demo\""
     },
     {
-      "rel": "coverage",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
       "href": "http://localhost:8080/ogc/collections/demo/coverage",
       "title": "Coverage for the dataset \"demo\" using OGC API \u2013 Coverages"
     }

--- a/test/webapi/ows/stac/demo-collection.json
+++ b/test/webapi/ows/stac/demo-collection.json
@@ -153,6 +153,17 @@
       "rel": "items",
       "href": "http://localhost:8080/ogc/collections/demo/items",
       "title": "feature collection of data cube items"
+    },
+    {
+      "rel": "item",
+      "href": "http://localhost:8080/ogc/collections/demo/items/datacube",
+      "type": "application/geo+json",
+      "title": "Feature for the dataset \"demo\""
+    },
+    {
+      "rel": "coverage",
+      "href": "http://localhost:8080/ogc/collections/demo/coverage",
+      "title": "Coverage for the dataset \"demo\" using OGC API \u2013 Coverages"
     }
   ],
   "providers": [],

--- a/test/webapi/ows/stac/stac-single-item.json
+++ b/test/webapi/ows/stac/stac-single-item.json
@@ -4,7 +4,7 @@
     "https://stac-extensions.github.io/datacube/v2.1.0/schema.json"
   ],
   "type": "Feature",
-  "id": "demo-1w",
+  "id": "datacube",
   "bbox": [
     0.0,
     50.0,

--- a/test/webapi/ows/stac/test_controllers.py
+++ b/test/webapi/ows/stac/test_controllers.py
@@ -161,7 +161,7 @@ class StacControllersTest(unittest.TestCase):
             content = json.load(fp)
         return content
 
-    # # Commented out to keep coverage checkers happy.
+    # Commented out to keep coverage checkers happy.
     # @staticmethod
     # def write_json(filename, content):
     #     """Convenience function for updating saved expected JSON

--- a/test/webapi/ows/stac/test_controllers.py
+++ b/test/webapi/ows/stac/test_controllers.py
@@ -79,25 +79,24 @@ EXPECTED_CONFORMANCE = {
 }
 
 EXPECTED_ENDPOINTS = functools.reduce(
-    lambda endpoint_list, ep: endpoint_list + [
-        {'methods': ep[0], 'path': ep[1] + suffix} for suffix in ('/', '')
-    ],
+    lambda endpoint_list, ep: endpoint_list
+    + [{'methods': ep[0], 'path': ep[1] + suffix} for suffix in ('/', '')],
     [
-        (['get'], '/ogc/collections/{collectionId}/coverage'),
-        (['get'], '/ogc/collections/{collectionId}/coverage/domainset'),
-        (['get'], '/ogc/collections/{collectionId}/coverage/rangetype'),
-        (['get'], '/ogc/collections/{collectionId}/coverage/metadata'),
-        (['get'], '/ogc/collections/{collectionId}/coverage/rangeset'),
-        (['get'], '/ogc'),
-        (['get'], '/ogc/conformance'),
-        (['get'], '/ogc/collections'),
-        (['get'], '/ogc/collections/{collectionId}'),
-        (['get'], '/ogc/collections/{collectionId}/items'),
-        (['get'], '/ogc/collections/{collectionId}/items/{featureId}'),
-        (['get', 'post'], '/ogc/search'),
-        (['get'], '/ogc/collections/{collectionId}/queryables'),
+        (['get'], '/collections/{collectionId}/coverage'),
+        (['get'], '/collections/{collectionId}/coverage/domainset'),
+        (['get'], '/collections/{collectionId}/coverage/rangetype'),
+        (['get'], '/collections/{collectionId}/coverage/metadata'),
+        (['get'], '/collections/{collectionId}/coverage/rangeset'),
+        (['get'], ''),
+        (['get'], '/conformance'),
+        (['get'], '/collections'),
+        (['get'], '/collections/{collectionId}'),
+        (['get'], '/collections/{collectionId}/items'),
+        (['get'], '/collections/{collectionId}/items/{featureId}'),
+        (['get', 'post'], '/search'),
+        (['get'], '/collections/{collectionId}/queryables'),
     ],
-    []
+    [],
 )
 
 EXPECTED_DATASETS_COLLECTION = {
@@ -164,7 +163,7 @@ class StacControllersTest(unittest.TestCase):
 
     # # Commented out to keep coverage checkers happy.
     # @staticmethod
-    # def write_json(content, filename):
+    # def write_json(filename, content):
     #     """Convenience function for updating saved expected JSON
     #
     #     Not used during an ordinary test run.

--- a/xcube/core/store/fs/store.py
+++ b/xcube/core/store/fs/store.py
@@ -632,7 +632,7 @@ class BaseFsDataStore(DefaultSearchMixin, MutableDataStore):
         assert_given(data_id, 'data_id')
         ext = self._get_filename_ext(data_id)
         data_type_aliases = None
-        format_id = _FILENAME_EXT_TO_FORMAT.get(ext)
+        format_id = _FILENAME_EXT_TO_FORMAT.get(ext.lower())
         if format_id is not None:
             data_type_aliases = _FORMAT_TO_DATA_TYPE_ALIASES.get(format_id)
         if data_type_aliases is None or format_id is None:

--- a/xcube/server/api.py
+++ b/xcube/server/api.py
@@ -845,6 +845,7 @@ class ApiError(Exception):
     InternalServerError: Type["_DerivedApiError"]
     NotImplemented: Type["_DerivedApiError"]
     InvalidServerConfig: Type["_DerivedApiError"]
+    UnsupportedMediaType: Type["_DerivedApiError"]
 
     @property
     def status_code(self) -> int:
@@ -901,6 +902,11 @@ class _Gone(ApiError):
         super().__init__(410, message=message)
 
 
+class _UnsupportedMediaType(ApiError):
+    def __init__(self, message: Optional[str] = None):
+        super().__init__(415, message=message)
+
+
 class _InternalServerError(ApiError):
     def __init__(self, message: Optional[str] = None):
         super().__init__(500, message=message)
@@ -921,6 +927,7 @@ ApiError.Unauthorized = _Unauthorized
 ApiError.Forbidden = _Forbidden
 ApiError.NotFound = _NotFound
 ApiError.MethodNotAllowed = _MethodNotAllowed
+ApiError.UnsupportedMediaType = _UnsupportedMediaType
 ApiError.Conflict = _Conflict
 ApiError.Gone = _Gone
 ApiError.InternalServerError = _InternalServerError

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -137,7 +137,8 @@ def get_coverage_data(
         # unhandled types, but we may as well do the right thing if any
         # do slip through.
         raise ApiError.UnsupportedMediaType(
-            'Available media types: '
+            f'Unsupported media type {content_type}. '
+            + 'Available media types: '
             + ', '.join(
                 [type_ for value in media_types.values() for type_ in value]
             )

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -96,11 +96,11 @@ def get_coverage_data(
         # TODO: slice according to axis order in dataset
         bbox = list(map(float, query['bbox'][0].split(',')))
         if {'lat', 'lon'}.issubset(ds.variables):
-            ds = ds.sel(lat=slice(bbox[0], bbox[2]),
-                        lon=slice(bbox[1], bbox[3]))
+            ds = ds.sel(
+                lat=slice(bbox[0], bbox[2]), lon=slice(bbox[1], bbox[3])
+            )
         else:
-            ds = ds.sel(y=slice(bbox[0], bbox[2]),
-                        x=slice(bbox[1], bbox[3]))
+            ds = ds.sel(y=slice(bbox[0], bbox[2]), x=slice(bbox[1], bbox[3]))
     if 'datetime' in query:
         # TODO: Raise an exception for non-existent time axis
         timespec = query['datetime'][0]
@@ -274,11 +274,16 @@ def _get_axes_properties(ds: xr.Dataset) -> list[dict]:
 
 def _get_axis_properties(ds: xr.Dataset, dim: str) -> dict[str, Any]:
     axis = ds.coords[dim]
+    if np.issubdtype(axis.dtype, np.datetime64):
+        lower_bound = np.datetime_as_string(axis[0])
+        upper_bound = np.datetime_as_string(axis[-1])
+    else:
+        lower_bound, upper_bound = axis[0].item(), axis[-1].item(),
     return dict(
         type='RegularAxis',
         axisLabel=dim,
-        lowerBound=axis[0].item(),
-        upperBound=axis[-1].item(),
+        lowerBound=lower_bound,
+        upperBound=upper_bound,
         resolution=abs((axis[-1] - axis[0]).item() / len(axis)),
         uomLabel=_get_units(ds, dim),
     )

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -286,7 +286,7 @@ def _get_axis_properties(ds: xr.Dataset, dim: str) -> dict[str, Any]:
         lowerBound=lower_bound,
         upperBound=upper_bound,
         resolution=abs((axis[-1] - axis[0]).item() / len(axis)),
-        uomLabel=_get_units(ds, dim),
+        uomLabel=get_units(ds, dim),
     )
 
 
@@ -296,20 +296,15 @@ def _get_grid_limits_axis(ds: xr.Dataset, dim: str) -> dict[str, Any]:
     )
 
 
-def _get_units(ds: xr.Dataset, dim: str) -> str:
+def get_units(ds: xr.Dataset, dim: str) -> str:
     coord = ds.coords[dim]
     if hasattr(coord, 'attrs') and 'units' in coord.attrs:
         return coord.attrs['units']
     if np.issubdtype(coord, np.datetime64):
         return np.datetime_data(coord)[0]
-    if dim == 'time':
-        # Pure guesswork, but without an attribute or a datetime64 we can't
-        # do much better.
-        return 's'
-    # TODO: improve this guess -- can we match dataset dimensions to
-    #  projection axes?
-    # Fallback for non-time axes: use the unit of the first CRS axis
-    return pyproj.crs.CRS(get_crs_from_dataset(ds)).axis_info[0].unit_name
+    # TODO: as a fallback for spatial axes, we could try matching dimensions
+    #  to CRS axes and take the unit from the CRS definition.
+    return 'unknown'
 
 
 def get_crs_from_dataset(ds: xr.Dataset) -> str:

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -103,6 +103,7 @@ def get_coverage_data(
             ds = ds.sel(y=slice(bbox[0], bbox[2]), x=slice(bbox[1], bbox[3]))
     if 'datetime' in query:
         # TODO: Raise an exception for non-existent time axis
+        # TODO: Support open ranges
         timespec = query['datetime'][0]
         if '/' in timespec:
             timefrom, timeto = timespec.split('/')

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -261,10 +261,16 @@ def _get_units(ds: xr.Dataset, dim: str):
     coord = ds.coords[dim]
     if hasattr(coord, 'attrs') and 'units' in coord.attrs:
         return coord.attrs['units']
-    else:
-        # TODO: improve this guess -- can we match dataset dimensions to
-        #  projection axes?
-        return pyproj.crs.CRS(get_crs_from_dataset(ds)).axis_info[0].unit_name
+    if np.issubdtype(coord, np.datetime64):
+        return np.datetime_data(coord)[0]
+    if dim == 'time':
+        # Pure guesswork, but without an attribute or a datetime64 we can't
+        # do much better.
+        return 's'
+    # TODO: improve this guess -- can we match dataset dimensions to
+    #  projection axes?
+    # Fallback for non-time axes: use the unit of the first CRS axis
+    return pyproj.crs.CRS(get_crs_from_dataset(ds)).axis_info[0].unit_name
 
 
 def get_crs_from_dataset(ds: xr.Dataset) -> str:

--- a/xcube/webapi/ows/coverages/controllers.py
+++ b/xcube/webapi/ows/coverages/controllers.py
@@ -79,6 +79,10 @@ def get_coverage_data(
     :return: the coverage as bytes in the requested output format, or None
              if the requested output format is not supported
     """
+
+    # TODO: support scale-factor, scale-axes, scale-size, subset-crs,
+    #  and bbox-crs
+
     ds = get_dataset(ctx, collection_id)
     if 'subset' in query:
         ds = ds.sel(indexers=_subset_to_indexers(query['subset'][0], ds))
@@ -102,6 +106,8 @@ def get_coverage_data(
         source_gm = GridMapping.from_dataset(ds)
         target_gm = source_gm.transform(target_crs).to_regular()
         ds = resample_in_space(ds, source_gm=source_gm, target_gm=target_gm)
+
+    # We don't
     if content_type in ['image/tiff', 'application/x-geotiff']:
         return dataset_to_tiff(ds)
     if content_type in ['application/netcdf', 'application/x-netcdf']:

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -34,11 +34,12 @@ from .controllers import (
 )
 
 
-PATH_PREFIX= '/ogc'
+PATH_PREFIX = '/ogc'
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + '/collections/{collectionId}/coverage')
+@api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/')
 class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
     """
     Return coverage data
@@ -85,6 +86,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/domainset')
+@api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/domainset/')
 class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
     """
     Describe the domain set of a coverage
@@ -106,6 +108,7 @@ class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/rangetype')
+@api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/rangetype/')
 class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
     """
     Describe the range type of a coverage
@@ -127,6 +130,7 @@ class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
 
 
 @api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/metadata')
+@api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/metadata/')
 class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
     """
     Return coverage metadata
@@ -145,6 +149,7 @@ class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
 
 
 @api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/rangeset')
+@api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/rangeset/')
 class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
     """
     Handle rangeset endpoint with a "not supported" response

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -48,6 +48,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
     data (as opposed to metadata), as TIFF or NetCDF. It can also provide
     representations in HTML and JSON.
     """
+
     # noinspection PyPep8Naming
     @api.operation(
         operation_id='coveragesCoverage',
@@ -55,13 +56,23 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
     )
     async def get(self, collectionId: str):
         ds_ctx = self.ctx.datasets_ctx
+        # The single-component type specifiers aren't RFC2045-compliant,
+        #  but the OGC API - Coverages draft allows them in the f parameter.
+
         available_types = [
+            'png',
+            'image/png',
             'image/tiff',
             'application/x-geotiff',
-            'text/html',
-            'application/json',
+            'geotiff',
             'application/netcdf',
             'application/x-netcdf',
+            'netcdf',
+            'html',
+            'text/html',
+            'json',
+            'application/json',
+            # TODO: support covjson
         ]
         content_type = negotiate_content_type(self.request, available_types)
         if content_type is None:
@@ -71,8 +82,10 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
             )
         elif content_type == 'text/html':
             result = (
-                '<html><title>Collection</title><body><pre>\n' +
-                json.dumps(get_coverage_as_json(ds_ctx, collectionId), indent=2)
+                '<html><title>Collection</title><body><pre>\n'
+                + json.dumps(
+                    get_coverage_as_json(ds_ctx, collectionId), indent=2
+                )
                 + '\n</pre></body></html>'
             )
         elif content_type == 'application/json':
@@ -94,6 +107,7 @@ class CoveragesDomainsetHandler(ApiHandler[CoveragesContext]):
     The domain set is the set of input parameters (e.g. geographical extent,
     time span) for which the coverage is defined.
     """
+
     # noinspection PyPep8Naming
     @api.operation(
         operation_id='coveragesDomainSet',
@@ -117,6 +131,7 @@ class CoveragesRangetypeHandler(ApiHandler[CoveragesContext]):
     of this coverage. For a data cube, these would typically correspond to
     the types of the variables or bands.
     """
+
     # noinspection PyPep8Naming
     @api.operation(
         operation_id='coveragesRangeType',
@@ -137,6 +152,7 @@ class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
 
     The metadata is taken from the source dataset's attributes
     """
+
     # noinspection PyPep8Naming
     @api.operation(
         operation_id='coveragesMetadata',
@@ -159,6 +175,7 @@ class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
     but we handle it to make clear that its non-implementation is a deliberate
     decision.
     """
+
     # noinspection PyPep8Naming
     @api.operation(
         operation_id='coveragesRangeset',

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -87,7 +87,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
                 )
                 + '\n</pre></body></html>'
             )
-        elif content_type == {'application/json', 'json'}:
+        elif content_type in {'application/json', 'json'}:
             result = get_coverage_as_json(ds_ctx, collectionId)
         else:
             result = get_coverage_data(

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -56,9 +56,9 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
     )
     async def get(self, collectionId: str):
         ds_ctx = self.ctx.datasets_ctx
+
         # The single-component type specifiers aren't RFC2045-compliant,
         #  but the OGC API - Coverages draft allows them in the f parameter.
-
         available_types = [
             'png',
             'image/png',
@@ -79,7 +79,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
             raise ApiError.UnsupportedMediaType(
                 f'Available media types: {", ".join(available_types)}\n'
             )
-        elif content_type == 'text/html':
+        elif content_type in {'text/html', 'html'}:
             result = (
                 '<html><title>Collection</title><body><pre>\n'
                 + json.dumps(
@@ -87,7 +87,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
                 )
                 + '\n</pre></body></html>'
             )
-        elif content_type == 'application/json':
+        elif content_type == {'application/json', 'json'}:
             result = get_coverage_as_json(ds_ctx, collectionId)
         else:
             result = get_coverage_data(

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -22,7 +22,7 @@ import json
 import re
 from typing import Collection, Optional
 import fnmatch
-from xcube.server.api import ApiHandler, ApiRequest
+from xcube.server.api import ApiHandler, ApiRequest, ApiError
 from .api import api
 from .context import CoveragesContext
 from .controllers import (
@@ -76,8 +76,7 @@ class CoveragesCoverageHandler(ApiHandler[CoveragesContext]):
         ]
         content_type = negotiate_content_type(self.request, available_types)
         if content_type is None:
-            self.response.set_status(415)
-            return await self.response.finish(
+            raise ApiError.UnsupportedMediaType(
                 f'Available media types: {", ".join(available_types)}\n'
             )
         elif content_type == 'text/html':

--- a/xcube/webapi/ows/coverages/routes.py
+++ b/xcube/webapi/ows/coverages/routes.py
@@ -152,7 +152,7 @@ class CoveragesMetadataHandler(ApiHandler[CoveragesContext]):
 @api.route(PATH_PREFIX + '/collections/{collectionId}/coverage/rangeset/')
 class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
     """
-    Handle rangeset endpoint with a "not supported" response
+    Handle rangeset endpoint with a "not allowed" response
 
     This endpoint has been deprecated
     (see https://github.com/m-mohr/geodatacube-api/pull/1 ),
@@ -165,7 +165,8 @@ class CoveragesRangesetHandler(ApiHandler[CoveragesContext]):
         summary='OGC API - Coverages - rangeset',
     )
     async def get(self, collectionId: str):
-        self.response.set_status(501)
+        self.response.set_status(405)
+        self.response.set_header('Allow', '')  # no methods supported
         return self.response.finish(
             'The rangeset endpoint has been deprecated and is not supported.'
         )

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -86,6 +86,9 @@ def get_root(ctx: DatasetsContext, base_url: str):
     # Coverages endpoints along with its own.
     endpoint_lists = [a.endpoints() for a in ctx.apis
                       if a.name in {'ows.stac', 'ows.coverages'}]
+    endpoints = list(itertools.chain.from_iterable(endpoint_lists))
+    for endpoint in endpoints:
+        endpoint['path'] = endpoint['path'][len(PATH_PREFIX):]
 
     return {
         "type": "Catalog",
@@ -97,7 +100,7 @@ def get_root(ctx: DatasetsContext, base_url: str):
         "api_version": "1.0.0",
         "backend_version": xcube.__version__,
         "gdc_version": "1.0.0-beta",
-        "endpoints": list(itertools.chain.from_iterable(endpoint_lists)),
+        "endpoints": endpoints,
         "links": [
             _root_link(base_url),
             {

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -488,6 +488,13 @@ def _get_single_dataset_collection(
                         f'{dataset_id}/items/{DEFAULT_FEATURE_ID}',
                 'type': 'application/geo+json',
                 'title': f'Feature for the dataset "{dataset_id}"'
+            },
+            {
+                'rel': 'coverage',
+                'href': f'{base_url}{PATH_PREFIX}/collections/'
+                        f'{dataset_id}/coverage',
+                'title': f'Coverage for the dataset "{dataset_id}" using'
+                         f'OGC API – Coverages'
             }
         ],
         'providers': [],

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -96,7 +96,7 @@ def get_root(ctx: DatasetsContext, base_url: str):
         "description": c_description,
         "api_version": "1.0.0",
         "backend_version": xcube.__version__,
-        "gdc_version": "1.0.0-beta.1",
+        "gdc_version": "1.0.0-beta",
         "endpoints": list(itertools.chain.from_iterable(endpoint_lists)),
         "links": [
             _root_link(base_url),

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -477,6 +477,13 @@ def _get_single_dataset_collection(
                 'href': f'{base_url}{PATH_PREFIX}/collections/'
                         f'{dataset_id}/items',
                 'title': 'feature collection of data cube items'
+            },
+            {
+                'rel': 'item',
+                'href': f'{base_url}{PATH_PREFIX}/collections/'
+                        f'{dataset_id}/items/{DEFAULT_FEATURE_ID}',
+                'type': 'application/geo+json',
+                'title': f'Feature for the dataset "{dataset_id}"'
             }
         ],
         'providers': [],
@@ -529,7 +536,7 @@ def _get_dataset_feature(ctx: DatasetsContext,
         "stac_version": STAC_VERSION,
         "stac_extensions": STAC_EXTENSIONS,
         "type": "Feature",
-        "id": dataset_id,
+        "id": feature_id,
         "bbox": bbox.as_bbox(),
         "geometry": bbox.as_geometry(),
         "properties": _get_cube_properties(ctx, dataset_id),

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -490,7 +490,7 @@ def _get_single_dataset_collection(
                 'title': f'Feature for the dataset "{dataset_id}"'
             },
             {
-                'rel': 'coverage',
+                'rel': 'http://www.opengis.net/def/rel/ogc/1.0/coverage',
                 'href': f'{base_url}{PATH_PREFIX}/collections/'
                         f'{dataset_id}/coverage',
                 'title': f'Coverage for the dataset "{dataset_id}" using '

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -268,7 +268,7 @@ def get_datasets_collection_items(
     """
     _assert_valid_collection(ctx, collection_id)
     all_configs = ctx.get_dataset_configs()
-    configs = all_configs[cursor : (cursor + limit)]
+    configs = all_configs[cursor: (cursor + limit)]
     features = []
     for dataset_config in configs:
         dataset_id = dataset_config["Identifier"]
@@ -419,11 +419,15 @@ def _get_datasets_collection(ctx: DatasetsContext,
                 "href": f"{base_url}{PATH_PREFIX}/collections/{c_id}/items",
                 "title": "feature collection of data cube items"
             }
-            # {
-            #     "rel": "license",
-            #     "href": ctx.get_url("TODO"),
-            #     "title": "TODO"
-            # }
+        ] + [
+            {
+                'rel': 'item',
+                'href': f'{base_url}{PATH_PREFIX}/collections/'
+                        f'{DEFAULT_COLLECTION_ID}/items/{dataset_id}',
+                'type': 'application/geo+json',
+                'title': f'Feature for the dataset "{dataset_id}"'
+            } for dataset_id in
+            map(lambda c: c['Identifier'], ctx.get_dataset_configs())
         ]
     }
 

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -493,7 +493,7 @@ def _get_single_dataset_collection(
                 'rel': 'coverage',
                 'href': f'{base_url}{PATH_PREFIX}/collections/'
                         f'{dataset_id}/coverage',
-                'title': f'Coverage for the dataset "{dataset_id}" using'
+                'title': f'Coverage for the dataset "{dataset_id}" using '
                          f'OGC API – Coverages'
             }
         ],

--- a/xcube/webapi/ows/stac/routes.py
+++ b/xcube/webapi/ows/stac/routes.py
@@ -51,6 +51,7 @@ class CatalogRootHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + "/conformance")
+@api.route(PATH_PREFIX + "/conformance/")
 class CatalogConformanceHandler(ApiHandler[StacContext]):
     @api.operation(operation_id="getCatalogConformance",
                    summary="Get the STAC catalog's conformance.")
@@ -61,6 +62,7 @@ class CatalogConformanceHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + "/collections")
+@api.route(PATH_PREFIX + "/collections/")
 class CatalogCollectionsHandler(ApiHandler[StacContext]):
     @api.operation(operation_id="getCatalogCollections",
                    summary="Get the STAC catalog's collections.")
@@ -72,6 +74,7 @@ class CatalogCollectionsHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + "/collections/{collectionId}")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/")
 class CatalogCollectionHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(operation_id="getCatalogCollection",
@@ -85,6 +88,7 @@ class CatalogCollectionHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + "/collections/{collectionId}/items")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/items/")
 class CatalogCollectionItemsHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(operation_id="getCatalogCollectionItems",
@@ -113,6 +117,7 @@ class CatalogCollectionItemsHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + '/collections/{collectionId}/items/{featureId}')
+@api.route(PATH_PREFIX + '/collections/{collectionId}/items/{featureId}/')
 class CatalogCollectionItemHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(
@@ -133,6 +138,7 @@ class CatalogCollectionItemHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + "/search")
+@api.route(PATH_PREFIX + "/search/")
 class CatalogSearchHandler(ApiHandler[StacContext]):
 
     @api.operation(operation_id="searchCatalogByKeywords",
@@ -152,6 +158,7 @@ class CatalogSearchHandler(ApiHandler[StacContext]):
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
 @api.route(PATH_PREFIX + "/collections/{collectionId}/queryables")
+@api.route(PATH_PREFIX + "/collections/{collectionId}/queryables/")
 class QueryablesHandler(ApiHandler[StacContext]):
     # noinspection PyPep8Naming
     @api.operation(operation_id="searchCatalogByKeywords",

--- a/xcube/webapi/ows/stac/routes.py
+++ b/xcube/webapi/ows/stac/routes.py
@@ -38,7 +38,8 @@ from .config import (
 
 
 # noinspection PyAbstractClass,PyMethodMayBeStatic
-@api.route(PATH_PREFIX + "")
+@api.route(PATH_PREFIX)
+@api.route(PATH_PREFIX + "/")
 class CatalogRootHandler(ApiHandler[StacContext]):
     @api.operation(operation_id="getCatalogRoot",
                    summary="Get the STAC catalog's root.")


### PR DESCRIPTION
Fixes #900 .

- Fix incorrect feature ID in STAC dataset features (dataset ID was being used, which is wrong in single-dataset collections).
- Add a single "item" link (in addition to "items") to the single-dataset collection links. This is not required for a STAC collection, but is recommended by the STAC specification and is also implicitly expected by some PySTAC methods.
- Handle upper-case file extensions when guessing accessor type in `xcube.core.store.fs`
- Add an `UnsupportedMediaType` (HTTP 415) exception definition to the xcube API server.
- Support `subset` and `crs` parameters for the `coverage` endpoint.
- Support PNG format for OGC coverages.
- More reliable determination of dataset variable units when returning coverage metadata.
- Support trailing slashes in STAC and coverages endpoints.
- Add more aliases for supported coverages media types, as specified in OGC Data Cube API.
- Handle the deprecated coverages rangeset endpoint with a "not supported" response (405), which (per RFC 7231) seems more appropriate than the previous 501 code (which implied ‘erver does not recognize the request method’).
- STAC/OGC root endpoint: change `gdc_version` value from `1.0.0-beta.1` to `1.0.0-beta` rather ; the latter is mandated in the current OGC Data Cube API sepcification.
- Add a link to the coverage endpoint in the STAC collection response.
- In the STAC collection metadata, change the relation type of the `coverage` link from `coverage` to `http://www.opengis.net/def/rel/ogc/1.0/coverage`.
- In coverage subset specifications, parse non-time subset specifiers to numbers.
- In coverage bbox implementation, support x/y axis names as well as lat/lon.

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes (except for the usual random transient time-out errors)
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
