### PR TITLE
updated xcube GH workflow to build docker image only during releases

### DIFF
--- a/.github/workflows/xcube_workflow.yaml
+++ b/.github/workflows/xcube_workflow.yaml
@@ -62,16 +62,19 @@ jobs:
         run: |
           echo "TAG: ${{ steps.release.outputs.tag }}"
           echo "EVENT: ${{ github.event_name }}"
+      # commented out the below step to avoid building docker image for each
+      # commit to master, rather build and push the xcube docker image only on
+      # event type release
       # Build and push docker image 'latest' to quay.io when the event is a 'push' and branch 'master'
-      - uses: mr-smithers-excellent/docker-build-push@v5
-        name: build-push-docker-image-latest
-        if: ${{ github.event_name == 'push' && steps.release.outputs.tag == 'master'  }}
-        with:
-          image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}
-          tags: master, latest
-          registry: ${{ env.IMG_REG_NAME }}
-          username: ${{ secrets.IMG_REG_USERNAME }}
-          password: ${{ secrets.IMG_REG_PASSWORD }}
+#      - uses: mr-smithers-excellent/docker-build-push@v5
+#        name: build-push-docker-image-latest
+#        if: ${{ github.event_name == 'push' && steps.release.outputs.tag == 'master'  }}
+#        with:
+#          image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}
+#          tags: master, latest
+#          registry: ${{ env.IMG_REG_NAME }}
+#          username: ${{ secrets.IMG_REG_USERNAME }}
+#          password: ${{ secrets.IMG_REG_PASSWORD }}
       # Build and push docker release to quay.io when the event is a 'release'
       - uses: mr-smithers-excellent/docker-build-push@v5
         name: build-push-docker-image-release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 * removed deprecated module xcube edit, which has been deprecated since 
   version 0.13.0
 * Update "Development process" section of developer guide.
+* Updated GitHub workflow to build docker image for GitHub releases only and 
+  not on each commit to master.
 
 ## Changes in 1.2.0
 


### PR DESCRIPTION
[Description of PR]

This PR updates xcube GH workflow to build docker image only during releases and disables docker image build and push for each commit to master

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
