### PR TITLE
adjusted tests to fsspec > 2023.10.0

### DIFF
--- a/xcube/core/byoa/fileset.py
+++ b/xcube/core/byoa/fileset.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, Optional, List, Collection, Iterator, Union
 
 import fsspec
 import fsspec.implementations.zip
+from fsspec.implementations.local import LocalFileSystem
 
 from xcube.core.byoa.constants import TEMP_FILE_PREFIX
 from xcube.util.assertions import assert_given
@@ -66,7 +67,9 @@ class _FileSetDetails:
                                              **(storage_params or {}))
         except (ImportError, OSError) as e:
             raise ValueError(f'Illegal file set {path!r}') from e
-        local_path = root if fs.protocol == 'file' else None
+        local_path = root \
+            if 'file' in fs.protocol or isinstance(fs, LocalFileSystem) \
+            else None
         return _FileSetDetails(fs, root, local_path)
 
     @property

--- a/xcube/util/fspath.py
+++ b/xcube/util/fspath.py
@@ -30,7 +30,7 @@ def is_local_fs(fs: fsspec.AbstractFileSystem) -> bool:
     """
     Check whether *fs* is a local filesystem.
     """
-    return fs.protocol == 'file' or isinstance(fs, LocalFileSystem)
+    return 'file' in fs.protocol or isinstance(fs, LocalFileSystem)
 
 
 def get_fs_path_class(fs: fsspec.AbstractFileSystem) \


### PR DESCRIPTION
Fixes tests. The tests failed because in the latest version of fsspec (2023.10.0), the localfilesystem returns a tuple of protocols, not a string, causing queries in xcube to fail.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
