### PR TITLE
Title added to preload table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 
 * Renamed [xrlint]() config file from `xrlint_config.yaml` to `xrlint-config.yaml`.
 
+* The title "Preload Datasets" has been added to the preload visualization table 
+
 ## Changes in 1.8.3
 
 ### Enhancements

--- a/xcube/core/store/preload.py
+++ b/xcube/core/store/preload.py
@@ -323,6 +323,9 @@ class ExecutorPreloadHandle(PreloadHandle):
             self.close()
 
 
+_TITLE = "Preload Datasets"
+
+
 class PreloadDisplay(ABC):
     @classmethod
     def create(
@@ -348,10 +351,11 @@ class PreloadDisplay(ABC):
         return self.to_html()
 
     def to_text(self) -> str:
-        return self.tabulate(table_format="simple")
+        return f"{_TITLE}\n" + self.tabulate(table_format="simple")
 
     def to_html(self) -> str:
-        return self.tabulate(table_format="html")
+        title = f"<b style='font-size: 20px;'>{_TITLE}</b>"
+        return title + self.tabulate(table_format="html")
 
     def tabulate(self, table_format: str = "simple") -> str:
         """Generate HTML table from job list."""


### PR DESCRIPTION
The title "Preload Datasets" has been added to the preload visualization table. 

![Screenshot from 2025-03-13 14-07-55](https://github.com/user-attachments/assets/9c8c223e-f481-4a05-9c05-92dfe8dd2903)


Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [ ] Changes documented in `CHANGES.md`
* [ ] GitHub CI passes
* [ ] AppVeyor CI passes
* [ ] Test coverage remains or increases (target 100%)
