### PR TITLE
Data stores can now return data iterators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ### Enhancements
 
+* Data stores can now return _data iterators_ from their `open_data()` method. 
+  For example, a data store implementation can now return a data cube either 
+  with a time dimension of size 100, or could be asked to return 100 cube 
+  time slices with dimension size 1 in form of an iterator. 
+  This feature has been added to effectively support the new 
+  [zappend](https://github.com/bcdev/zappend) tool. (#919) 
+
 ### Fixes
 
 ### Other changes

--- a/test/core/store/test_datatype.py
+++ b/test/core/store/test_datatype.py
@@ -5,11 +5,16 @@ import geopandas
 import xarray
 
 from xcube.core.mldataset import MultiLevelDataset
-from xcube.core.store.datatype import ANY_TYPE, DataTypeLike
+from xcube.core.store.datatype import ANY_TYPE
 from xcube.core.store.datatype import DATASET_TYPE
+from xcube.core.store.datatype import DATASET_ITERATOR_TYPE
+from xcube.core.store.datatype import DataIterator
 from xcube.core.store.datatype import DataType
+from xcube.core.store.datatype import DataTypeLike
 from xcube.core.store.datatype import GEO_DATA_FRAME_TYPE
+from xcube.core.store.datatype import GEO_DATA_FRAME_ITERATOR_TYPE
 from xcube.core.store.datatype import MULTI_LEVEL_DATASET_TYPE
+from xcube.core.store.datatype import MULTI_LEVEL_DATASET_ITERATOR_TYPE
 from xcube.util.jsonschema import JsonStringSchema
 
 
@@ -27,87 +32,133 @@ class C:
 
 class DataTypeTest(unittest.TestCase):
     def test_normalize_to_any(self):
-        self.assertNormalizeOk('any',
-                               ANY_TYPE,
-                               object,
-                               'any',
-                               ('any', '*', 'object', 'builtins.object'))
-        self.assertNormalizeOk(None,
-                               ANY_TYPE,
-                               object,
-                               'any',
-                               ('any', '*', 'object', 'builtins.object'))
-        self.assertNormalizeOk(type(None),
-                               ANY_TYPE,
-                               object,
-                               'any',
-                               ('any', '*', 'object', 'builtins.object'))
+        self.assertNormalizeOk(
+            "any", ANY_TYPE, object, "any", ("any", "*", "object", "builtins.object")
+        )
+        self.assertNormalizeOk(
+            None, ANY_TYPE, object, "any", ("any", "*", "object", "builtins.object")
+        )
+        self.assertNormalizeOk(
+            type(None),
+            ANY_TYPE,
+            object,
+            "any",
+            ("any", "*", "object", "builtins.object"),
+        )
 
     def test_normalize_to_dataset(self):
-        self.assertNormalizeOk('dataset',
-                               DATASET_TYPE,
-                               xarray.Dataset,
-                               'dataset',
-                               ('dataset',
-                                'xarray.Dataset',
-                                'xarray.core.dataset.Dataset'))
+        self.assertNormalizeOk(
+            "dataset",
+            DATASET_TYPE,
+            xarray.Dataset,
+            "dataset",
+            ("dataset", "xarray.Dataset", "xarray.core.dataset.Dataset"),
+        )
 
     def test_normalize_to_mldataset(self):
-        self.assertNormalizeOk('mldataset',
-                               MULTI_LEVEL_DATASET_TYPE,
-                               MultiLevelDataset,
-                               'mldataset',
-                               ('mldataset',
-                                'xcube.MultiLevelDataset',
-                                'xcube.core.mldataset.MultiLevelDataset',
-                                'xcube.core.mldataset.abc.MultiLevelDataset'))
+        self.assertNormalizeOk(
+            "mldataset",
+            MULTI_LEVEL_DATASET_TYPE,
+            MultiLevelDataset,
+            "mldataset",
+            (
+                "mldataset",
+                "xcube.MultiLevelDataset",
+                "xcube.core.mldataset.MultiLevelDataset",
+                "xcube.core.mldataset.abc.MultiLevelDataset",
+            ),
+        )
 
     def test_normalize_to_geodataframe(self):
-        self.assertNormalizeOk('geodataframe',
-                               GEO_DATA_FRAME_TYPE,
-                               geopandas.GeoDataFrame,
-                               'geodataframe',
-                               ('geodataframe',
-                                'geopandas.GeoDataFrame',
-                                'geopandas.geodataframe.GeoDataFrame'))
+        self.assertNormalizeOk(
+            "geodataframe",
+            GEO_DATA_FRAME_TYPE,
+            geopandas.GeoDataFrame,
+            "geodataframe",
+            (
+                "geodataframe",
+                "geopandas.GeoDataFrame",
+                "geopandas.geodataframe.GeoDataFrame",
+            ),
+        )
 
-    def assertNormalizeOk(self,
-                          data_type: DataTypeLike,
-                          expected_data_type,
-                          expected_dtype,
-                          expected_alias,
-                          expected_aliases):
+    def test_normalize_to_dataset_iterator(self):
+        self.assertNormalizeOk(
+            "dsiter",
+            DATASET_ITERATOR_TYPE,
+            DataIterator,
+            "dsiter",
+            (
+                "dsiter",
+                "DataIterator[xarray.Dataset]",
+                "xcube.core.store.datatype.DataIterator",
+            ),
+        )
+
+    def test_normalize_to_ml_dataset_iterator(self):
+        self.assertNormalizeOk(
+            "mldsiter",
+            MULTI_LEVEL_DATASET_ITERATOR_TYPE,
+            DataIterator,
+            "mldsiter",
+            (
+                "mldsiter",
+                "DataIterator[xcube.MultiLevelDataset]",
+                "xcube.core.store.datatype.DataIterator",
+            ),
+        )
+
+    def test_normalize_to_gdf_iterator(self):
+        self.assertNormalizeOk(
+            "gdfiter",
+            GEO_DATA_FRAME_ITERATOR_TYPE,
+            DataIterator,
+            "gdfiter",
+            (
+                "gdfiter",
+                "DataIterator[geopandas.GeoDataFrame]",
+                "xcube.core.store.datatype.DataIterator",
+            ),
+        )
+
+    def assertNormalizeOk(
+        self,
+        data_type: DataTypeLike,
+        expected_data_type,
+        expected_dtype,
+        expected_alias,
+        expected_aliases,
+    ):
         data_type = DataType.normalize(data_type)
         self.assertIs(expected_data_type, data_type)
         self.assertIs(expected_dtype, data_type.dtype)
         self.assertEqual(expected_alias, data_type.alias)
         self.assertEqual(expected_alias, str(data_type))
-        self.assertEqual(f'{expected_alias!r}', repr(data_type))
+        self.assertEqual(f"{expected_alias!r}", repr(data_type))
         self.assertEqual(expected_aliases, data_type.aliases)
-        for other_alias in data_type.aliases:
-            self.assertIs(data_type,
-                          DataType.normalize(other_alias))
-        self.assertIs(expected_data_type,
-                      DataType.normalize(expected_dtype))
-        self.assertIs(expected_data_type,
-                      DataType.normalize(expected_data_type))
+        self.assertIs(expected_data_type, DataType.normalize(expected_data_type))
+        # The following tests are not applicable to iterators,
+        # because iterators are not (cannot be) forced to have
+        # a specific item type.
+        if data_type.dtype is not DataIterator:
+            for other_alias in data_type.aliases:
+                self.assertIs(data_type, DataType.normalize(other_alias))
+            self.assertIs(expected_data_type, DataType.normalize(expected_dtype))
 
     def test_normalize_non_default_types(self):
         data_type = DataType.normalize(str)
         self.assertIs(str, data_type.dtype)
-        self.assertEqual('builtins.str', data_type.alias)
+        self.assertEqual("builtins.str", data_type.alias)
 
     def test_normalize_failure(self):
         with self.assertRaises(ValueError) as cm:
-            DataType.normalize('Gnartz')
-        self.assertEqual("unknown data type 'Gnartz'",
-                         f'{cm.exception}')
+            DataType.normalize("Gnartz")
+        self.assertEqual("unknown data type 'Gnartz'", f"{cm.exception}")
 
         with self.assertRaises(ValueError) as cm:
             # noinspection PyTypeChecker
             DataType.normalize(42)
-        self.assertEqual("cannot convert 42 into a data type",
-                         f'{cm.exception}')
+        self.assertEqual("cannot convert 42 into a data type", f"{cm.exception}")
 
     def test_equality(self):
         self.assertIs(DATASET_TYPE, DATASET_TYPE)

--- a/xcube/core/store/datatype.py
+++ b/xcube/core/store/datatype.py
@@ -20,8 +20,9 @@
 # SOFTWARE.
 
 import os
+from abc import ABC, abstractmethod
 
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, Iterator, Generic, TypeVar, Any
 from typing import Type, List
 from typing import Union
 
@@ -33,7 +34,7 @@ from xcube.util.assertions import assert_instance
 from xcube.util.jsonschema import JsonStringSchema
 
 # A data type name or a DataType
-DataTypeLike = Union[str, None, type, 'DataType']
+DataTypeLike = Union[str, None, type, "DataType"]
 
 
 class DataType:
@@ -45,46 +46,40 @@ class DataType:
     to the Python data type ``xarray.Dataset```.
     """
 
-    _READTHEDOCS = os.environ.get("READTHEDOCS") == 'True'
-    _REGISTERED_DATA_TYPES: List['DataType'] = []
+    _READTHEDOCS = os.environ.get("READTHEDOCS") == "True"
+    _REGISTERED_DATA_TYPES: List["DataType"] = []
 
     @classmethod
-    def register_data_type(cls, data_type: 'DataType'):
-        assert_instance(data_type, DataType, name='data_type')
+    def register_data_type(cls, data_type: "DataType"):
+        assert_instance(data_type, DataType, name="data_type")
         cls._REGISTERED_DATA_TYPES.append(data_type)
 
-    def __init__(self,
-                 dtype: Type,
-                 alias: Union[None, str, Sequence[str]] = None):
+    def __init__(self, dtype: Type, alias: Union[None, str, Sequence[str]] = None):
         """
         :param dtype: The Python data type.
         :param alias: An alias name or list of aliases.
         """
-        assert_instance(dtype,
-                        type if not self._READTHEDOCS else object,
-                        name='dtype')
+        assert_instance(dtype, type if not self._READTHEDOCS else object, name="dtype")
         if alias is not None:
-            assert_instance(alias, (str, tuple, list), name='alias')
+            assert_instance(alias, (str, tuple, list), name="alias")
         self._dtype = dtype
         self._aliases = (
-                ([] if alias is None else
-                 [alias] if isinstance(alias, str) else
-                 list(alias))
-                + [self._get_fully_qualified_type_name(dtype)]
-        )
+            [] if alias is None else [alias] if isinstance(alias, str) else list(alias)
+        ) + [self._get_fully_qualified_type_name(dtype)]
         self._alias_set = set(self._aliases)  # for faster lookup
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.alias
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.alias)
 
-    def __eq__(self, other):
-        return self is other \
-               or (isinstance(other, DataType)
-                   and self.dtype is other.dtype
-                   and self.aliases == other.aliases)
+    def __eq__(self, other: Any):
+        return self is other or (
+            isinstance(other, DataType)
+            and self.dtype is other.dtype
+            and self.aliases == other.aliases
+        )
 
     def __hash__(self):
         return hash(self.dtype) + 16 * hash(self.aliases)
@@ -100,12 +95,12 @@ class DataType:
         return self._aliases[0]
 
     @property
-    def aliases(self) -> Tuple[str]:
+    def aliases(self) -> Tuple[str, ...]:
         """All alias names."""
         return tuple(self._aliases)
 
     @classmethod
-    def normalize(cls, data_type: DataTypeLike) -> 'DataType':
+    def normalize(cls, data_type: DataTypeLike) -> "DataType":
         """
         Normalize the given *data_type* value into
         an instance of :class:DataType.
@@ -122,13 +117,13 @@ class DataType:
             for dt in cls._REGISTERED_DATA_TYPES:
                 if data_type in dt._alias_set:
                     return dt
-            raise ValueError(f'unknown data type {data_type!r}')
+            raise ValueError(f"unknown data type {data_type!r}")
         if isinstance(data_type, type):
             for dt in cls._REGISTERED_DATA_TYPES:
                 if data_type is dt.dtype:
                     return dt
             return DataType(data_type)
-        raise ValueError(f'cannot convert {data_type!r} into a data type')
+        raise ValueError(f"cannot convert {data_type!r} into a data type")
 
     def is_sub_type_of(self, data_type: DataTypeLike) -> bool:
         """
@@ -139,8 +134,7 @@ class DataType:
             alias name, as a type, or as a DataType instance.
         :return: Whether this data type satisfies another data type.
         """
-        return issubclass(self.dtype,
-                          self._normalize_dtype(data_type))
+        return issubclass(self.dtype, self._normalize_dtype(data_type))
 
     def is_super_type_of(self, data_type: DataTypeLike) -> bool:
         """
@@ -151,17 +145,12 @@ class DataType:
             alias name, as a type, or as a DataType instance.
         :return: Whether this data type satisfies another data type.
         """
-        return issubclass(self._normalize_dtype(data_type),
-                          self.dtype)
+        return issubclass(self._normalize_dtype(data_type), self.dtype)
 
     @classmethod
     def get_schema(cls) -> JsonStringSchema:
         """Get the JSON Schema."""
-        return JsonStringSchema(
-            min_length=1,
-            factory=cls.normalize,
-            serializer=str
-        )
+        return JsonStringSchema(min_length=1, factory=cls.normalize, serializer=str)
 
     @classmethod
     def _normalize_dtype(cls, data_type: DataTypeLike) -> Type:
@@ -173,29 +162,52 @@ class DataType:
 
     @staticmethod
     def _get_fully_qualified_type_name(data_type: Type) -> str:
-        return f'{data_type.__module__}.{data_type.__name__}'
+        return f"{data_type.__module__}.{data_type.__name__}"
 
 
-ANY_TYPE = DataType(
-    object,
-    ['any', '*', 'object']
-)
+T = TypeVar("T")
 
-DATASET_TYPE = DataType(
-    xarray.Dataset,
-    ['dataset', 'xarray.Dataset']
+
+class DataIterator(Generic[T], Iterator[T], ABC):
+    """An iterator for data items.
+    This class is a marker type for data stores that can return data iterators
+    from their ``open_data()`` method.
+    Data stores that support data iterators are not required to yield
+    instances of this class. They just have to return iterator objects
+    that yield instances of the desired item type, e.g. ``xarray.Dataset``.
+    """
+
+    @abstractmethod
+    def __next__(self) -> T:
+        """Yield the next data item."""
+
+
+ANY_TYPE = DataType(object, ["any", "*", "object"])
+
+DATASET_TYPE = DataType(xarray.Dataset, ["dataset", "xarray.Dataset"])
+
+DATASET_ITERATOR_TYPE = DataType(
+    DataIterator,  # Unfortunately we cannot use DataIterator[xarray.Dataset]
+    ["dsiter", "DataIterator[xarray.Dataset]"],
 )
 
 MULTI_LEVEL_DATASET_TYPE = DataType(
     MultiLevelDataset,
-    ['mldataset',
-     'xcube.MultiLevelDataset',
-     'xcube.core.mldataset.MultiLevelDataset']
+    ["mldataset", "xcube.MultiLevelDataset", "xcube.core.mldataset.MultiLevelDataset"],
+)
+
+MULTI_LEVEL_DATASET_ITERATOR_TYPE = DataType(
+    DataIterator,  # Unfortunately we cannot use DataIterator[MultiLevelDataset]
+    ["mldsiter", "DataIterator[xcube.MultiLevelDataset]"],
 )
 
 GEO_DATA_FRAME_TYPE = DataType(
-    geopandas.GeoDataFrame,
-    ['geodataframe', 'geopandas.GeoDataFrame']
+    geopandas.GeoDataFrame, ["geodataframe", "geopandas.GeoDataFrame"]
+)
+
+GEO_DATA_FRAME_ITERATOR_TYPE = DataType(
+    DataIterator,  # Unfortunately we cannot use DataIterator[GeoDataFrame]
+    ["gdfiter", "DataIterator[geopandas.GeoDataFrame]"],
 )
 
 
@@ -203,8 +215,11 @@ def register_default_data_types():
     for data_type in [
         ANY_TYPE,
         DATASET_TYPE,
+        DATASET_ITERATOR_TYPE,
         MULTI_LEVEL_DATASET_TYPE,
+        MULTI_LEVEL_DATASET_ITERATOR_TYPE,
         GEO_DATA_FRAME_TYPE,
+        GEO_DATA_FRAME_ITERATOR_TYPE,
     ]:
         DataType.register_data_type(data_type)
 


### PR DESCRIPTION
Data stores can now return _data iterators_ from their `open_data()` method. 

For example, a data store implementation can now return a data cube either with a time dimension of size 100, or could be asked to return 100 cube time slices with dimension size 1 in form of an iterator. This feature has been added to effectively support the new [zappend](https://github.com/bcdev/zappend) tool.

Closes #919 

Checklist:

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
