### PR TITLE
install rasterio explicitly as a workaround to fix the missing rasterio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cmems ${XCUBE_CMEMS_VERSION} release; fi;
 
 # TODO: Investigate the missing rasterio in the docker build and delete the below workaround
-# install raterio explicitly as a workaround
+# Install rasterio explicitly as a workaround
 RUN micromamba install rasterio>=1.2 -c conda-forge
 
 RUN micromamba clean --all --force-pkgs-dirs --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,13 @@ RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cci ${XCUBE_CCI_VERSION} release; fi;
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cds ${XCUBE_CDS_VERSION} release; fi;
 RUN if [[ ${INSTALL_PLUGINS} == '1' ]]; then bash install-xcube-plugin.sh xcube-cmems ${XCUBE_CMEMS_VERSION} release; fi;
+
+# TODO: Investigate the missing rasterio in the docker build and delete the below workaround
+# install raterio explicitly as a workaround
+RUN micromamba install rasterio>=1.2 -c conda-forge
+
 RUN micromamba clean --all --force-pkgs-dirs --yes
+
 WORKDIR /home/$MAMBA_USER
 
 # The micromamba entrypoint.


### PR DESCRIPTION
[Description of PR]

install rasterio explicitly as a workaround to fix the missing rasterio issue in xcube docker image

Checklist:

~* [ ] Add unit tests and/or doctests in docstrings~
~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] New/modified features documented in `docs/source/*`~
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
