### PR TITLE
Fix endpoint url in STAC item's asset published by xcube server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,11 @@
 
 * Added two new versions of the xcube logo, one for dark and one for light themes,
   and replaced the logo in the documentation with the light logo.
+
+### Fixes
+
+* Fix STAC item asset endpoint_url (was incorrectly set to http://localhost:8080/s3; 
+  now correctly parsed from the base URL). (#1178)
   
 
 ## Changes in 1.11.1

--- a/xcube/webapi/ows/stac/controllers.py
+++ b/xcube/webapi/ows/stac/controllers.py
@@ -900,7 +900,7 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
                 "root": "datasets",
                 "storage_options": {
                     "anon": True,
-                    "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
+                    "client_kwargs": {"endpoint_url": f"{base_url}/s3"},
                 },
             },
             "xcube:open_data_params": {"data_id": f"{dataset_id}.zarr"},
@@ -924,7 +924,7 @@ def _get_assets(ctx: DatasetsContext, base_url: str, dataset_id: str):
                 "root": "pyramids",
                 "storage_options": {
                     "anon": True,
-                    "client_kwargs": {"endpoint_url": "http://localhost:8080/s3"},
+                    "client_kwargs": {"endpoint_url": f"{base_url}/s3"},
                 },
             },
             "xcube:open_data_params": {"data_id": f"{dataset_id}.levels"},


### PR DESCRIPTION
The `endpoint_url` was wrongly assigned to `"http://localhost:8080/s3"`, which prevents data access. This Pr fixes this issue by parsing in the base url. 

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
