### PR TITLE
new workflow to build and push docker image

### DIFF
--- a/.github/workflows/xcube_build_docker.yaml
+++ b/.github/workflows/xcube_build_docker.yaml
@@ -1,0 +1,37 @@
+name: xcube docker build
+
+on:
+  workflow_dispatch:
+
+env:
+  APP_NAME: xcube
+  ORG_NAME: bcdev
+  IMG_REG_NAME: quay.io
+
+jobs:
+  build-docker-image-and-push:
+    runs-on: ubuntu-latest
+    # Build the docker image and push to quay.io
+    name: build-docker-image
+    steps:
+      - name: git-checkout
+        uses: actions/checkout@v2
+      # Determine release tag from git ref
+      - name: get-release-tag
+        id: release
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      # Print some info
+      - name: info
+        id: info
+        run: |
+          echo "TAG: ${{ steps.release.outputs.tag }}"
+          echo "EVENT: ${{ github.event_name }}"
+      # Build and push docker release to quay.io
+      - name: push-docker-image-with-release-tag
+        uses: mr-smithers-excellent/docker-build-push@v5
+        with:
+          image: ${{ env.ORG_NAME }}/${{ env.APP_NAME }}
+          tags: ${{ steps.release.outputs.tag }}
+          registry: ${{ env.IMG_REG_NAME }}
+          username: ${{ secrets.IMG_REG_USERNAME }}
+          password: ${{ secrets.IMG_REG_PASSWORD }}


### PR DESCRIPTION
[Description of PR]

This PR introduces a new workflow which builds and pushes a new xcube docker image. This is a workaround for the timeout errors in unit test which blocks us from making a release.

Checklist:

~* [ ] Add unit tests and/or doctests in docstrings~
~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] New/modified features documented in `docs/source/*`~
* [ ] Changes documented in `CHANGES.md`
~* [ ] GitHub CI passes~
~* [ ] AppVeyor CI passes~
~* [ ] Test coverage remains or increases (target 100%)~
