### PR TITLE
xcube-893: xcube cannot access geotiff datasets from public buckets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 
 ### Fixes
 * Resolved the issue for CRS84 error due to latest version of gdal (#869)
-
 * Fixed incorrect additional variable data in STAC datacube properties.
+* Fixed access of geotiff datasets from public s3 buckets (#893)
 
 ### Other changes
 * `update_dataset_attrs` can now also handle datasets with CRS other than 

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -376,8 +376,10 @@ class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
 
     @classmethod
     def create_env_session(cls, fs):
+        aws_unsigned = bool(fs.anon)
         if isinstance(fs, s3fs.S3FileSystem):
             aws_session = AWSSession(
+                aws_unsigned=aws_unsigned,
                 aws_secret_access_key=fs.secret,
                 aws_access_key_id=fs.key,
                 aws_session_token=fs.token,

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -376,8 +376,8 @@ class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
 
     @classmethod
     def create_env_session(cls, fs):
-        aws_unsigned = bool(fs.anon)
         if isinstance(fs, s3fs.S3FileSystem):
+            aws_unsigned = bool(fs.anon)
             aws_session = AWSSession(
                 aws_unsigned=aws_unsigned,
                 aws_secret_access_key=fs.secret,
@@ -389,10 +389,9 @@ class DatasetGeoTiffFsDataAccessor(DatasetFsDataAccessor):
                 ),
             )
             return rasterio.env.Env(session=aws_session,
-                                    aws_no_sign_request=bool(fs.anon)
+                                    aws_no_sign_request=aws_unsigned
                                     )
-        else:
-            return rasterio.env.NullContextManager()
+        return rasterio.env.NullContextManager()
 
     @classmethod
     def open_dataset_with_rioxarray(cls, file_path, overview_level,


### PR DESCRIPTION
Fixes #893.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
