### PR TITLE
Update to Zarr 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   Zarr store, making it independent of any specific Zarr store implementation. 
   This change prepares xcube for the migration to Zarr v3, whose store API differs 
   significantly from that of Zarr v2.
+* Migrated to Zarr v3, adapting xcube's Zarr handling to the new Zarr store API and
+  ensuring compatibility with the latest Zarr ecosystem.
 
 ## Changes in 1.13.4
  

--- a/environment.yml
+++ b/environment.yml
@@ -45,14 +45,14 @@ dependencies:
   - tornado >=6.0,<6.5
   - urllib3 >=2.0
   - xarray >=2024.7
-  - zarr >=2.11,<3  # until we can ensure zarr 3 compatibility; see Issue #1102
+  - zarr >=3.0
   # Chartlets
   - altair
   - chartlets >= 0.1.3
   # Testing
   - flake8 >=3.7
   - isort >=6
-  - kerchunk
+  - kerchunk >=0.2.8
   - moto >=4
   - pytest >=4.4
   - pytest-cov >=2.6

--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - tornado >=6.0,<6.5
   - urllib3 >=2.0
   - xarray >=2024.7
-  - zarr >=3.0
+  - zarr >=3.0,<4
   # Chartlets
   - altair
   - chartlets >= 0.1.3

--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - tornado >=6.0,<6.5
   - urllib3 >=2.0
   - xarray >=2024.7
-  - zarr >=3.0,<4
+  - zarr >=3.1.4,<4
   # Chartlets
   - altair
   - chartlets >= 0.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "tornado>=6.0",
   "urllib3>=1.26",
   "xarray>=2024.7",
-  "zarr>=2.11,<3"
+  "zarr>=3.0"
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "tornado>=6.0",
   "urllib3>=1.26",
   "xarray>=2024.7",
-  "zarr>=3.0,<4",
+  "zarr>=3.1.4,<4",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "tornado>=6.0",
   "urllib3>=1.26",
   "xarray>=2024.7",
-  "zarr>=3.0"
+  "zarr>=3.0,<4",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/test/cli/helpers.py
+++ b/test/cli/helpers.py
@@ -43,7 +43,7 @@ class CliDataTest(CliTest, metaclass=ABCMeta):
         if self.chunks() is not None:
             dataset = dataset.chunk(self.chunks())
         dataset.to_netcdf(TEST_NC_FILE, mode="w")
-        dataset.to_zarr(TEST_ZARR_DIR, mode="w", zarr_version=2)
+        dataset.to_zarr(TEST_ZARR_DIR, mode="w", zarr_format=2)
 
     def tearDown(self):
         self._rm_outputs()

--- a/test/cli/helpers.py
+++ b/test/cli/helpers.py
@@ -43,7 +43,7 @@ class CliDataTest(CliTest, metaclass=ABCMeta):
         if self.chunks() is not None:
             dataset = dataset.chunk(self.chunks())
         dataset.to_netcdf(TEST_NC_FILE, mode="w")
-        dataset.to_zarr(TEST_ZARR_DIR, mode="w")
+        dataset.to_zarr(TEST_ZARR_DIR, mode="w", zarr_version=2)
 
     def tearDown(self):
         self._rm_outputs()

--- a/test/cli/test_optimize.py
+++ b/test/cli/test_optimize.py
@@ -24,7 +24,7 @@ class OptimizeDataTest(CliDataTest):
 
     def setUp(self):
         self._clear_outputs()
-        TEST_CUBE.to_zarr(INPUT_CUBE_PATH)
+        TEST_CUBE.to_zarr(INPUT_CUBE_PATH, zarr_version=2)
 
     def tearDown(self):
         self._clear_outputs()

--- a/test/cli/test_patch.py
+++ b/test/cli/test_patch.py
@@ -137,7 +137,7 @@ class PatchZarrCubeTest(CliTest):
                 "TileSize": "1024:1024",  # SNAP adds this to NetCDFs
             }
         )
-        cube.to_zarr(cls.CUBE_PATH)
+        cube.to_zarr(cls.CUBE_PATH, zarr_version=2)
 
     def tearDown(self) -> None:
         rimraf(self.CUBE_PATH, self.METADATA_PATH, self.OPTIONS_PATH)

--- a/test/cli/test_prune.py
+++ b/test/cli/test_prune.py
@@ -31,7 +31,7 @@ class PruneDataTest(CliTest):
         ).chunk(dict(time=1, lat=90, lon=90))
         fv_encoding = dict(_FillValue=None)
         encoding = dict(precipitation=fv_encoding, temperature=fv_encoding)
-        cube.to_zarr(self.TEST_CUBE, encoding=encoding)
+        cube.to_zarr(self.TEST_CUBE, encoding=encoding, zarr_version=2)
 
     def tearDown(self) -> None:
         rimraf(self.TEST_CUBE)

--- a/test/core/gen/test_gen.py
+++ b/test/core/gen/test_gen.py
@@ -720,12 +720,12 @@ class DefaultProcessTest(unittest.TestCase):
             ds_default_compressor.analysed_sst.values, ds_compressed.analysed_sst.values
         )
         self.assertEqual(
-            "Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)",
-            str(ds_default_compressor.analysed_sst.encoding["compressor"]),
+            "(Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0),)",
+            str(ds_default_compressor.analysed_sst.encoding["compressors"]),
         )
         self.assertEqual(
-            "Blosc(cname='zstd', clevel=1, shuffle=BITSHUFFLE, blocksize=0)",
-            str(ds_compressed.analysed_sst.encoding["compressor"]),
+            "(Blosc(cname='zstd', clevel=1, shuffle=BITSHUFFLE, blocksize=0),)",
+            str(ds_compressed.analysed_sst.encoding["compressors"]),
         )
 
     def assert_cube_ok(

--- a/test/core/gen2/remote/server.py
+++ b/test/core/gen2/remote/server.py
@@ -284,8 +284,8 @@ def _init_local_store():
     local_base_dir = new_temp_dir(suffix="_local_store")
     dataset_1 = new_cube(width=36, height=18, variables={"A": 0.1, "B": 0.2})
     dataset_2 = new_cube(width=36, height=18, variables={"C": 0.2, "D": 0.3})
-    dataset_1.to_zarr(os.path.join(local_base_dir, "DATASET-1.zarr"))
-    dataset_2.to_zarr(os.path.join(local_base_dir, "DATASET-2.zarr"))
+    dataset_1.to_zarr(os.path.join(local_base_dir, "DATASET-1.zarr"), zarr_version=2)
+    dataset_2.to_zarr(os.path.join(local_base_dir, "DATASET-2.zarr"), zarr_version=2)
 
     global STORES_CONFIG_PATH
     _, STORES_CONFIG_PATH = new_temp_file(suffix="_stores.yaml")

--- a/test/core/gridmapping/test_cfconv.py
+++ b/test/core/gridmapping/test_cfconv.py
@@ -241,12 +241,12 @@ class XarrayDecodeCfTest(unittest.TestCase):
     @classmethod
     def _write_coords(cls, noise, crs, lon, lat):
         dataset = xr.Dataset(dict(noise=noise, crs=crs), coords=dict(lon=lon, lat=lat))
-        dataset.to_zarr("noise.zarr", mode="w")
+        dataset.to_zarr("noise.zarr", mode="w", zarr_version=2)
 
     @classmethod
     def _write_data_vars(cls, noise, crs, lon, lat):
         dataset = xr.Dataset(dict(noise=noise, crs=crs, lon=lon, lat=lat))
-        dataset.to_zarr("noise.zarr", mode="w")
+        dataset.to_zarr("noise.zarr", mode="w", zarr_version=2)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/test/core/gridmapping/test_dataset.py
+++ b/test/core/gridmapping/test_dataset.py
@@ -12,6 +12,7 @@ import xarray as xr
 
 import xcube.core.new
 from xcube.core.gridmapping import GridMapping
+from xcube.core.dsio import ZarrDatasetIO
 
 # noinspection PyProtectedMember
 
@@ -102,7 +103,7 @@ class DatasetGridMappingTest(unittest.TestCase):
             "S3-OLCI-L2A.zarr.zip",
         )
 
