### PR TITLE
Fix duplicated log entries in xcube-server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Fixes
 * Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
   reducing visual offsets between rendered map tiles and dataset coordinates. (#1216)
+* Fixed duplicated `tornado` log entries for xcube Server. (#1224)
 
 ### Other changes
 * Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Fixes
 * Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
   reducing visual offsets between rendered map tiles and dataset coordinates. (#1216)
-* Fixed duplicated `tornado` log entries for xcube Server. (#1224)
+* Fixed duplicated `tornado` log entries emitted by xcube Server. (#1224)
 
 ### Other changes
 * Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)

--- a/test/server/webservers/test_tornado.py
+++ b/test/server/webservers/test_tornado.py
@@ -45,75 +45,59 @@ class TornadoFrameworkTest(unittest.TestCase):
     def test_config_schema(self):
         self.assertIsInstance(self.framework.config_schema, JsonObjectSchema)
 
-    def test_configure_logging_uses_root_handler_once(self):
-        class CountingHandler(logging.Handler):
-            def __init__(self):
-                super().__init__()
-                self.count = 0
-
-            def emit(self, record):
-                self.count += 1
-
-        logger_names = [
-            "tornado",
-            "tornado.access",
-            "tornado.application",
-            "tornado.general",
-        ]
+    def test_configure_logging_uses_root_handler_by_propagation(self):
         root = logging.getLogger()
+        tornado_log = logging.getLogger("tornado")
+        access_log = logging.getLogger("tornado.access")
+        loggers = [tornado_log, access_log]
 
-        # save original logging state to restore after test
-        saved_root_handlers = list(root.handlers)
-        saved_root_level = root.level
+        saved_root = (list(root.handlers), root.level, root.propagate)
         saved_loggers = {
-            name: (
-                list(logging.getLogger(name).handlers),
-                logging.getLogger(name).level,
-                logging.getLogger(name).propagate,
-            )
-            for name in logger_names
+            logger: (list(logger.handlers), logger.level, logger.propagate)
+            for logger in loggers
         }
 
         try:
+            # Set up root like the CLI-configured logger.
             for handler in list(root.handlers):
                 root.removeHandler(handler)
+            root_handler = logging.NullHandler()
+            root.addHandler(root_handler)
             root.setLevel(logging.INFO)
-            counting_handler = CountingHandler()
-            root.addHandler(counting_handler)
 
-            for name in logger_names:
-                logger = logging.getLogger(name)
+            # Give Tornado loggers local state that configure_logging() must clean.
+            for logger in loggers:
                 for handler in list(logger.handlers):
                     logger.removeHandler(handler)
                 logger.addHandler(logging.NullHandler())
+                logger.setLevel(logging.WARNING)
                 logger.propagate = False
 
             TornadoFramework.configure_logging()
-            for name in logger_names:
-                logger = logging.getLogger(name)
+
+            # Root keeps the handler; Tornado loggers only propagate to it.
+            self.assertEqual([root_handler], root.handlers)
+            for logger in loggers:
                 self.assertEqual([], logger.handlers)
                 self.assertTrue(logger.propagate)
                 self.assertEqual(logging.INFO, logger.level)
-
-            logging.getLogger("tornado.access").info("GET /api/viewer/test.txt")
-            self.assertEqual(1, counting_handler.count)
-            
-        # restore original logging state
         finally:
-            for name in logger_names:
-                logger = logging.getLogger(name)
+            # Restore process-global logging state for other tests.
+            for handler in list(root.handlers):
+                root.removeHandler(handler)
+            handlers, level, propagate = saved_root
+            for handler in handlers:
+                root.addHandler(handler)
+            root.setLevel(level)
+            root.propagate = propagate
+
+            for logger, (handlers, level, propagate) in saved_loggers.items():
                 for handler in list(logger.handlers):
                     logger.removeHandler(handler)
-                handlers, level, propagate = saved_loggers[name]
                 for handler in handlers:
                     logger.addHandler(handler)
                 logger.setLevel(level)
                 logger.propagate = propagate
-            for handler in list(root.handlers):
-                root.removeHandler(handler)
-            for handler in saved_root_handlers:
-                root.addHandler(handler)
-            root.setLevel(saved_root_level)
 
     def test_add_routes(self):
         class Handler(ApiHandler):

--- a/test/server/webservers/test_tornado.py
+++ b/test/server/webservers/test_tornado.py
@@ -2,6 +2,7 @@
 # Permissions are hereby granted under the terms of the MIT License:
 # https://opensource.org/licenses/MIT.
 
+import logging
 import unittest
 from collections.abc import Awaitable, Sequence
 from typing import Any, Callable, Optional, Union
@@ -43,6 +44,76 @@ class TornadoFrameworkTest(unittest.TestCase):
 
     def test_config_schema(self):
         self.assertIsInstance(self.framework.config_schema, JsonObjectSchema)
+
+    def test_configure_logging_uses_root_handler_once(self):
+        class CountingHandler(logging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.count = 0
+
+            def emit(self, record):
+                self.count += 1
+
+        logger_names = [
+            "tornado",
+            "tornado.access",
+            "tornado.application",
+            "tornado.general",
+        ]
+        root = logging.getLogger()
+
+        # save original logging state to restore after test
+        saved_root_handlers = list(root.handlers)
+        saved_root_level = root.level
+        saved_loggers = {
+            name: (
+                list(logging.getLogger(name).handlers),
+                logging.getLogger(name).level,
+                logging.getLogger(name).propagate,
+            )
+            for name in logger_names
+        }
+
+        try:
+            for handler in list(root.handlers):
+                root.removeHandler(handler)
+            root.setLevel(logging.INFO)
+            counting_handler = CountingHandler()
+            root.addHandler(counting_handler)
+
+            for name in logger_names:
+                logger = logging.getLogger(name)
+                for handler in list(logger.handlers):
+                    logger.removeHandler(handler)
+                logger.addHandler(logging.NullHandler())
+                logger.propagate = False
+
+            TornadoFramework.configure_logging()
+            for name in logger_names:
+                logger = logging.getLogger(name)
+                self.assertEqual([], logger.handlers)
+                self.assertTrue(logger.propagate)
+                self.assertEqual(logging.INFO, logger.level)
+
+            logging.getLogger("tornado.access").info("GET /api/viewer/test.txt")
+            self.assertEqual(1, counting_handler.count)
+            
+        # restore original logging state
+        finally:
+            for name in logger_names:
+                logger = logging.getLogger(name)
+                for handler in list(logger.handlers):
+                    logger.removeHandler(handler)
+                handlers, level, propagate = saved_loggers[name]
+                for handler in handlers:
+                    logger.addHandler(handler)
+                logger.setLevel(level)
+                logger.propagate = propagate
+            for handler in list(root.handlers):
+                root.removeHandler(handler)
+            for handler in saved_root_handlers:
+                root.addHandler(handler)
+            root.setLevel(saved_root_level)
 
     def test_add_routes(self):
         class Handler(ApiHandler):

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -190,9 +190,9 @@ class TornadoFramework(Framework):
 
     @staticmethod
     def configure_logging():
-        # Configure Tornado loggers to use root handlers, so we
-        # have a single log level and format. Root handlers are
-        # assumed to be already configured by xcube CLI.
+        # Configure Tornado loggers to use root handlers through
+        # propagation, so we have a single log level and format.
+        # Root handlers are assumed to be already configured by xcube CLI.
         for logger_name in [
             "tornado",
             "tornado.access",
@@ -204,9 +204,8 @@ class TornadoFramework(Framework):
             for h in list(log.handlers):
                 log.removeHandler(h)
                 h.close()
-            # Add root handlers configured by xcube CLI
-            for h in list(logging.root.handlers):
-                log.addHandler(h)
+
+            log.propagate = True
             # Use common log level
             log.setLevel(logging.root.level)
 

--- a/xcube/server/webservers/tornado.py
+++ b/xcube/server/webservers/tornado.py
@@ -204,7 +204,6 @@ class TornadoFramework(Framework):
             for h in list(log.handlers):
                 log.removeHandler(h)
                 h.close()
-
             log.propagate = True
             # Use common log level
             log.setLevel(logging.root.level)


### PR DESCRIPTION
## Summary

Fixes duplicate Tornado log output by ensuring Tornado log records are handled through normal root-logger propagation instead of being emitted multiple times through the logger hierarchy.

This prevents `tornado.access` entries from being printed multiple times for a single request.

## Testing

Run the server locally:

```powershell
xcube --loglevel INFO serve -c examples\serve\demo\config.yml  
```

In other terminal run:
```powershell
curl.exe http://localhost:8080/api/viewer/sitemap.xml #Windows
curl http://localhost:8080/api/viewer/sitemap.xml #Linux/macOS
```

Closes #1224.

Checklist:

* [ ] ~~Add unit tests and/or doctests in docstrings~~
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in `docs/source/*`~~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)
