### PR TITLE
Add chartlets to util/versions.py

### DIFF
--- a/xcube/util/versions.py
+++ b/xcube/util/versions.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 
 DEFAULT_DEPENDENCY_NAMES = [
     "affine",
+    "chartlets",
     "click",
     "cmocean",
     "dask",


### PR DESCRIPTION
This PR adds `charlets` to `util/versions.py`. As a result the chartlets version gets added to xcube Server meta information.

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [ ] ~~Changes documented in `CHANGES.md`~~
* [ ] ~~GitHub CI passes~~
* [ ] ~~AppVeyor CI passes~~
* [ ] ~~Test coverage remains or increases (target 100%)~~