-        dataset = xr.open_zarr(olci_l2_path, consolidated=False)
+        dataset = ZarrDatasetIO().read(olci_l2_path)
         gm = GridMapping.from_dataset(dataset)
         self.assertEqual((1189, 1890), gm.size)
         self.assertEqual((512, 512), gm.tile_size)

--- a/test/core/mldataset/test_fs.py
+++ b/test/core/mldataset/test_fs.py
@@ -4,6 +4,7 @@
 
 
 import math
+import json
 import unittest
 from collections.abc import Mapping
 from typing import List, Optional, Any
@@ -13,6 +14,7 @@ import fsspec.core
 import xarray as xr
 
 from xcube.core.mldataset import FsMultiLevelDataset
+from xcube.core.mldataset.fs import FsMultiLevelDatasetError
 from xcube.core.new import new_cube
 from xcube.core.subsampling import AggMethod
 
@@ -136,3 +138,24 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
         self.assertEqual(
             [201523393, 50380849, 12595213, 3148804, 787201], weighted_sizes
         )
+
+    def test_invalid_base_dataset_path_raises(self):
+        with self.assertRaises(FsMultiLevelDatasetError):
+            FsMultiLevelDataset.write_dataset(
+                self.dataset,
+                "store/test.levels",
+                fs=self.fs,
+                fs_root="",
+                replace=True,
+                num_levels=1,
+                base_dataset_path="base.zarr",
+            )
+
+    def test_invalid_levels_spec_raises_type_error(self):
+        self.fs.mkdirs("test.levels", exist_ok=True)
+        with self.fs.open("test.levels/.zlevels", "w") as fp:
+            json.dump([], fp)
+
+        ml_dataset = FsMultiLevelDataset("test.levels", fs=self.fs)
+        with self.assertRaises(TypeError):
+            _ = ml_dataset.num_levels

--- a/test/core/mldataset/test_fs.py
+++ b/test/core/mldataset/test_fs.py
@@ -139,14 +139,14 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
             set(fs.listdir(path, detail=False)),
         )
 
-        ml_dataset = FsMultiLevelDataset(path, fs=fs)
+        ml_dataset = FsMultiLevelDataset(path, fs=fs, cache_size=2**22)
         self.assertEqual(expected_num_levels, ml_dataset.num_levels)
         self.assertEqual(expected_agg_methods, ml_dataset.agg_methods)
         self.assertEqual(expected_tile_size, ml_dataset.tile_size)
         self.assertEqual(use_saved_levels, ml_dataset.use_saved_levels)
         self.assertEqual(base_dataset_path, ml_dataset.base_dataset_path)
         self.assertEqual(base_dataset_params, ml_dataset.base_dataset_params)
-        self.assertEqual(None, ml_dataset.cache_size)
+        self.assertEqual(2**22, ml_dataset.cache_size)
         self.assertEqual(num_levels, len(ml_dataset.size_weights))
         self.assertTrue(all(ml_dataset.size_weights > 0.0))
         for i in range(num_levels):

--- a/test/core/mldataset/test_fs.py
+++ b/test/core/mldataset/test_fs.py
@@ -117,6 +117,8 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
         zarr_kwargs: Optional[dict] = None,
     ):
         fs = self.fs
+        if zarr_kwargs is None:
+            zarr_kwargs = {}
         FsMultiLevelDataset.write_dataset(
             self.dataset,
             path,

--- a/test/core/mldataset/test_fs.py
+++ b/test/core/mldataset/test_fs.py
@@ -66,7 +66,7 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
         )
 
     def test_io_nl_4_ts_256_base(self):
-        self.dataset.to_zarr(self.fs.get_mapper("test.zarr"))
+        self.dataset.to_zarr(self.fs.get_mapper("test.zarr"), zarr_version=2)
         self.assert_io_ok(
             "test.levels",
             num_levels=4,

--- a/test/core/mldataset/test_fs.py
+++ b/test/core/mldataset/test_fs.py
@@ -7,11 +7,12 @@ import math
 import json
 import unittest
 from collections.abc import Mapping
-from typing import List, Optional, Any
+from typing import Optional, Any
 
 import fsspec
 import fsspec.core
 import xarray as xr
+import zarr
 
 from xcube.core.mldataset import FsMultiLevelDataset
 from xcube.core.mldataset.fs import FsMultiLevelDatasetError
@@ -83,6 +84,23 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
             expected_agg_methods={"CHL": "mean", "qflags": "first"},
         )
 
