### PR TITLE
Update AppVeyor Ubuntu configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: '{build}'
 
 image:
+  - Ubuntu2204
   - macos
-  - Ubuntu2004
 
 configuration: Release
 
@@ -26,7 +26,7 @@ for:
 -
   matrix:
     only:
-      - image: Ubuntu2004
+      - image: Ubuntu2204
   install:
     - wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
 
@@ -42,7 +42,7 @@ build_script:
   # Set up micromamba
   - ./micromamba shell init -s bash -p ~/micromamba
   - source ~/.bashrc
-  - source ~/.bash_profile
+  - source ~/.profile
   - hash -r
   - mkdir -p ~/micromamba/pkgs/
   - export MAMBA_ROOT_PREFIX=~/micromamba


### PR DESCRIPTION
Fixes #942.

- Update Ubuntu image from 20.04 to 22.04.

- When setting up environment, source ~/.profile rather than the now non-existent ~/.bash_profile.

- Re-order images with Ubuntu first (speeds up testing of these changes).

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~ n/a
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~ n/a
* ~[ ] New/modified features documented in `docs/source/*`~ n/a
* ~[ ] Changes documented in `CHANGES.md`~ n/a
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
