### PR TITLE
Fix CI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### Other changes
 * Constrained `matplotlib >=3.8.3,<3.11.0` (#1219)
+* Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
+  rasterio/GDAL binary incompatibilities.
 
 ## Changes in 1.13.3
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - jdcal >=1.4
   - jsonschema >=3.2
   - libgdal-jp2openjpeg
+  # because >=0.12.0 causes CI failures with rasterio/GDAL binaries
   - libjxl <=0.11.2
   - mashumaro
   - matplotlib-base >=3.8.3,<3.11.0 # see Issue #1219

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - jdcal >=1.4
   - jsonschema >=3.2
   - libgdal-jp2openjpeg
+  - libjxl <=0.11.2
   - mashumaro
   - matplotlib-base >=3.8.3,<3.11.0 # see Issue #1219
   - netcdf4 >=1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "geopandas>=0.8",
   "jdcal>=1.4",
   "jsonschema>=3.2",
+  "libjxl<=0.11.2",
   "mashumaro",
   "matplotlib>=3.8.3,<3.11.0", #see Issue #1219
   "netcdf4>=1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "geopandas>=0.8",
   "jdcal>=1.4",
   "jsonschema>=3.2",
-  "libjxl<=0.11.2",
   "mashumaro",
   "matplotlib>=3.8.3,<3.11.0", #see Issue #1219
   "netcdf4>=1.5",


### PR DESCRIPTION
* Pinned libjxl <=0.11.2 because libjxl >=0.12.0 causes CI failures due to 
  rasterio/GDAL binary incompatibilities.

Checklist:

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [ ] Test coverage remains or increases (target 100%)