+    def test_io_nl_4_ts_256_base_zarr3(self):
+        self.dataset.to_zarr(self.fs.get_mapper("test.zarr"), zarr_version=2)
+        self.assert_io_ok(
+            "test.levels",
+            num_levels=4,
+            agg_methods=None,
+            tile_size=256,
+            use_saved_levels=False,
+            base_dataset_path="test.zarr",
+            base_dataset_params=None,
+            expected_files=[".zlevels", "0.link", "1.zarr", "2.zarr", "3.zarr"],
+            expected_num_levels=4,
+            expected_tile_size=[256, 256],
+            expected_agg_methods={"CHL": "mean", "qflags": "first"},
+            zarr_kwargs={"zarr_format": 3},
+        )
+
     def assert_io_ok(
         self,
         path: str,
@@ -96,6 +114,7 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
         expected_num_levels: int,
         expected_agg_methods: Optional[Mapping[str, AggMethod]],
         expected_tile_size: list[int],
+        zarr_kwargs: Optional[dict] = None,
     ):
         fs = self.fs
         FsMultiLevelDataset.write_dataset(
@@ -110,6 +129,7 @@ class FsMultiLevelDatasetTest(unittest.TestCase):
             use_saved_levels=use_saved_levels,
             base_dataset_path=base_dataset_path,
             base_dataset_params=base_dataset_params,
+            **zarr_kwargs,
         )
         self.assertTrue(fs.isdir(path))
         self.assertEqual(

--- a/test/core/store/fs/impl/test_dataset.py
+++ b/test/core/store/fs/impl/test_dataset.py
@@ -4,7 +4,7 @@
 
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import fsspec
 import xarray as xr
@@ -22,64 +22,44 @@ class DatasetZarrFsDataAccessorTest(unittest.TestCase):
         self.dataset = new_cube(variables=dict(temperature=279.1))
         self.temp_dir = tempfile.TemporaryDirectory()
         self.fs = fsspec.filesystem("file")
-        self.data_id = f"{self.temp_dir.name}/cube.zarr"
-        self.dataset.to_zarr(self.data_id, zarr_version=2)
+        self.data_id_v2 = f"{self.temp_dir.name}/cube_v2.zarr"
+        self.data_id_v3 = f"{self.temp_dir.name}/cube_v3.zarr"
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
 
-    def test_open_data_with_cache_size(self):
+    def test_write_and_open_data_with_cache_size(self):
         accessor = DatasetZarrFsDataAccessor()
-        opened = accessor.open_data(self.data_id, fs=self.fs, root=None, cache_size=2**20)
+        accessor.write_data(self.dataset, self.data_id_v2, fs=self.fs, root=None)
+        opened = accessor.open_data(
+            self.data_id_v2, fs=self.fs, root=None, cache_size=2**20
+        )
         self.assertIsInstance(opened, xr.Dataset)
-        self.assertIn("temperature", opened)
+        xr.testing.assert_equal(self.dataset, opened)
 
-    @patch("xcube.core.store.fs.impl.dataset.xr.open_dataset")
-    def test_open_data_with_non_zarr_engine(self, mock_open_dataset):
-        mock_open_dataset.return_value = xr.Dataset()
-
+    def test_write_and_open_data_zarr_v3(self):
         accessor = DatasetZarrFsDataAccessor()
-        opened = accessor.open_data(self.data_id, fs=self.fs, root=None, engine="scipy")
-
-        mock_open_dataset.assert_called_once()
+        accessor.write_data(
+            self.dataset, self.data_id_v3, fs=self.fs, root=None, zarr_format=3
+        )
+        opened = accessor.open_data(self.data_id_v3, fs=self.fs, root=None)
         self.assertIsInstance(opened, xr.Dataset)
+        xr.testing.assert_equal(self.dataset, opened)
 
     def test_write_data_params_schema_exposes_zarr_format(self):
         accessor = DatasetZarrFsDataAccessor()
         schema = accessor.get_write_data_params_schema().to_dict()
 
-        self.assertEqual(
-            [2, 3], schema["properties"]["zarr_format"]["enum"]
-        )
-        self.assertEqual(
-            2, schema["properties"]["zarr_format"]["default"]
-        )
-
-    @patch("xcube.core.store.fs.impl.dataset.is_local_fs", return_value=False)
-    def test_write_data_uses_default_zarr_format_2(self, _mock_is_local_fs):
-        accessor = DatasetZarrFsDataAccessor()
-        dataset = MagicMock()
-        fs = fsspec.filesystem("memory")
-
-        accessor.write_data(dataset, "cube.zarr", fs=fs, root=None)
-
-        self.assertEqual(2, dataset.to_zarr.call_args.kwargs["zarr_format"])
-
-    @patch("xcube.core.store.fs.impl.dataset.is_local_fs", return_value=False)
-    def test_write_data_passes_through_zarr_format_3(self, _mock_is_local_fs):
-        accessor = DatasetZarrFsDataAccessor()
-        dataset = MagicMock()
-        fs = fsspec.filesystem("memory")
-
-        accessor.write_data(dataset, "cube.zarr", fs=fs, root=None, zarr_format=3)
-
-        self.assertEqual(3, dataset.to_zarr.call_args.kwargs["zarr_format"])
+        self.assertEqual([2, 3], schema["properties"]["zarr_format"]["enum"])
+        self.assertEqual(2, schema["properties"]["zarr_format"]["default"])
 
 
 class DatasetNetcdfFsDataAccessorTest(unittest.TestCase):
     @patch("xcube.core.store.fs.impl.dataset.is_https_fs", return_value=True)
     @patch("xcube.core.store.fs.impl.dataset.xr.open_dataset")
-    def test_open_data_https_uses_bytes_mode(self, mock_open_dataset, _mock_is_https_fs):
+    def test_open_data_https_uses_bytes_mode(
+        self, mock_open_dataset, _mock_is_https_fs
+    ):
         mock_open_dataset.return_value = xr.Dataset()
 
         accessor = DatasetNetcdfFsDataAccessor()
@@ -98,9 +78,5 @@ class MultiLevelDatasetLevelsFsDataAccessorTest(unittest.TestCase):
         accessor = MultiLevelDatasetLevelsFsDataAccessor()
         schema = accessor.get_write_data_params_schema().to_dict()
 
-        self.assertEqual(
-            [2, 3], schema["properties"]["zarr_format"]["enum"]
-        )
-        self.assertEqual(
-            2, schema["properties"]["zarr_format"]["default"]
-        )
+        self.assertEqual([2, 3], schema["properties"]["zarr_format"]["enum"])
+        self.assertEqual(2, schema["properties"]["zarr_format"]["default"])

--- a/test/core/store/fs/impl/test_dataset.py
+++ b/test/core/store/fs/impl/test_dataset.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2018-2026 by xcube team and contributors
+# Permissions are hereby granted under the terms of the MIT License:
+# https://opensource.org/licenses/MIT.
+
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import fsspec
+import xarray as xr
+
+from xcube.core.new import new_cube
+from xcube.core.store.fs.impl.dataset import (
+    DatasetNetcdfFsDataAccessor,
+    DatasetZarrFsDataAccessor,
+)
+
+
+class DatasetZarrFsDataAccessorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dataset = new_cube(variables=dict(temperature=279.1))
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.fs = fsspec.filesystem("file")
+        self.data_id = f"{self.temp_dir.name}/cube.zarr"
+        self.dataset.to_zarr(self.data_id, zarr_version=2)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_open_data_with_cache_size(self):
+        accessor = DatasetZarrFsDataAccessor()
+        opened = accessor.open_data(self.data_id, fs=self.fs, root=None, cache_size=2**20)
+        self.assertIsInstance(opened, xr.Dataset)
+        self.assertIn("temperature", opened)
+
+    @patch("xcube.core.store.fs.impl.dataset.xr.open_dataset")
+    def test_open_data_with_non_zarr_engine(self, mock_open_dataset):
+        mock_open_dataset.return_value = xr.Dataset()
+
+        accessor = DatasetZarrFsDataAccessor()
+        opened = accessor.open_data(self.data_id, fs=self.fs, root=None, engine="scipy")
+
+        mock_open_dataset.assert_called_once()
+        self.assertIsInstance(opened, xr.Dataset)
+
+
+class DatasetNetcdfFsDataAccessorTest(unittest.TestCase):
+    @patch("xcube.core.store.fs.impl.dataset.is_https_fs", return_value=True)
+    @patch("xcube.core.store.fs.impl.dataset.xr.open_dataset")
+    def test_open_data_https_uses_bytes_mode(self, mock_open_dataset, _mock_is_https_fs):
+        mock_open_dataset.return_value = xr.Dataset()
+
+        accessor = DatasetNetcdfFsDataAccessor()
+        opened = accessor.open_data(
+            "root.example/sample.nc", fs=fsspec.filesystem("memory"), root=None
+        )
+
+        mock_open_dataset.assert_called_once_with(
+            "https://root.example/sample.nc#mode=bytes", engine="netcdf4"
+        )
+        self.assertIsInstance(opened, xr.Dataset)

--- a/test/core/store/fs/impl/test_dataset.py
+++ b/test/core/store/fs/impl/test_dataset.py
@@ -4,7 +4,7 @@
 
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import fsspec
 import xarray as xr
@@ -14,6 +14,7 @@ from xcube.core.store.fs.impl.dataset import (
     DatasetNetcdfFsDataAccessor,
     DatasetZarrFsDataAccessor,
 )
+from xcube.core.store.fs.impl.mldataset import MultiLevelDatasetLevelsFsDataAccessor
 
 
 class DatasetZarrFsDataAccessorTest(unittest.TestCase):
@@ -43,6 +44,37 @@ class DatasetZarrFsDataAccessorTest(unittest.TestCase):
         mock_open_dataset.assert_called_once()
         self.assertIsInstance(opened, xr.Dataset)
 
+    def test_write_data_params_schema_exposes_zarr_format(self):
+        accessor = DatasetZarrFsDataAccessor()
+        schema = accessor.get_write_data_params_schema().to_dict()
+
+        self.assertEqual(
+            [2, 3], schema["properties"]["zarr_format"]["enum"]
+        )
+        self.assertEqual(
+            2, schema["properties"]["zarr_format"]["default"]
+        )
+
+    @patch("xcube.core.store.fs.impl.dataset.is_local_fs", return_value=False)
+    def test_write_data_uses_default_zarr_format_2(self, _mock_is_local_fs):
+        accessor = DatasetZarrFsDataAccessor()
+        dataset = MagicMock()
+        fs = fsspec.filesystem("memory")
+
+        accessor.write_data(dataset, "cube.zarr", fs=fs, root=None)
+
+        self.assertEqual(2, dataset.to_zarr.call_args.kwargs["zarr_format"])
+
+    @patch("xcube.core.store.fs.impl.dataset.is_local_fs", return_value=False)
+    def test_write_data_passes_through_zarr_format_3(self, _mock_is_local_fs):
+        accessor = DatasetZarrFsDataAccessor()
+        dataset = MagicMock()
+        fs = fsspec.filesystem("memory")
+
+        accessor.write_data(dataset, "cube.zarr", fs=fs, root=None, zarr_format=3)
+
+        self.assertEqual(3, dataset.to_zarr.call_args.kwargs["zarr_format"])
+
 
 class DatasetNetcdfFsDataAccessorTest(unittest.TestCase):
     @patch("xcube.core.store.fs.impl.dataset.is_https_fs", return_value=True)
@@ -59,3 +91,16 @@ class DatasetNetcdfFsDataAccessorTest(unittest.TestCase):
             "https://root.example/sample.nc#mode=bytes", engine="netcdf4"
         )
         self.assertIsInstance(opened, xr.Dataset)
