### PR TITLE
Update tests to work with moto 5.0.0 and pytest 8.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 ### Fixes
 
 * Make S3 unit tests compatible with moto 5 server (#922)
+* Make some CLI unit tests compatible with pytest 8 (#922)
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@
   * Set Content-Bbox and Content-Crs headers in the HTTP response
   * Support safe CURIE syntax for CRS specification
 
+### Fixes
+
+* Make S3 unit tests compatible with moto 5 server (#922)
+
 ### Other changes
 
 * Require Python >=3.9 (previously >=3.8)

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -16,19 +16,25 @@ class ClickMainTest(CliTest):
         @command(name='test_warnings')
         def test_warnings():
             warnings.warn(self.USER_WARNING_MESSAGE)
-            warnings.warn(self.DEPRECATION_WARNING_MESSAGE, category=DeprecationWarning)
-            warnings.warn(self.RUNTIME_WARNING_MESSAGE, category=RuntimeWarning)
+            warnings.warn(
+                self.DEPRECATION_WARNING_MESSAGE, category=DeprecationWarning
+            )
+            warnings.warn(
+                self.RUNTIME_WARNING_MESSAGE, category=RuntimeWarning
+            )
 
         xcube.cli.main.cli.add_command(test_warnings)
 
     def test_warnings_not_issued_by_default(self):
-        with pytest.warns(None) as record:
+        with pytest.warns(UserWarning) as record:
             self.invoke_cli(['test_warnings'])
         self.assertEqual(['This is a user warning.'],
                          list(map(lambda r: str(r.message), record.list)))
 
     def test_warnings_issued_when_enabled(self):
-        with pytest.warns(None) as record:
+        with pytest.warns(
+            (UserWarning, DeprecationWarning, RuntimeWarning)
+        ) as record:
             self.invoke_cli(['--warnings', 'test_warnings'])
         self.assertEqual(['This is a user warning.',
                           'This is a deprecation warning.',

--- a/test/s3test.py
+++ b/test/s3test.py
@@ -12,7 +12,7 @@ import moto.server
 MOTO_SERVER_ENDPOINT_URL = f'http://127.0.0.1:5000'
 
 MOTOSERVER_PATH = moto.server.__file__
-MOTOSERVER_ARGS = [sys.executable, MOTOSERVER_PATH, 's3']
+MOTOSERVER_ARGS = [sys.executable, MOTOSERVER_PATH]
 
 
 class S3Test(unittest.TestCase):


### PR DESCRIPTION
Closes #922.

- Omit "s3" argument when starting moto server: moto 5 no longer supports the service argument, and it is not needed.
- Specify expected warnings explicitly in `pytest.warns` usages in `test_main`, since former `None` argument is no longer supported in pytest 8.0.0.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
