### PR TITLE
correct example configuration filename in documentation

### DIFF
--- a/examples/serve/panels-demo/README.md
+++ b/examples/serve/panels-demo/README.md
@@ -5,12 +5,12 @@
 ```shell
 conda activate xcube
 cd xcube
-xcube serve --traceback --loglevel -vvv -c examples/serve/panels-demo/server-config.yaml
+xcube serve --traceback --loglevel -vvv -c examples/serve/panels-demo/config.yaml
 ```
 
 ### Test data
 
-The following data is used by the demo configuration `server-config.yaml`:
+The following data is used by the demo configuration `config.yaml`:
 
 1. Kattegat
    - Derived from CMEMS product BALTICSEA_ANALYSISFORECAST_BGC_003_007

--- a/examples/serve/panels-demo/README.md
+++ b/examples/serve/panels-demo/README.md
@@ -5,7 +5,7 @@
 ```shell
 conda activate xcube
 cd xcube
-xcube serve --traceback --loglevel -vvv -c examples/serve/panels-demo/config.yaml
+xcube serve -vvv -c examples/serve/panels-demo/config.yaml
 ```
 
 ### Test data


### PR DESCRIPTION
Make documentation match actual filename.