+
+
+class MultiLevelDatasetLevelsFsDataAccessorTest(unittest.TestCase):
+    def test_write_data_params_schema_exposes_zarr_format(self):
+        accessor = MultiLevelDatasetLevelsFsDataAccessor()
+        schema = accessor.get_write_data_params_schema().to_dict()
+
+        self.assertEqual(
+            [2, 3], schema["properties"]["zarr_format"]["enum"]
+        )
+        self.assertEqual(
+            2, schema["properties"]["zarr_format"]["default"]
+        )

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -76,7 +76,7 @@ class DataPackingTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         data = new_cube_data()
-        data.to_zarr(cls.path, mode="w")
+        data.to_zarr(cls.path, mode="w", zarr_version=2)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/test/core/store/fs/test_registry.py
+++ b/test/core/store/fs/test_registry.py
@@ -76,7 +76,7 @@ class DataPackingTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         data = new_cube_data()
-        data.to_zarr(cls.path, mode="w", zarr_version=2)
+        data.to_zarr(cls.path, mode="w", zarr_format=2)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/test/core/store/fs/test_subset.py
+++ b/test/core/store/fs/test_subset.py
@@ -54,7 +54,7 @@ class FsStoreSubset:
                         else cls.fs.get_mapper(root=zarr_path)
                     ),
                     mode="w",
-                    zarr_version=2,
+                    zarr_format=2,
                 )
 
             dir_path = f"{cls.root}/l2"
@@ -68,7 +68,7 @@ class FsStoreSubset:
                         else cls.fs.get_mapper(root=zarr_path)
                     ),
                     mode="w",
-                    zarr_version=2,
+                    zarr_format=2,
                 )
 
             dir_path = f"{cls.root}/l3"
@@ -85,7 +85,7 @@ class FsStoreSubset:
                             else cls.fs.get_mapper(root=zarr_path)
                         ),
                         mode="w",
-                        zarr_version=2,
+                        zarr_format=2,
                     )
 
         @classmethod

--- a/test/core/store/fs/test_subset.py
+++ b/test/core/store/fs/test_subset.py
@@ -12,6 +12,7 @@ import fsspec
 from xcube.core.new import new_cube
 from xcube.core.store.fs.registry import new_fs_data_store
 from xcube.core.store.fs.store import FsDataStore
+from xcube.util.fspath import is_local_fs
 from xcube.util.temp import new_temp_dir
 
 
@@ -46,13 +47,25 @@ class FsStoreSubset:
             cls.fs.mkdir(dir_path)
             for i in range(3):
                 zarr_path = f"{dir_path}/olci-l1b-2022050{i + 1}.zarr"
-                cube.to_zarr(cls.fs.get_mapper(root=zarr_path), mode="w")
+                cube.to_zarr(
+                    zarr_path
+                    if is_local_fs(cls.fs)
+                    else cls.fs.get_mapper(root=zarr_path, create=True),
+                    mode="w",
+                    zarr_version=2,
+                )
 
             dir_path = f"{cls.root}/l2"
             cls.fs.mkdir(dir_path)
             for i in range(3):
                 zarr_path = f"{dir_path}/olci-l2-2022050{i + 1}.zarr"
-                cube.to_zarr(cls.fs.get_mapper(root=zarr_path), mode="w")
+                cube.to_zarr(
+                    zarr_path
+                    if is_local_fs(cls.fs)
+                    else cls.fs.get_mapper(root=zarr_path, create=True),
+                    mode="w",
+                    zarr_version=2,
+                )
 
             dir_path = f"{cls.root}/l3"
             cls.fs.mkdir(dir_path)
@@ -61,7 +74,13 @@ class FsStoreSubset:
                 cls.fs.mkdir(levels_path)
                 for j in range(4):
                     zarr_path = f"{levels_path}/{j}.zarr"
-                    cube.to_zarr(cls.fs.get_mapper(root=zarr_path), mode="w")
+                    cube.to_zarr(
+                        zarr_path
+                        if is_local_fs(cls.fs)
+                        else cls.fs.get_mapper(root=zarr_path, create=True),
+                        mode="w",
+                        zarr_version=2,
+                    )
 
         @classmethod
         def tearDownClass(cls) -> None:

--- a/test/core/store/fs/test_subset.py
+++ b/test/core/store/fs/test_subset.py
@@ -48,9 +48,11 @@ class FsStoreSubset:
             for i in range(3):
                 zarr_path = f"{dir_path}/olci-l1b-2022050{i + 1}.zarr"
                 cube.to_zarr(
-                    zarr_path
-                    if is_local_fs(cls.fs)
-                    else cls.fs.get_mapper(root=zarr_path, create=True),
+                    (
+                        zarr_path
+                        if is_local_fs(cls.fs)
+                        else cls.fs.get_mapper(root=zarr_path)
+                    ),
                     mode="w",
                     zarr_version=2,
                 )
@@ -60,9 +62,11 @@ class FsStoreSubset:
             for i in range(3):
                 zarr_path = f"{dir_path}/olci-l2-2022050{i + 1}.zarr"
                 cube.to_zarr(
-                    zarr_path
-                    if is_local_fs(cls.fs)
-                    else cls.fs.get_mapper(root=zarr_path, create=True),
+                    (
+                        zarr_path
+                        if is_local_fs(cls.fs)
+                        else cls.fs.get_mapper(root=zarr_path)
+                    ),
                     mode="w",
                     zarr_version=2,
                 )
