### PR TITLE
ensure compatibility with matplotblib 3.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ### Fixes
 * Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
   reducing visual offsets between rendered map tiles and dataset coordinates. (#1216)
-* ensure compatibility with matplotlib 3.11.0 (#1219)
+* Ensure compatibility with matplotlib 3.11.0 (#1219)
 
 ### Other changes
 * Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,6 @@
 * Ensure compatibility with matplotlib 3.11.0 (#1219)
 
 ### Other changes
-* Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)
 * Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
   rasterio/GDAL binary incompatibilities.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Fixes
 * Improved raster tile alignment by using nearest-pixel rounding during tile reprojection,
   reducing visual offsets between rendered map tiles and dataset coordinates. (#1216)
+* ensure compatibility with matplotlib 3.11.0 (#1219)
 
 ### Other changes
 * Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - jsonschema >=3.2
   - libgdal-jp2openjpeg
   - mashumaro
-  - matplotlib-base >=3.8.3
+  - matplotlib-base >=3.8.3,<4
   - netcdf4 >=1.5
   - numba >=0.52
   - numcodecs >=0.12.1

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - jsonschema >=3.2
   - libgdal-jp2openjpeg
   - mashumaro
-  - matplotlib-base >=3.8.3,<3.11.0 # see Issue #1219
+  - matplotlib-base >=3.8.3
   - netcdf4 >=1.5
   - numba >=0.52
   - numcodecs >=0.12.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "jdcal>=1.4",
   "jsonschema>=3.2",
   "mashumaro",
-  "matplotlib>=3.8.3,<3.11.0", #see Issue #1219
+  "matplotlib>=3.8.3,<4",
   "netcdf4>=1.5",
   "numba>=0.52",
   "numcodecs>=0.12.1",

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -521,6 +521,8 @@ def parse_cm_code(cm_code: str) -> tuple[str, Optional[Colormap]]:
                 cm_items = list(zip(norm_values, colors))
             if cm_type == "stepwise":
                 # Turn cm_items into discrete step function
+                # We use a small offset to make values increase strictly
+                # monotonically, which is required since matplotlib v3.11
                 stepwise_cm_items = []
                 offset = 0
                 for i, (value, color) in enumerate(cm_items[0:-1]):

--- a/xcube/util/cmaps.py
+++ b/xcube/util/cmaps.py
@@ -522,10 +522,12 @@ def parse_cm_code(cm_code: str) -> tuple[str, Optional[Colormap]]:
             if cm_type == "stepwise":
                 # Turn cm_items into discrete step function
                 stepwise_cm_items = []
+                offset = 0
                 for i, (value, color) in enumerate(cm_items[0:-1]):
                     next_value = cm_items[i + 1][0]
-                    stepwise_cm_items.append((value, color))
+                    stepwise_cm_items.append((value + offset, color))
                     stepwise_cm_items.append((next_value, color))
+                    offset = 1e-8
                 cm_items = stepwise_cm_items
             cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
                 cm_base_name, cm_items


### PR DESCRIPTION
Solves #1219. The issue is that since matplotlib 3.11.0 color map values need to be given in a strictly ascending order; in our declaration of stepwise categorical color maps we state values as end points for one range and start points for the next one. I added a small value to the beginning of a range, so there is a tiny increase.

Checklist:

* ~[ ] Add unit tests and/or doctests in docstrings~
* ~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
* ~[ ] New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)
