### PR TITLE
Docs for STAC stores in Data Access updated

### DIFF
--- a/docs/source/dataaccess.md
+++ b/docs/source/dataaccess.md
@@ -649,7 +649,7 @@ Differences between the two stores:
 * `stac-cdse`: Generates a unified dataset from a single CDSE STAC item 
   (observational tile) with tailored data processing. Only items from the 
   collections listed below are supported.
-* `"stac-cdse-ardc"`: Generates **3D spatiotemporal analysis-ready data cubes 
+* `stac-cdse-ardc`: Generates **3D spatiotemporal analysis-ready data cubes 
   (ARDCs)** from multiple STAC items for the supported CDSE collections listed below.
 
 


### PR DESCRIPTION
Updated documentation of the STAC stores in the Data Access section due to new development in xcube-stac (see https://github.com/xcube-dev/xcube-stac/blob/main/README.md)

Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [x] New/modified features documented in `docs/source/*`
* [ ]  ~Changes documented in `CHANGES.md`~
* [x] GitHub CI passes
* [x] AppVeyor CI passes
* [x] Test coverage remains or increases (target 100%)