@@ -75,9 +79,11 @@ class FsStoreSubset:
                 for j in range(4):
                     zarr_path = f"{levels_path}/{j}.zarr"
                     cube.to_zarr(
-                        zarr_path
-                        if is_local_fs(cls.fs)
-                        else cls.fs.get_mapper(root=zarr_path, create=True),
+                        (
+                            zarr_path
+                            if is_local_fs(cls.fs)
+                            else cls.fs.get_mapper(root=zarr_path)
+                        ),
                         mode="w",
                         zarr_version=2,
                     )

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -282,6 +282,22 @@ class ZarrDatasetIOTest(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             ds_io.read("test.zarr")
 
+    @patch("xcube.core.dsio.get_path_or_s3_store", return_value=("test.zarr", False))
+    def test_write_uses_default_zarr_format_2(self, _mock_get_path_or_s3_store):
+        dataset = xr.Dataset()
+        with patch.object(dataset, "to_zarr") as mock_to_zarr:
+            ZarrDatasetIO().write(dataset, "test.zarr")
+
+        self.assertEqual(2, mock_to_zarr.call_args.kwargs["zarr_format"])
+
+    @patch("xcube.core.dsio.get_path_or_s3_store", return_value=("test.zarr", False))
+    def test_write_passes_through_zarr_format_3(self, _mock_get_path_or_s3_store):
+        dataset = xr.Dataset()
+        with patch.object(dataset, "to_zarr") as mock_to_zarr:
+            ZarrDatasetIO().write(dataset, "test.zarr", zarr_format=3)
+
+        self.assertEqual(3, mock_to_zarr.call_args.kwargs["zarr_format"])
+
 
 class ZarrDatasetS3IOTest(S3Test):
     def test_write_to_and_read_from_s3(self):
@@ -293,6 +309,7 @@ class ZarrDatasetS3IOTest(S3Test):
 
         ds1 = new_cube(width=36, height=18, variables=dict(chl=0.5, tsm=0.2))
 
+        # write as zarr v2
         write_cube(
             ds1,
             "upload_bucket/cube-1-250-250.zarr",
@@ -303,6 +320,26 @@ class ZarrDatasetS3IOTest(S3Test):
 
         ds2 = open_cube(
             "upload_bucket/cube-1-250-250.zarr",
+            format_name="zarr",
+            s3_kwargs=s3_kwargs,
+            s3_client_kwargs=s3_client_kwargs,
+        )
+
+        self.assertEqual(set(ds1.coords), set(ds2.coords))
+        self.assertEqual(set(ds1.data_vars), set(ds2.data_vars))
+
+        # write as zarr v3
+        write_cube(
+            ds1,
+            "upload_bucket/cube-1-250-250_v3.zarr",
+            format_name="zarr",
+            s3_kwargs=s3_kwargs,
+            s3_client_kwargs=s3_client_kwargs,
+            zarr_format=3,
+        )
+
+        ds2 = open_cube(
+            "upload_bucket/cube-1-250-250_v3.zarr",
             format_name="zarr",
             s3_kwargs=s3_kwargs,
             s3_client_kwargs=s3_client_kwargs,

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -280,7 +280,7 @@ class ZarrDatasetIOTest(unittest.TestCase):
     def test_read(self):
         ds_io = ZarrDatasetIO()
         with self.assertRaises(FileNotFoundError):
-            ds_io.read("test.zarr")
+            ds_io.read("test.zarr", max_cache_size=2**20)
 
 
 class ZarrDatasetS3IOTest(S3Test):

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -277,7 +277,7 @@ class ZarrDatasetIOTest(unittest.TestCase):
 
     def test_read(self):
         ds_io = ZarrDatasetIO()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FileNotFoundError):
             ds_io.read("test.zarr")
 
 

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -282,22 +282,6 @@ class ZarrDatasetIOTest(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             ds_io.read("test.zarr")
 
-    @patch("xcube.core.dsio.get_path_or_s3_store", return_value=("test.zarr", False))
-    def test_write_uses_default_zarr_format_2(self, _mock_get_path_or_s3_store):
-        dataset = xr.Dataset()
-        with patch.object(dataset, "to_zarr") as mock_to_zarr:
-            ZarrDatasetIO().write(dataset, "test.zarr")
-
-        self.assertEqual(2, mock_to_zarr.call_args.kwargs["zarr_format"])
-
-    @patch("xcube.core.dsio.get_path_or_s3_store", return_value=("test.zarr", False))
-    def test_write_passes_through_zarr_format_3(self, _mock_get_path_or_s3_store):
-        dataset = xr.Dataset()
-        with patch.object(dataset, "to_zarr") as mock_to_zarr:
-            ZarrDatasetIO().write(dataset, "test.zarr", zarr_format=3)
-
-        self.assertEqual(3, mock_to_zarr.call_args.kwargs["zarr_format"])
-
 
 class ZarrDatasetS3IOTest(S3Test):
     def test_write_to_and_read_from_s3(self):

--- a/test/core/test_dsio.py
+++ b/test/core/test_dsio.py
@@ -5,6 +5,7 @@
 import os
 import os.path
 import unittest
+from unittest.mock import patch
 from test.s3test import MOTO_SERVER_ENDPOINT_URL, S3Test
 from test.sampledata import new_test_dataset
 from typing import Set
@@ -23,6 +24,7 @@ from xcube.core.dsio import (
     ZarrDatasetIO,
     find_dataset_io,
     get_path_or_s3_store,
+    new_s3_file_system,
     open_cube,
     open_dataset,
     parse_s3_url_and_kwargs,
@@ -424,6 +426,15 @@ class GetPathOrObsStoreTest(S3Test):
         self.assertEqual("../examples/serve/demo/cube-1-250-250.zarr", path)
         self.assertEqual(False, consolidated)
 
+    def test_path_or_store_with_explicit_s3_kwargs_for_local_path(self):
+        s3_store, consolidated = get_path_or_s3_store(
+            "examples/serve/demo/cube-1-250-250.zarr",
+            s3_kwargs={"anon": True},
+            mode="r",
+        )
+        self.assertIsInstance(s3_store, fsspec.mapping.FSMap)
+        self.assertEqual(False, consolidated)
+
 
 class ParseObsUrlAndKwargsTest(unittest.TestCase):
     def test_http(self):
@@ -484,6 +495,17 @@ class ParseObsUrlAndKwargsTest(unittest.TestCase):
         self.assertEqual(
             {"endpoint_url": "https://s3.eu-central-1.amazonaws.com"}, s3_client_kwargs
         )
+
+
+class NewS3FileSystemTest(unittest.TestCase):
+    @patch("xcube.core.dsio.s3fs.S3FileSystem")
+    def test_no_credentials_warning_is_emitted(self, mock_s3_file_system):
+        import botocore
+
+        mock_s3_file_system.side_effect = botocore.exceptions.NoCredentialsError()
+        with self.assertWarns(UserWarning):
+            with self.assertRaises(botocore.exceptions.NoCredentialsError):
+                new_s3_file_system(s3_kwargs={}, s3_client_kwargs={})
 
 
 class SplitBucketUrlTest(unittest.TestCase):

--- a/test/core/test_level.py
+++ b/test/core/test_level.py
@@ -158,7 +158,7 @@ class PyramidTest(unittest.TestCase):
 
         try:
             dataset = self.create_test_dataset(shape, chunks=(1, *tile_shape))
-            dataset.to_zarr(input_path)
+            dataset.to_zarr(input_path, zarr_version=2)
 
             t0 = time.perf_counter()
 

--- a/test/core/test_optimize.py
+++ b/test/core/test_optimize.py
@@ -70,7 +70,7 @@ class OptimizeDatasetTest(unittest.TestCase):
 
     def setUp(self):
         self._clear_outputs()
-        TEST_CUBE.to_zarr(INPUT_CUBE_PATH)
+        TEST_CUBE.to_zarr(INPUT_CUBE_PATH, zarr_version=2)
         self.assertEqual(INPUT_CUBE_FILE_SET, list_file_set(INPUT_CUBE_PATH))
 
     def tearDown(self):

--- a/test/core/test_select.py
+++ b/test/core/test_select.py
@@ -14,6 +14,8 @@ import cftime
 import numpy as np
 import pytest
 import xarray as xr
+from zarr.core.buffer.cpu import Buffer
+from zarr.storage import MemoryStore
 
 from xcube.core.gridmapping import GridMapping
 from xcube.core.new import new_cube
@@ -454,7 +456,10 @@ def new_virtual_dataset(
         [time_chunk or time_size, lat_chunk or lat_size, lon_chunk or lon_size],
     )
 
-    return xr.open_zarr(chunk_store, consolidated=False)
+    store_dict = {
+        key: Buffer.from_bytes(value) for key, value in chunk_store._entries.items()
+    }
+    return xr.open_zarr(MemoryStore(store_dict=store_dict), consolidated=False)
 
 
 class VirtualChunkStore(MutableMapping):

--- a/test/core/test_timeslice.py
+++ b/test/core/test_timeslice.py
@@ -40,7 +40,7 @@ class TimeSliceTest(unittest.TestCase):
 
     def write_cube(self, start_date, num_days: int):
         cube = self.make_cube(start_date, num_days)
-        cube.to_zarr(self.CUBE_PATH)
+        cube.to_zarr(self.CUBE_PATH, zarr_version=2)
 
     @staticmethod
     def make_cube(start_date, num_days: int) -> xr.Dataset:
@@ -212,7 +212,7 @@ class TimeSliceTest(unittest.TestCase):
             dims=new_dims,
             coords=cube.precipitation.coords,
         )
-        cube.to_zarr(self.CUBE_PATH_2)
+        cube.to_zarr(self.CUBE_PATH_2, zarr_version=2)
 
         with self.assertRaises(ValueError) as cm:
             insert_time_slice(self.CUBE_PATH_2, 2, self.make_slice("2019-01-02T06:30"))
@@ -238,14 +238,10 @@ class ZarrStoreTest(unittest.TestCase):
             variables=dict(precipitation=0.1, temperature=270.5, soil_moisture=0.2),
         )
         cube = chunk_dataset(cube, dict(time=1, lat=90, lon=90), format_name="zarr")
-        cube.to_zarr(self.CUBE_PATH)
+        cube.to_zarr(self.CUBE_PATH, zarr_version=2)
         cube.close()
 
-        diagnostic_store = DiagnosticStore(
-            zarr.DirectoryStore(self.CUBE_PATH),
-            logging_observer(log_path="local-cube.log"),
-        )
-        xr.open_zarr(diagnostic_store)
+        xr.open_zarr(zarr.storage.LocalStore(self.CUBE_PATH))
 
     @unittest.skipUnless(False, "is enabled")
     def test_remote(self):

--- a/test/core/test_unchunk.py
+++ b/test/core/test_unchunk.py
@@ -21,7 +21,7 @@ class UnchunkDatasetTest(unittest.TestCase):
         cube = chunk_dataset(
             cube, chunk_sizes=dict(time=1, lat=90, lon=90), format_name=FORMAT_NAME_ZARR
         )
-        cube.to_zarr(self.TEST_ZARR)
+        cube.to_zarr(self.TEST_ZARR, zarr_version=2)
 
         self.chunked_a_files = {
             ".zarray",

--- a/test/core/test_xarray.py
+++ b/test/core/test_xarray.py
@@ -156,7 +156,7 @@ class XarrayEncodingTest(unittest.TestCase):
 
         if engine == "zarr":
             path = self.zarr_path
-            ds.to_zarr(path, mode="w")
+            ds.to_zarr(path, mode="w", zarr_version=2)
         else:
             path = self.nc_path
             ds.to_netcdf(path, mode="w")

--- a/test/webapi/timeseries/test_controllers.py
+++ b/test/webapi/timeseries/test_controllers.py
@@ -512,7 +512,7 @@ class TsPerfTest(unittest.TestCase):
 
             cube = new_cube(time_periods=2000, variables=dict(analysed_sst=280.4))
             cube = cube.chunk(dict(time=1, lon=90, lat=90))
-            cube.to_zarr(test_cube)
+            cube.to_zarr(test_cube, zarr_version=2)
 
         ctx = get_timeseries_ctx(
             dict(

--- a/xcube/cli/patch.py
+++ b/xcube/cli/patch.py
@@ -168,7 +168,7 @@ def _patch_dataset(
                 LOG.info(f"{k}: {del_count} attribute(s) deleted")
 
     if not dry_run:
-        zarr.convenience.consolidate_metadata(zarr_store)
+        zarr.consolidate_metadata(zarr_store)
     LOG.info(f"Consolidated {dataset_path}")
 
 

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -466,7 +466,8 @@ class ZarrDatasetIO(DatasetIO):
                 client_kwargs=s3_client_kwargs)``.
             max_cache_size: if this is a positive integer, the store
                 will be wrapped in an in-memory cache, that is ``store =
-                zarr.LRUStoreCache(store, max_size=max_cache_size)``.
+                zarr.experimental.cache_store.CacheStore(store=path,
+                cache_store=MemoryStore(), max_size=max_cache_size)``.
             **kwargs: Keyword-arguments passed to xarray Zarr adapter,
                 that is ``xarray.open_zarr(..., **kwargs)``. In
                 addition, the parameter **
@@ -489,15 +490,15 @@ class ZarrDatasetIO(DatasetIO):
                     mode="r",
                 )
             if max_cache_size is not None and max_cache_size > 0:
-                lru_store_cache = getattr(zarr, "LRUStoreCache", None)
-                if lru_store_cache is not None:
-                    path_or_store = lru_store_cache(
-                        path_or_store, max_size=max_cache_size
-                    )
-        try:
-            return xr.open_zarr(path_or_store, consolidated=consolidated, **kwargs)
-        except (FileNotFoundError, zarr.errors.GroupNotFoundError) as e:
-            raise ValueError(str(e)) from e
+                from zarr.experimental.cache_store import CacheStore
+                from zarr.storage import MemoryStore
+
+                path_or_store = CacheStore(
+                    store=path_or_store,
+                    cache_store=MemoryStore(),
+                    max_size=max_cache_size,
+                )
+        return xr.open_zarr(path_or_store, consolidated=consolidated, **kwargs)
 
     def write(
         self,

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -489,6 +489,8 @@ class ZarrDatasetIO(DatasetIO):
                     s3_client_kwargs=s3_client_kwargs,
                     mode="r",
                 )
+                if isinstance(path_or_store, str):
+                    path_or_store = zarr.storage.LocalStore(path_or_store)
             if max_cache_size is not None and max_cache_size > 0:
                 from zarr.experimental.cache_store import CacheStore
                 from zarr.storage import MemoryStore

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -519,12 +519,13 @@ class ZarrDatasetIO(DatasetIO):
         )
         encoding = self._get_write_encodings(dataset, compressor, chunksizes, packing)
         consolidated = kwargs.pop("consolidated", True)
+        zarr_format = kwargs.pop("zarr_format", 2)
         dataset.to_zarr(
             path_or_store,
             mode="w",
             encoding=encoding,
             consolidated=consolidated,
-            zarr_format=2,
+            zarr_format=zarr_format,
             **kwargs,
         )
 

--- a/xcube/core/dsio.py
+++ b/xcube/core/dsio.py
@@ -5,11 +5,13 @@
 import os
 import shutil
 import warnings
+import zipfile
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, Mapping
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import botocore.exceptions
+import numcodecs
 import pandas as pd
 import s3fs
 import urllib3.util
@@ -475,17 +477,27 @@ class ZarrDatasetIO(DatasetIO):
         path_or_store = path
         consolidated = False
         if isinstance(path, str):
-            path_or_store, consolidated = get_path_or_s3_store(
-                path_or_store,
-                s3_kwargs=s3_kwargs,
-                s3_client_kwargs=s3_client_kwargs,
-                mode="r",
-            )
-            if max_cache_size is not None and max_cache_size > 0:
-                path_or_store = zarr.LRUStoreCache(
-                    path_or_store, max_size=max_cache_size
+            if path.lower().endswith(".zarr.zip"):
+                path_or_store = zarr.storage.ZipStore(path, mode="r")
+                with zipfile.ZipFile(path) as zip_file:
+                    consolidated = ".zmetadata" in zip_file.namelist()
+            else:
+                path_or_store, consolidated = get_path_or_s3_store(
+                    path_or_store,
+                    s3_kwargs=s3_kwargs,
+                    s3_client_kwargs=s3_client_kwargs,
+                    mode="r",
                 )
-        return xr.open_zarr(path_or_store, consolidated=consolidated, **kwargs)
+            if max_cache_size is not None and max_cache_size > 0:
+                lru_store_cache = getattr(zarr, "LRUStoreCache", None)
+                if lru_store_cache is not None:
+                    path_or_store = lru_store_cache(
+                        path_or_store, max_size=max_cache_size
+                    )
+        try:
+            return xr.open_zarr(path_or_store, consolidated=consolidated, **kwargs)
+        except (FileNotFoundError, zarr.errors.GroupNotFoundError) as e:
+            raise ValueError(str(e)) from e
 
     def write(
         self,
@@ -511,6 +523,7 @@ class ZarrDatasetIO(DatasetIO):
             mode="w",
             encoding=encoding,
             consolidated=consolidated,
+            zarr_format=2,
             **kwargs,
         )
 
@@ -542,7 +555,7 @@ class ZarrDatasetIO(DatasetIO):
                     encoding[var_name] = dict(packing[var_name])
 
         if compressor:
-            compressor = zarr.Blosc(**compressor)
+            compressor = numcodecs.Blosc(**compressor)
 
             if encoding:
                 for var_name in encoding.keys():

--- a/xcube/core/gridmapping/cfconv.py
+++ b/xcube/core/gridmapping/cfconv.py
@@ -10,7 +10,6 @@ import numpy as np
 import pyproj
 import xarray as xr
 import zarr
-import zarr.convenience
 
 from xcube.core.schema import get_dataset_chunks
 from xcube.util.assertions import assert_instance
@@ -313,7 +312,7 @@ def _find_dataset_tile_size(
 
 
 def add_spatial_ref(
-    dataset_store: zarr.convenience.StoreLike,
+    dataset_store: str | MutableMapping,
     crs: pyproj.CRS,
     crs_var_name: Optional[str] = "spatial_ref",
     xy_dim_names: Optional[tuple[str, str]] = None,
@@ -336,10 +335,12 @@ def add_spatial_ref(
     spatial_attrs = crs.to_cf()
     spatial_attrs["_ARRAY_DIMENSIONS"] = []  # Required by xarray
     group = zarr.open(dataset_store, mode="r+")
-    spatial_ref = group.array(crs_var_name, 0, shape=(), dtype=np.uint8, fill_value=0)
+    spatial_ref = group.create_array(
+        crs_var_name, shape=(), dtype=np.uint8, fill_value=0
+    )
     spatial_ref.attrs.update(**spatial_attrs)
 
-    for item_name, item in group.items():
+    for item_name, item in group.arrays():
         if item_name != crs_var_name:
             dims = item.attrs.get("_ARRAY_DIMENSIONS")
             if (
@@ -350,4 +351,4 @@ def add_spatial_ref(
             ):
                 item.attrs["grid_mapping"] = crs_var_name
 
-    zarr.convenience.consolidate_metadata(dataset_store)
+    zarr.consolidate_metadata(dataset_store)

--- a/xcube/core/level.py
+++ b/xcube/core/level.py
@@ -185,7 +185,7 @@ def write_levels(
                 fp.write(input_path)
         else:
             path = os.path.join(output_path, f"{index}.zarr")
-            level_dataset.to_zarr(path)
+            level_dataset.to_zarr(path, zarr_format=2)
             level_dataset.close()
             level_dataset = xr.open_zarr(path)
 

--- a/xcube/core/mldataset/fs.py
+++ b/xcube/core/mldataset/fs.py
@@ -15,7 +15,7 @@ import fsspec
 import fsspec.core
 import numpy as np
 import xarray as xr
-import zarr
+from zarr.storage import FsspecStore
 
 # noinspection PyUnresolvedReferences
 import xcube.core.zarrstore
@@ -162,12 +162,15 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
             # size in pixels for each level
             cache_size = math.ceil(self.size_weights[index] * cache_size)
             if cache_size >= self._MIN_CACHE_SIZE:
-                lru_store_cache = getattr(zarr, "LRUStoreCache", None)
-                if lru_store_cache is not None:
-                    xarray_store = lru_store_cache(
-                        xarray_store, max_size=cache_size
-                    )
+                from zarr.experimental.cache_store import CacheStore
+                from zarr.storage import MemoryStore
 
+                xarray_store = FsspecStore.from_mapper(level_zarr_store)
+                xarray_store = CacheStore(
+                    store=xarray_store,
+                    cache_store=MemoryStore(),
+                    max_size=cache_size,
+                )
         try:
             level_dataset = xr.open_zarr(
                 xarray_store, consolidated=consolidated, **self._zarr_kwargs

--- a/xcube/core/mldataset/fs.py
+++ b/xcube/core/mldataset/fs.py
@@ -266,6 +266,7 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
             tile_size = normalize_scalar_or_pair(
                 tile_size, item_type=int, name="tile_size"
             )
+        zarr_format = zarr_kwargs.pop("zarr_format", 2)
 
         assert_instance(path, str, name="path")
         assert_instance(fs, fsspec.AbstractFileSystem, name="fs")
@@ -360,7 +361,7 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
                         xarray_store,
                         mode="w" if replace else None,
                         consolidated=consolidated,
-                        zarr_format=2,
+                        zarr_format=zarr_format,
                         **zarr_kwargs,
                     )
                 except ValueError as e:

--- a/xcube/core/mldataset/fs.py
+++ b/xcube/core/mldataset/fs.py
@@ -22,7 +22,7 @@ import xcube.core.zarrstore
 from xcube.core.gridmapping import GridMapping
 from xcube.core.subsampling import AggMethod, AggMethods
 from xcube.util.assertions import assert_instance
-from xcube.util.fspath import get_fs_path_class, resolve_path
+from xcube.util.fspath import get_fs_path_class, is_local_fs, resolve_path
 from xcube.util.types import ScalarOrPair, normalize_scalar_or_pair
 
 from .abc import MultiLevelDataset
@@ -149,6 +149,7 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
             engine = base_dataset_open_params.pop("engine", "zarr")
 
         level_zarr_store = fs.get_mapper(str(level_path))
+        xarray_store = str(level_path) if is_local_fs(fs) else level_zarr_store
 
         consolidated = (
             self._consolidate
@@ -161,13 +162,15 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
             # size in pixels for each level
             cache_size = math.ceil(self.size_weights[index] * cache_size)
             if cache_size >= self._MIN_CACHE_SIZE:
-                level_zarr_store = zarr.LRUStoreCache(
-                    level_zarr_store, max_size=cache_size
-                )
+                lru_store_cache = getattr(zarr, "LRUStoreCache", None)
+                if lru_store_cache is not None:
+                    xarray_store = lru_store_cache(
+                        xarray_store, max_size=cache_size
+                    )
 
         try:
             level_dataset = xr.open_zarr(
-                level_zarr_store, consolidated=consolidated, **self._zarr_kwargs
+                xarray_store, consolidated=consolidated, **self._zarr_kwargs
             )
         except ValueError as e:
             raise FsMultiLevelDatasetError(
@@ -348,11 +351,13 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
                 # Write level "{index}.zarr"
                 level_path = data_path / f"{index}.zarr"
                 level_zarr_store = fs.get_mapper(str(level_path), create=True)
+                xarray_store = str(level_path) if is_local_fs(fs) else level_zarr_store
                 try:
                     level_dataset.to_zarr(
-                        level_zarr_store,
+                        xarray_store,
                         mode="w" if replace else None,
                         consolidated=consolidated,
+                        zarr_format=2,
                         **zarr_kwargs,
                     )
                 except ValueError as e:
@@ -362,7 +367,7 @@ class FsMultiLevelDataset(LazyMultiLevelDataset):
                     ) from e
                 if use_saved_levels:
                     level_dataset = xr.open_zarr(
-                        level_zarr_store, consolidated=consolidated
+                        xarray_store, consolidated=consolidated
                     )
                     level_dataset.zarr_store.set(level_zarr_store)
                     ml_dataset.set_dataset(index, level_dataset)

--- a/xcube/core/optimize.py
+++ b/xcube/core/optimize.py
@@ -47,7 +47,10 @@ def optimize_dataset(
         exception_type: Type of exception to be used on value errors.
     """
 
-    if not os.path.isfile(os.path.join(input_path, ".zgroup")):
+    if not (
+        os.path.isfile(os.path.join(input_path, ".zgroup"))
+        or os.path.isfile(os.path.join(input_path, "zarr.json"))
+    ):
         raise exception_type("Input path must point to ZARR dataset directory.")
 
     input_path = os.path.abspath(os.path.normpath(input_path))
@@ -76,4 +79,4 @@ def optimize_dataset(
             var_names = tuple(unchunk_coords)
         unchunk_dataset(output_path, var_names=var_names, coords_only=True)
 
-    zarr.convenience.consolidate_metadata(output_path)
+    zarr.consolidate_metadata(output_path)

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -156,15 +156,15 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         consolidated = open_params.pop(
             "consolidated", fs.exists(f"{data_id}/.zmetadata")
         )
-        zarr_store = fs.get_mapper(data_id)
-        xarray_store = data_id if is_local_fs(fs) else zarr_store
+        fs_map = fs.get_mapper(data_id)
+        zarr_store = data_id if is_local_fs(fs) else fs_map
         if isinstance(cache_size, int) and cache_size > 0:
             from zarr.experimental.cache_store import CacheStore
             from zarr.storage import MemoryStore
 
-            xarray_store = FsspecStore.from_mapper(zarr_store)
-            xarray_store = CacheStore(
-                store=xarray_store,
+            zarr_store = FsspecStore.from_mapper(fs_map)
+            zarr_store = CacheStore(
+                store=zarr_store,
                 cache_store=MemoryStore(),
                 max_size=cache_size,
             )
@@ -173,19 +173,19 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         if engine == "zarr":
             try:
                 dataset = xr.open_zarr(
-                    xarray_store, consolidated=consolidated, **open_params
+                    zarr_store, consolidated=consolidated, **open_params
                 )
             except ValueError as e:
                 raise DataStoreError(f"Failed to open dataset {data_id!r}: {e}") from e
         else:
             try:
-                dataset = xr.open_dataset(xarray_store, engine=engine, **open_params)
+                dataset = xr.open_dataset(zarr_store, engine=engine, **open_params)
             except ValueError as e:
                 raise DataStoreError(
                     f"Failed to open dataset {data_id!r} using engine {engine!r}: {e}"
                 ) from e
 
-        dataset.zarr_store.set(zarr_store)
+        dataset.zarr_store.set(fs_map)
         return dataset
 
     # noinspection PyMethodMayBeStatic
@@ -198,13 +198,13 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         assert_instance(data, xr.Dataset, name="data")
         assert_instance(data_id, str, name="data_id")
         fs, root, write_params = self.load_fs(write_params)
-        zarr_store = fs.get_mapper(data_id, create=True)
-        xarray_store = data_id if is_local_fs(fs) else zarr_store
+        fs_map = fs.get_mapper(data_id, create=True)
+        zarr_store = data_id if is_local_fs(fs) else fs_map
         consolidated = write_params.pop("consolidated", True)
         zarr_format = write_params.pop("zarr_format", 2)
         try:
             data.to_zarr(
-                xarray_store,
+                zarr_store,
                 mode="w" if replace else None,
                 consolidated=consolidated,
                 zarr_format=zarr_format,

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -114,6 +114,11 @@ ZARR_WRITE_DATA_PARAMS_SCHEMA = JsonObjectSchema(
             description="If set, the dimension on which the data will be appended.",
             min_length=1,
         ),
+        zarr_format=JsonIntegerSchema(
+            description="Zarr format version to write. Supported values are 2 and 3.",
+            enum=[2, 3],
+            default=2,
+        ),
         replace=JsonBooleanSchema(
             description="If set, an existing dataset will be replaced without warning.",
         ),
@@ -196,12 +201,13 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         zarr_store = fs.get_mapper(data_id, create=True)
         xarray_store = data_id if is_local_fs(fs) else zarr_store
         consolidated = write_params.pop("consolidated", True)
+        zarr_format = write_params.pop("zarr_format", 2)
         try:
             data.to_zarr(
                 xarray_store,
                 mode="w" if replace else None,
                 consolidated=consolidated,
-                zarr_format=2,
+                zarr_format=zarr_format,
                 **write_params,
             )
         except ValueError as e:

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -153,20 +153,23 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
             "consolidated", fs.exists(f"{data_id}/.zmetadata")
         )
         zarr_store = fs.get_mapper(data_id)
+        xarray_store = data_id if is_local_fs(fs) else zarr_store
         if isinstance(cache_size, int) and cache_size > 0:
-            zarr_store = zarr.LRUStoreCache(zarr_store, max_size=cache_size)
+            lru_store_cache = getattr(zarr, "LRUStoreCache", None)
+            if lru_store_cache is not None:
+                xarray_store = lru_store_cache(xarray_store, max_size=cache_size)
         # TODO: test whether we really need to distinguish here as we know
         #   we are opening a zarr dataset, even without another backend.
         if engine == "zarr":
             try:
                 dataset = xr.open_zarr(
-                    zarr_store, consolidated=consolidated, **open_params
+                    xarray_store, consolidated=consolidated, **open_params
                 )
             except ValueError as e:
                 raise DataStoreError(f"Failed to open dataset {data_id!r}: {e}") from e
         else:
             try:
-                dataset = xr.open_dataset(zarr_store, engine=engine, **open_params)
+                dataset = xr.open_dataset(xarray_store, engine=engine, **open_params)
             except ValueError as e:
                 raise DataStoreError(
                     f"Failed to open dataset {data_id!r} using engine {engine!r}: {e}"
@@ -186,12 +189,14 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         assert_instance(data_id, str, name="data_id")
         fs, root, write_params = self.load_fs(write_params)
         zarr_store = fs.get_mapper(data_id, create=True)
+        xarray_store = data_id if is_local_fs(fs) else zarr_store
         consolidated = write_params.pop("consolidated", True)
         try:
             data.to_zarr(
-                zarr_store,
+                xarray_store,
                 mode="w" if replace else None,
                 consolidated=consolidated,
+                zarr_format=2,
                 **write_params,
             )
         except ValueError as e:

--- a/xcube/core/store/fs/impl/dataset.py
+++ b/xcube/core/store/fs/impl/dataset.py
@@ -3,10 +3,9 @@
 # https://opensource.org/licenses/MIT.
 
 from abc import ABC
-from typing import Optional
 
 import xarray as xr
-import zarr
+from zarr.storage import FsspecStore
 
 # Note, we need the following reference to register the
 # xarray property accessor
@@ -155,9 +154,15 @@ class DatasetZarrFsDataAccessor(DatasetFsDataAccessor):
         zarr_store = fs.get_mapper(data_id)
         xarray_store = data_id if is_local_fs(fs) else zarr_store
         if isinstance(cache_size, int) and cache_size > 0:
-            lru_store_cache = getattr(zarr, "LRUStoreCache", None)
-            if lru_store_cache is not None:
-                xarray_store = lru_store_cache(xarray_store, max_size=cache_size)
+            from zarr.experimental.cache_store import CacheStore
+            from zarr.storage import MemoryStore
+
+            xarray_store = FsspecStore.from_mapper(zarr_store)
+            xarray_store = CacheStore(
+                store=xarray_store,
+                cache_store=MemoryStore(),
+                max_size=cache_size,
+            )
         # TODO: test whether we really need to distinguish here as we know
         #   we are opening a zarr dataset, even without another backend.
         if engine == "zarr":

--- a/xcube/core/timeslice.py
+++ b/xcube/core/timeslice.py
@@ -86,7 +86,9 @@ def append_time_slice(
         # from next time_slice.to_zarr(...) call.
         time_slice.attrs.pop("coordinates")
 
-    time_slice.to_zarr(store, mode="a", append_dim="time", consolidated=True)
+    time_slice.to_zarr(
+        store, mode="a", append_dim="time", consolidated=True, zarr_format=2
+    )
 
     unchunk_dataset(store, coords_only=True)
 
@@ -173,7 +175,7 @@ def update_time_slice(
     if chunk_sizes:
         time_slice = chunk_dataset(time_slice, chunk_sizes, format_name="zarr")
     temp_dir = tempfile.TemporaryDirectory(prefix="xcube-time-slice-", suffix=".zarr")
-    time_slice.to_zarr(temp_dir.name, encoding=encoding)
+    time_slice.to_zarr(temp_dir.name, encoding=encoding, zarr_format=2)
     slice_root_group = zarr.open(temp_dir.name, mode="r")
     slice_arrays = dict(slice_root_group.arrays())
 
@@ -183,7 +185,7 @@ def update_time_slice(
             slice_array = slice_arrays[var_name]
             if insert_mode:
                 # Add one empty time step
-                empty = zarr.creation.empty(slice_array.shape, dtype=var_array.dtype)
+                empty = np.empty(slice_array.shape, dtype=var_array.dtype)
                 var_array.append(empty, axis=0)
                 # Shift contents
                 var_array[insert_index + 1 :, ...] = var_array[insert_index:-1, ...]

--- a/xcube/core/unchunk.py
+++ b/xcube/core/unchunk.py
@@ -23,7 +23,9 @@ def unchunk_dataset(
         coords_only: Un-chunk coordinate variables only.
     """
 
-    is_zarr = os.path.isfile(os.path.join(dataset_path, ".zgroup"))
+    is_zarr = os.path.isfile(os.path.join(dataset_path, ".zgroup")) or os.path.isfile(
+        os.path.join(dataset_path, "zarr.json")
+    )
     if not is_zarr:
         raise ValueError(f"{dataset_path!r} is not a valid Zarr directory")
 
@@ -55,26 +57,32 @@ def _unchunk_vars(dataset_path: str, var_names: list[str]):
 
         # Optimization: if "shape" and "chunks" are equal in ${var}/.zarray, we are done
         var_array_info_path = os.path.join(var_path, ".zarray")
-        with open(var_array_info_path) as fp:
-            var_array_info = json.load(fp)
-            if var_array_info.get("shape") == var_array_info.get("chunks"):
-                continue
+        if os.path.isfile(var_array_info_path):
+            with open(var_array_info_path) as fp:
+                var_array_info = json.load(fp)
+                if var_array_info.get("shape") == var_array_info.get("chunks"):
+                    continue
 
         # Open array and remove chunks from the data
-        var_array = zarr.convenience.open_array(var_path, "r+")
+        var_array = zarr.open_array(var_path, mode="r+")
         if var_array.shape != var_array.chunks:
             # TODO (forman): Fully loading data is inefficient and dangerous for large arrays.
             #                Instead save unchunked to temp and replace existing chunked array dir with temp.
             # Fully load data and attrs so we no longer depend on files
             data = np.array(var_array)
             attributes = var_array.attrs.asdict()
-            # Save array data
-            zarr.convenience.save_array(
-                var_path, data, chunks=False, fill_value=var_array.fill_value
+            # Recreate the array with a single chunk that covers the full data.
+            zarr.create_array(
+                store=var_path,
+                data=data,
+                chunks=data.shape,
+                fill_value=var_array.fill_value,
+                zarr_format=2,
+                overwrite=True,
             )
-            # zarr.convenience.save_array() does not seem save user attributes (file ".zattrs" not written),
+            # zarr.save_array() does not seem save user attributes (file ".zattrs" not written),
             # therefore we must modify attrs explicitly:
-            var_array = zarr.convenience.open_array(var_path, "r+")
+            var_array = zarr.open_array(var_path, mode="r+")
             var_array.attrs.update(attributes)
 
     zarr.consolidate_metadata(dataset_path)


### PR DESCRIPTION
Migrated to Zarr v3, adapting xcube's Zarr handling to the new Zarr store API an ensuring compatibility with the latest Zarr ecosystem.


Checklist:

* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in `docs/source/*`~
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)
