### PR TITLE
fixing GitHub CI #899

### DIFF
--- a/xcube/server/testing.py
+++ b/xcube/server/testing.py
@@ -23,6 +23,7 @@ import asyncio
 import json
 import socket
 import threading
+import time
 import unittest
 from abc import ABC
 from contextlib import closing
@@ -64,6 +65,14 @@ class ServerTestCase(unittest.TestCase, ABC):
         tornado.start()
 
         self.http = urllib3.PoolManager()
+
+        while True:
+            # noinspection PyBroadException
+            try:
+                self.fetch('/')
+                break
+            except Exception:
+                time.sleep(0.1)
 
     def tearDown(self) -> None:
         self.server.stop()

--- a/xcube/server/testing.py
+++ b/xcube/server/testing.py
@@ -69,18 +69,12 @@ class ServerTestCase(unittest.TestCase, ABC):
 
         # Taking care that server is fully started until tests make requests.
         # Fixing https://github.com/dcs4cop/xcube/issues/899
-        elapsed_time = 0.0
         while True:
-            if elapsed_time > 60:
-                self.fail('Server did not respond after one minute. '
-                          'Failing the test.')
             try:
                 self.fetch('/')
                 break
             except (MaxRetryError, TimeoutError):
-                sleep_time = 0.1
-                time.sleep(sleep_time)
-                elapsed_time += sleep_time
+                time.sleep(0.1)
 
     def tearDown(self) -> None:
         self.server.stop()

--- a/xcube/server/testing.py
+++ b/xcube/server/testing.py
@@ -67,7 +67,7 @@ class ServerTestCase(unittest.TestCase, ABC):
 
         self.http = urllib3.PoolManager()
 
-        # Taking care that server is fully started until tests make requests.
+        # Taking care that server is fully started before tests make requests.
         # Fixing https://github.com/dcs4cop/xcube/issues/899
         while True:
             try:


### PR DESCRIPTION
This PR fixes #899. The reason for the test failures in GitHub has been a race condition: the server starts in the background, and on another thread, the tests use it. The fix ensured that the server has started before the setUp() method terminates.

The checklist items below do not apply mostly, as there are no new features to be documented.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [ ] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
