### PR TITLE
Bump minimum Python version from 3.8 to 3.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@
   * Set Content-Bbox and Content-Crs headers in the HTTP response
   * Support safe CURIE syntax for CRS specification
 
+### Other changes
+
+* Require Python >=3.9 (previously >=3.8)
+
 ## Changes in 1.3.1
 
 * Updated Dockerfile and GitHub workflows; no changes to the xcube codebase

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # Python
-  - python >=3.8
+  - python >=3.9
   # Required
   - adlfs >=2023.1  # for azure blob filesystem
   - affine >=2.2

--- a/rtd-environment.yml
+++ b/rtd-environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # Python
-  - python >=3.8
+  - python >=3.9
   # Required
   - adlfs >=2023.1  # for azure blob filesystem
   - affine >=2.2


### PR DESCRIPTION
Fixes #920.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
