### PR TITLE
Added tileLevelMin/Max and colormap details to STAC xcube:data_vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,28 @@
 ## Changes in 1.4.1 (in development)
 
 ### Enhancements
+* Improved xcube Server's STAC API:
+  * Added the `tileLevelMin`, `tileLevelMax`, `colorBarName`, `colorBarMax` and `colorBarMin` attributes to the `xcube:data_vars` property returned in a STAC item JSON schema of a dataset's data
+  variables.
+  * The `xcube:data_vars` in a STAC item will display the following example:
+   
+   ```json
+    "xcube:data_vars": [
+                    {
+                    "name": "gpp",
+                    "dtype": "float32",
+                    "dims": [],
+                    "chunks": [],
+                    "shape": [],
+                    "attrs": {},
+                    "tileLevelMax": 11, 
+                    "tileLevelMin": 10,
+                    "colorBarName": "bwr",
+                    "colorBarMax": 0,
+                    "colorBarMin": 20
+                    }
+                  ]
+  ```
 
 ### Fixes
 


### PR DESCRIPTION
[Description of PR]
Currently, our web visualisation development team have been using the `/datasets` endpoint from the xcube server API which provides `tileLevelMin`, `tileLevelMax`, `colorBarName`, `colorBarMax` and `colorBarMin` per data variable as part of the JSON output. We are however changing to `ows.stac` via the` /ogc` endpoint because it's faster, but the STAC JSON output does not provide the above-listed attributes.

What I have done here is to use the `DatasetsContext` to derive the tiling scheme and get the colormap details using `derive_tiling_scheme()` and `get_color_mapping()` in `xcube/webapi/ows/stac/controllers.py` so the `xcube:data_vars` in the STAC item JSON output will return the additional variables like `tileLevelMin`, `tileLevelMax`, `colorBarName`, `colorBarMax` and `colorBarMin`.

To keep the structure of `xcube:coords` in the cube properties, I renamed the method for generating it to `_get_xc_coordinates` and kept the `_get_xc_variables` for the `xcube:data_vars`.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `xcube/webapi/ows/stac/controllers.py`
* [x] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
